### PR TITLE
fixed one sample prediction

### DIFF
--- a/fedot_ind/core/models/base_extractor.py
+++ b/fedot_ind/core/models/base_extractor.py
@@ -57,8 +57,12 @@ class BaseExtractor(IndustrialCachableOperationImplementation):
         except Exception:
             input_data_squeezed = np.squeeze(features)
 
+        if len(input_data_squeezed.shape) == 1:
+            input_data_squeezed = [input_data_squeezed]
+
         parallel = Parallel(n_jobs=self.n_processes, verbose=0, pre_dispatch="2*n_jobs")
         feature_matrix = parallel(delayed(self.generate_features_from_ts)(sample) for sample in input_data_squeezed)
+
         predict = self._clean_predict(np.array([ts.features for ts in feature_matrix]))
         self.relevant_features = feature_matrix[0].supplementary_data['feature_name']
         return predict

--- a/tests/unit/operation/decomposition/test_decomposed_conv.py
+++ b/tests/unit/operation/decomposition/test_decomposed_conv.py
@@ -4,38 +4,43 @@ import torch
 from fedot_ind.core.operation.decomposition.decomposed_conv import DecomposedConv2d
 
 
-def run(mode):
-    for in_channels in [3, 32]:
-        for kernel_size in [(3, 5), (7, 1)]:
-            for stride in [(1, 2), (2, 3)]:
-                for padding in [(1, 2), (2, 3)]:
-                    for dilation in [(1, 2), (2, 3)]:
-                        base_conv = torch.nn.Conv2d(
-                            in_channels=in_channels,
-                            out_channels=32,
-                            kernel_size=kernel_size,
-                            stride=stride,
-                            padding=padding,
-                            dilation=dilation,
-                        )
-                        dconvs = {
-                            'dconv': DecomposedConv2d(base_conv, None),
-                            'one_layer': DecomposedConv2d(base_conv, mode),
-                            'two_layers': DecomposedConv2d(base_conv, mode, forward_mode='two_layers'),
-                            'three_layers': DecomposedConv2d(base_conv, mode, forward_mode='three_layers')
-                        }
-                        x = torch.rand((random.randint(1, 16), in_channels, random.randint(28, 1000), random.randint(28, 1000)))
-                        y_true = base_conv(x)
-                        for name, dconv in dconvs.items():
-                            y = dconv(x)
-                            is_ok = torch.allclose(y, y_true, rtol=0.0001, atol=0.00001)
-                            print(is_ok)
-                            assert is_ok, f"{mode}: {base_conv} {torch.isclose(y, y_true)}"
+@pytest.fixture(scope='module')
+def params():
+    return dict(in_channels=3,
+                out_channels=32,
+                kernel_size=(3, 5),
+                stride=(1, 2),
+                padding=(1, 2),
+                dilation=(1, 2))
 
 
-def test_channel_decomposed_conv():
-    run('channel')
+def run(mode, params):
+    base_conv = torch.nn.Conv2d(
+        in_channels=params['in_channels'],
+        out_channels=params['out_channels'],
+        kernel_size=params['kernel_size'],
+        stride=params['stride'],
+        padding=params['padding'],
+        dilation=params['dilation'],
+    )
+    dconvs = {
+        'dconv': DecomposedConv2d(base_conv, None),
+        'one_layer': DecomposedConv2d(base_conv, mode),
+        'two_layers': DecomposedConv2d(base_conv, mode, forward_mode='two_layers'),
+        'three_layers': DecomposedConv2d(base_conv, mode, forward_mode='three_layers')
+    }
+    x = torch.rand((random.randint(1, 16), params['in_channels'], random.randint(28, 1000), random.randint(28, 1000)))
+    y_true = base_conv(x)
+    for name, dconv in dconvs.items():
+        y = dconv(x)
+        is_ok = torch.allclose(y, y_true, rtol=0.0001, atol=0.00001)
+        print(is_ok)
+        assert is_ok, f"{mode}: {base_conv} {torch.isclose(y, y_true)}"
 
 
-def test_spatial_decomposed_conv():
-    run('spatial')
+def test_channel_decomposed_conv(params):
+    run('channel', params)
+
+
+def test_spatial_decomposed_conv(params):
+    run('spatial', params)


### PR DESCRIPTION
fixed issue #95 with small code implementation. The thing is that if only one sample goes into `_transform` method of `BaseExtractor`, the `generatre_features_from_ts` method iterates over elements of this sample instead of extraction features from it.