### PR TITLE
hotfix: change import of is_multi_output according to fedot

### DIFF
--- a/fedot_ind/core/operation/interfaces/industrial_preprocessing_strategy.py
+++ b/fedot_ind/core/operation/interfaces/industrial_preprocessing_strategy.py
@@ -6,7 +6,7 @@ from typing import Optional, Union, Callable
 import numpy as np
 from fedot.core.data.data import InputData, OutputData
 from fedot.core.operations.evaluation.evaluation_interfaces import convert_to_multivariate_model, EvaluationStrategy
-from fedot.core.utils import is_multi_output_task
+from fedot.core.utils import is_multi_output_target
 from fedot.core.operations.operation_parameters import OperationParameters
 from fedot.core.repository.dataset_types import DataTypesEnum
 from fedot.core.repository.operation_types_repository import get_operation_type_from_id, OperationTypesRepository
@@ -161,7 +161,7 @@ class MultiDimPreprocessingStrategy(EvaluationStrategy):
         is_model_not_support_multi = self.operation_type in OperationTypesRepository().suitable_operation(
             task_type=train_data.task.task_type, tags=['non_multi'])
         not_fedot_input_data = len(signature(self.operation_condition.operation_implementation.fit).parameters) > 1
-        is_multi_target = is_multi_output_task(train_data)
+        is_multi_target = is_multi_output_target(train_data)
         model_multi_adaptation = all([is_model_not_support_multi, is_multi_target])
 
         operation_implementation = Either(value=train_data,

--- a/fedot_ind/core/operation/interfaces/industrial_preprocessing_strategy.py
+++ b/fedot_ind/core/operation/interfaces/industrial_preprocessing_strategy.py
@@ -5,8 +5,8 @@ from typing import Optional, Union, Callable
 
 import numpy as np
 from fedot.core.data.data import InputData, OutputData
-from fedot.core.operations.evaluation.evaluation_interfaces import convert_to_multivariate_model, EvaluationStrategy, \
-    is_multi_output_task
+from fedot.core.operations.evaluation.evaluation_interfaces import convert_to_multivariate_model, EvaluationStrategy
+from fedot.core.utils import is_multi_output_task
 from fedot.core.operations.operation_parameters import OperationParameters
 from fedot.core.repository.dataset_types import DataTypesEnum
 from fedot.core.repository.operation_types_repository import get_operation_type_from_id, OperationTypesRepository

--- a/fedot_ind/core/operation/transformation/representation/topological/topofeatures.py
+++ b/fedot_ind/core/operation/transformation/representation/topological/topofeatures.py
@@ -2,6 +2,7 @@ from abc import ABC
 from multiprocessing.dummy import Pool as ThreadPool
 
 import pandas as pd
+import numpy as np
 from gtda.diagrams import BettiCurve, Filtering, PersistenceEntropy, PersistenceLandscape, Scaler
 from gtda.homology import VietorisRipsPersistence
 
@@ -62,7 +63,8 @@ class PersistenceDiagramsExtractor:
             metric='euclidean',
             homology_dimensions=self.homology_dimensions_,
             n_jobs=self.n_job)
-        diagram_scaler = Scaler(n_jobs=self.n_job)
+        # TODO: remove workaround (gtda expects `function` to be a plain function, not a NumPy dispatcher)
+        diagram_scaler = Scaler(function=lambda x: float(np.max(x)), n_jobs=self.n_job)
         persistence_diagrams = diagram_scaler.fit_transform(
             vr.fit_transform([embedding]))
         if self.filtering_:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,9 +7,9 @@ license = "BSD 3-Clause"
 readme = "README_en.rst"
 
 [tool.poetry.dependencies]
-python = ">=3.9, <3.12"
+python = ">=3.10, <3.12"
 fedot = { git = "https://github.com/aimclub/FEDOT.git" }
-dask-ml = "^2024.4.4"
+dask-ml = ">2025"
 spacy = ">=3.5,<3.6"
 fastai = "^2.7.18"
 giotto-tda = { version = "*", extras = [] }


### PR DESCRIPTION
with https://github.com/aimclub/FEDOT/pull/1392 changes `is_multi_output` method migrated to a `fedot.core.utils` module

outdated imports in `fedot_ind/core/operation/interfaces/industrial_preprocessing_strategy.py` have caused integration suite failures:
https://github.com/aimclub/Fedot.Industrial/actions/runs/17377351235
https://github.com/aimclub/Fedot.Industrial/actions/runs/16989778940