### PR TITLE
PR1: PDL contracts & safety hardening

### DIFF
--- a/docs/pr_plans/pdl-time-series/pr_1_safety_and_contracts.md
+++ b/docs/pr_plans/pdl-time-series/pr_1_safety_and_contracts.md
@@ -121,12 +121,10 @@ flowchart TB
         P1["TestPairwiseDifferenceEstimator<br/>pair_output_difference — legacy"]
         P2["TestPDLContracts<br/>_predict_same_probability"]
         P3["TestPDLDiagnostics<br/>Classifier/Regressor.fit → get_diagnostics"]
-        P4["TestPDCDataTransformerContracts<br/>Issue 2, xfail"]
     end
 
     pairwise_core["pairwise_core.py"] --> core
     pairwise_model["pairwise_model.py"] --> pdl
-    pairwise_transform["pairwise_transform.py"] --> P4
 
 ```
 
@@ -134,21 +132,23 @@ flowchart TB
 
 ## Отчёт по выполнению PR 1
 
-Статус: **Issue 1 — выполнен** (с оговорками ниже). **Issue 2 — частично** (тесты добавлены, код transformer не починен).
+Статус: **Issue 1 — выполнен** (с оговорками ниже). **Issue 2 — выполнен** (код transformer пернесён в legacy, тесты добавлены и адаптированы под перенос модуля в legacy).
 
 Затронутые файлы:
 
 ```text
-fedot_ind/core/models/pdl/pairwise_core.py      — контракты, diagnostics, имена
-fedot_ind/core/models/pdl/pairwise_model.py     — legacy API, score_difference
-tests/unit/core/models/test_pdl.py              — estimator + legacy + PDC (xfail)
-tests/unit/core/models/test_pairwise_learning_core.py — core-level контракты
+* fedot_ind/core/models/pdl/pairwise_core.py — контракты, diagnostics, имена
+* fedot_ind/core/models/pdl/pairwise_model.py — legacy API, score_difference
+* tests/unit/core/models/test_pdl.py  — estimator + legacy + PDC (xfail)
+* tests/unit/core/models/test_pairwise_learning_core.py — core-level контракты
+
+* fedot_ind/core/models/pdl/legacy_pairwise_transform.py — модуль transform перенесённый в legacy
+* tests/unit/core/models/test_pdl_transform.py — пересобранные тесты для legacy transform
 ```
 
 Не изменялись в рамках PR 1:
 
 ```text
-fedot_ind/core/models/pdl/pairwise_transform.py  — Issue 2, только тесты-заготовки
 fedot_ind/core/models/pdl/__init__.py
 ```
 
@@ -305,37 +305,23 @@ build_*_pairs → batch.diagnostics["pair_target_semantics"]
 
 ---
 
-### 5. Починить `PDCDataTransformer` или вывести в legacy
-
-**Статус: не выполнено (Issue 2 отложен)**
-
-**Текущие проблемы в `pairwise_transform.py` (без изменений):**
-
-- `fit()` не создаёт `preprocessing_` для X;
-- `transform()` вызывает `self.preprocessing_.transform(X)` → AttributeError при реальном использовании;
-- для `y` вызывается `preprocessing_.transform(y)` вместо `preprocessing_y_.transform(y)` (~102–103);
-- `warnings.catch_warnings()` (~196) без `import warnings`.
-
-**Сделано вместо починки:** добавлены контракт-тесты с `@pytest.mark.xfail` в `test_pdl.py` → `TestPDCDataTransformerContracts`:
-
-- `test_pdc_data_transformer_initializes_x_preprocessor`
-- `test_pdc_data_transformer_uses_y_preprocessor_for_target`
-
-Тесты документируют ожидаемое поведение; после фикса transformer — снять `xfail`.
+### 5. Модуль `pairwise_transform.py` выведены в legacy
+- `legacy_pairwise_transform.py`
+    - Исправлен module docstring: статус `deprecated`
+    - Добавлены `DeprecationWarning` при создании `PDCDataTransformer` и `SampleWeights`
+    - `transform` теперь явно бросает NotImplementedError вместо падения на неинициализированном  `preprocessing_`
+    - `fit` помечает объект как fitted через `_legacy_fit_complete_`
+    - Исправлен `fit` при отсутствии preprocessing_y_ (getattr)
+    - Добавлены `import warnings` и `import sklearn.metrics` (раньше SampleWeights ссылался на  неимпортированный модуль)
+- `test_pdl_transform.py`
+    - Импорты переведены на `legacy_pairwise_transform`
+    - Обновлён patch-путь для minimize.
+    - Удалены мок-тесты сломанного `transform`; добавлен `test_transform_raises_not_implemented`
+    - Все создания legacy-классов обёрнуты в `pytest.warns(DeprecationWarning, ...)`
 
 ---
 
-### 6. Недостающие imports
-
-**Статус: N/A для production-кода PR 1; Issue 2 — не исправлен**
-
-В `pairwise_transform.py` по-прежнему отсутствует `import warnings` (баг Issue 2).
-
-В тестах добавлены импорты: `_predict_same_probability`, `PDCDataTransformer`, `StandardScaler`, `patch` (`test_pdl.py`).
-
----
-
-### 7. Тесты на deterministic toy arrays
+### 6. Тесты на deterministic toy arrays
 
 **Статус: выполнено**
 
@@ -350,7 +336,6 @@ build_*_pairs → batch.diagnostics["pair_target_semantics"]
 | `test_predict_same_probability_falls_back_to_hard_predictions` | `TestPDLContracts` | `predict` без `predict_proba` |
 | `test_pair_target_semantics_is_reported_in_diagnostics_classifier` | `TestPDLDiagnostics` | semantics после `Classifier.fit` |
 | `test_pair_target_semantics_is_reported_in_diagnostics_regressor` | `TestPDLDiagnostics` | semantics после `Regressor.fit` |
-| `test_pdc_data_transformer_*` | `TestPDCDataTransformerContracts` | Issue 2, xfail |
 
 Заглушки `_PairProbaStub`, `_HardLabelStub` вместо `MagicMock` — проще читать и стабильнее в CI.
 
@@ -389,13 +374,8 @@ pytest tests/unit/core/models/test_pdl.py tests/unit/core/models/test_pairwise_l
 
 | Критерий | Статус |
 |---|---|
-| `fit().transform()` не падает на базовых сценариях | ❌ `preprocessing_` не инициализируется |
-| X и y — разные pipelines | ❌ `y` идёт через `preprocessing_` |
-| Нет обращения к неинициализированным attributes | ❌ |
-| Тесты `test_pdc_data_transformer_*` | ✅ добавлены (xfail) |
-| `test_pdc_data_transformer_handles_numeric/categorical` | ❌ не добавлены |
-
-**Рекомендация для следующего PR:** починить `PDCDataTransformer` или перенести в `legacy.py`; снять `xfail` с двух тестов.
+| Вынести в legacy и удалить из production path | ✅ |
+| Тесты `test_pdl_transform.py` | ✅ |
 
 ---
 
@@ -405,8 +385,8 @@ pytest tests/unit/core/models/test_pdl.py tests/unit/core/models/test_pairwise_l
 |---|---|
 | Поведение default classifier/regressor не меняется | ✅ |
 | Diagnostics явно сообщает target semantics | ✅ |
-| Нет обращения к неинициализированным attributes в transformer | ❌ Issue 2 |
-| Все PDL unit tests проходят | ✅ (кроме 2 xfail по PDC) |
+| Нет обращения к неинициализированным attributes в transformer | ✅ |
+| Все PDL unit tests проходят | ✅ |
 
 ---
 
@@ -415,6 +395,5 @@ pytest tests/unit/core/models/test_pdl.py tests/unit/core/models/test_pairwise_l
 - Удалить закомментированную строку `# pair_target = ...` в `build_classification_pairs` (`pairwise_core.py` ~142).
 - Module-level docstring в `pairwise_core.py`.
 - TypedContract для `PairwiseBatch.diagnostics` (TODO в коде).
-- Починка `PDCDataTransformer` (Issue 2).
 - Переименовать `similarity` → `same_probability_matrix` в `_predict_encoded_proba` (косметика).
 

--- a/docs/pr_plans/pdl-time-series/pr_1_safety_and_contracts.md
+++ b/docs/pr_plans/pdl-time-series/pr_1_safety_and_contracts.md
@@ -1,0 +1,420 @@
+```mermaid
+flowchart TB
+    subgraph Input["Вход"]
+        X["features (n × F)"]
+        Y["target (n)"]
+        CFG["PairwiseLearningConfig"]
+    end
+
+    subgraph Anchor["Выбор якорей — pairwise_core.py"]
+        direction TB
+        CLF_A["select_classification_anchor_indices<br/>per-class evenly spaced<br/>или all если n² ≤ max_pairs"]
+        REG_A["select_regression_anchor_indices<br/>evenly spaced по индексу<br/>или all если n² ≤ max_pairs"]
+    end
+
+    subgraph PairBuild["Сбор пар — pairwise_core.py"]
+        PI["_pair_indices<br/>left × anchor (cross-product)"]
+        PF["build_pair_features<br/>concat_diff / absdiff / diff_only"]
+        CLF_T["build_classification_pairs<br/>dissimilarity = int(left≠anchor)<br/>0=same, 1=different"]
+        REG_T["build_regression_pairs<br/>delta = left − anchor"]
+    end
+
+    subgraph Train["Обучение — pairwise_model.py"]
+        BM["base_model.fit(pair_features, pair_target)"]
+        DIAG["diagnostics_ ← batch.diagnostics<br/>+ task metadata<br/>+ pair_target_semantics"]
+    end
+
+    subgraph InferClf["Inference Classification"]
+        PS["predict_similarity_by_chunks<br/>→ P(same) matrix (n × n_anchors)"]
+        AGG["aggregate_similarity_to_class_proba<br/>mean P(same) per class → normalize"]
+    end
+
+    subgraph InferReg["Inference Regression"]
+        PR["predict_regression_by_chunks<br/>delta = model.predict<br/>y = anchor_target + delta<br/>mean over anchors"]
+    end
+
+    X --> CLF_A & REG_A
+    Y --> CLF_A & REG_A
+    CFG --> CLF_A & REG_A
+
+    CLF_A -->|"anchor_indices_"| PI
+    REG_A -->|"anchor_indices_"| PI
+    X --> PF
+    PI --> CLF_T & REG_T
+    PF --> CLF_T & REG_T
+
+    CLF_T --> BM
+    REG_T --> BM
+    CLF_T & REG_T --> DIAG
+
+    BM --> PS & PR
+    PS --> AGG
+```
+
+```mermaid
+classDiagram
+    direction TB
+
+    class PairwiseLearningConfig {
+        +backend: str
+        +pairing_policy: str
+        +max_pairs: int
+        +anchors_per_class: int
+        +pair_feature_mode: str
+        +chunk_size: int
+        +random_state: int
+        pairwise_core.py
+    }
+
+    class PairwiseBatch {
+        +features: ndarray
+        +target: ndarray
+        +left_indices: ndarray
+        +anchor_indices: ndarray
+        +diagnostics: dict
+        pairwise_core.py
+    }
+
+    class PairwiseDifferenceClassifier {
+        +fit()
+        +predict()
+        +predict_proba()
+        +score_difference()
+        +get_diagnostics()
+        pairwise_model.py
+    }
+
+    class PairwiseDifferenceRegressor {
+        +fit()
+        +predict()
+        +get_diagnostics()
+        pairwise_model.py
+    }
+
+    class PairwiseDifferenceEstimator {
+        +pair_input()
+        +pair_output() left−anchor
+        +pair_output_difference()
+        pairwise_model.py legacy
+    }
+
+    note for PairwiseDifferenceClassifier "task=classification\nanchor: per-class\npair target: dissimilarity\ninference: P(same)"
+
+    note for PairwiseDifferenceRegressor "task=regression\nanchor: evenly spaced\ndelta: left−anchor\ninference: anchor+delta"
+
+    PairwiseLearningConfig --> PairwiseDifferenceClassifier
+    PairwiseLearningConfig --> PairwiseDifferenceRegressor
+    PairwiseDifferenceClassifier --> PairwiseBatch : build_classification_pairs
+    PairwiseDifferenceRegressor --> PairwiseBatch : build_regression_pairs
+    PairwiseDifferenceClassifier --> PairwiseDifferenceEstimator : legacy helper
+    PairwiseDifferenceRegressor --> PairwiseDifferenceEstimator : legacy helper
+```
+```mermaid
+flowchart TB
+    subgraph core ["test_pairwise_learning_core.py"]
+        C1["test_classification_pair_target_semantics...<br/>build_classification_pairs"]
+        C2["test_pair_target_semantics_is_reported...<br/>batch.diagnostics"]
+        C3["test_predict_same_probability...<br/>_predict_same_probability"]
+    end
+
+    subgraph pdl ["test_pdl.py"]
+        P1["TestPairwiseDifferenceEstimator<br/>pair_output_difference — legacy"]
+        P2["TestPDLContracts<br/>_predict_same_probability"]
+        P3["TestPDLDiagnostics<br/>Classifier/Regressor.fit → get_diagnostics"]
+        P4["TestPDCDataTransformerContracts<br/>Issue 2, xfail"]
+    end
+
+    pairwise_core["pairwise_core.py"] --> core
+    pairwise_model["pairwise_model.py"] --> pdl
+    pairwise_transform["pairwise_transform.py"] --> P4
+
+```
+
+---
+
+## Отчёт по выполнению PR 1
+
+Статус: **Issue 1 — выполнен** (с оговорками ниже). **Issue 2 — частично** (тесты добавлены, код transformer не починен).
+
+Затронутые файлы:
+
+```text
+fedot_ind/core/models/pdl/pairwise_core.py      — контракты, diagnostics, имена
+fedot_ind/core/models/pdl/pairwise_model.py     — legacy API, score_difference
+tests/unit/core/models/test_pdl.py              — estimator + legacy + PDC (xfail)
+tests/unit/core/models/test_pairwise_learning_core.py — core-level контракты
+```
+
+Не изменялись в рамках PR 1:
+
+```text
+fedot_ind/core/models/pdl/pairwise_transform.py  — Issue 2, только тесты-заготовки
+fedot_ind/core/models/pdl/__init__.py
+```
+
+---
+
+### 1. Явные constants/metadata для classification target semantics
+
+**Статус: выполнено**
+
+**Файл:** `pairwise_core.py`, строки 14–16
+
+**Добавлено:**
+
+```python
+CLASSIFICATION_SAME_LABEL = 0
+CLASSIFICATION_DIFFERENT_LABEL = 1
+REGRESSION_DELTA_SIGN = "left_minus_anchor"
+```
+
+**Где используется:**
+
+| Константа | Файл | Функция / место |
+|---|---|---|
+| `CLASSIFICATION_SAME_LABEL` | `pairwise_core.py` | `_predict_same_probability` — выбор столбца P(same) из `predict_proba`; fallback `predict == 0` |
+| `CLASSIFICATION_SAME_LABEL`, `CLASSIFICATION_DIFFERENT_LABEL` | `pairwise_core.py` | `_pair_target_semantics(task="classification")` → поля `same_label`, `different_label` |
+| `REGRESSION_DELTA_SIGN` | `pairwise_core.py` | `_pair_target_semantics(task="regression")` → поле `delta_sign` |
+
+**Не сделано (non-blocking):** module-level docstring в начале `pairwise_core.py` (в Issue 1 указан, но не блокирует acceptance).
+
+---
+
+### 2. Политика имён: `same` и `different` не смешиваются
+
+**Статус: выполнено в active path и legacy helper**
+
+#### Classification — training target
+
+| Было | Стало | Файл |
+|---|---|---|
+| `pair_target = (left != anchor)` | `dissimilarity_target = (left != anchor)` | `pairwise_core.py`, `build_classification_pairs` (~143) |
+| — | `dissimilarity_target` + docstring контракта `0=same, 1=different` | `pairwise_model.py`, `pair_output_difference` (~65–78) |
+
+**Семантика (зафиксированный контракт):**
+
+```text
+same_label           = 0   → одинаковый класс
+different_label      = 1   → разные классы
+dissimilarity_target = int(left_class != anchor_class)   # 0 если same, 1 если different
+```
+
+**В `PairwiseBatch.target`** по-прежнему поле называется `target` (публичная структура не менялась), но в него кладётся `dissimilarity_target`.
+
+#### Classification — inference / scoring
+
+| Было | Стало | Файл |
+|---|---|---|
+| `similarity = predict_similarity_by_chunks(...)` | `same_probability = predict_similarity_by_chunks(...)` | `pairwise_model.py`, `score_difference` (~174) |
+| `target_difference` | `dissimilarity_target` | `pairwise_model.py`, `score_difference` (~175–176) |
+| `predicted_difference = 1.0 - similarity` | `predicted_dissimilarity = 1.0 - same_probability` | `pairwise_model.py`, `score_difference` (~177) |
+
+**В `predict_similarity_by_chunks`** локальная переменная `same_probability` (~211) — это P(class == `same_label`), не «разность» и не dissimilarity.
+
+**Не переименовано (косметика, поведение то же):**
+
+- `aggregate_similarity_to_class_proba(similarity, ...)` — аргумент по-прежнему `similarity`, по смыслу это матрица P(same).
+- `_predict_encoded_proba`: локально `similarity = predict_similarity_by_chunks(...)` (~185).
+
+#### Regression — training target
+
+| Было | Стало | Файл |
+|---|---|---|
+| `pair_target = left - anchor` | `delta_left_minus_anchor = left - anchor` | `pairwise_core.py`, `build_regression_pairs` (~166) |
+| `return anchor - left` | `delta_left_minus_anchor = left - anchor` | `pairwise_model.py`, `pair_output` (~60–63) |
+
+---
+
+### 3. Regression sign convention `left - anchor`
+
+**Статус: выполнено, active path и legacy выровнены**
+
+**Формула:**
+
+```text
+delta_left_minus_anchor = target_left - target_anchor
+feature difference      = left_features - anchor_features   # concat_diff, diff_only
+inference               = anchor_target + predicted_delta
+```
+
+**Где зафиксировано:**
+
+| Место | Файл |
+|---|---|
+| `build_regression_pairs` | `pairwise_core.py` ~166 |
+| `predict_regression_by_chunks` (`anchor_target + deltas`) | `pairwise_core.py` ~233–234 |
+| `_build_pair_features_numpy` (`left - anchors`) | `pairwise_core.py` ~282 |
+| Legacy `pair_output` | `pairwise_model.py` ~60–63 |
+
+**Тесты:** `test_regression_pair_target_is_left_minus_anchor` (`test_pdl.py`), `test_regression_pair_target_uses_left_minus_anchor_sign_convention` (`test_pairwise_learning_core.py`).
+
+**Удалено из тестов:** старый `test_pair_output` с ожиданием `anchor - left` (`y2 - y1`); заменён на `test_regression_pair_target_is_left_minus_anchor`.
+
+---
+
+### 4. `pair_target_semantics` в diagnostics
+
+**Статус: выполнено**
+
+**Добавлено:**
+
+| Элемент | Файл | Строки |
+|---|---|---|
+| `_pair_target_semantics(task)` | `pairwise_core.py` | ~303–321 |
+| параметр `task` в `_pair_diagnostics` | `pairwise_core.py` | ~346–366 |
+| `task="classification"` в `build_classification_pairs` | `pairwise_core.py` | ~150 |
+| `task="regression"` в `build_regression_pairs` | `pairwise_core.py` | ~173 |
+| ключ `"pair_target_semantics"` в return diagnostics | `pairwise_core.py` | ~365 |
+
+**Цепочка до внешнего API:**
+
+```text
+build_*_pairs → batch.diagnostics["pair_target_semantics"]
+    → PairwiseDifferenceClassifier/Regressor.fit → self.diagnostics_
+    → get_diagnostics()
+```
+
+**Пример classification:**
+
+```json
+{
+  "task": "classification",
+  "same_label": 0,
+  "different_label": 1,
+  "target_type": "dissimilarity",
+  "target_formula": "int(left_class != anchor_class)",
+  "inference_output": "same_probability"
+}
+```
+
+**Пример regression:**
+
+```json
+{
+  "task": "regression",
+  "delta_sign": "left_minus_anchor",
+  "target_formula": "target_left - target_anchor",
+  "inference_reconstruction": "anchor_target + predicted_delta"
+}
+```
+
+**Тесты:**
+
+- `test_pair_target_semantics_is_reported_in_diagnostics` — core (`test_pairwise_learning_core.py`)
+- `test_pair_target_semantics_is_reported_in_diagnostics_classifier` / `_regressor` — estimator (`test_pdl.py`, `TestPDLDiagnostics`)
+
+---
+
+### 5. Починить `PDCDataTransformer` или вывести в legacy
+
+**Статус: не выполнено (Issue 2 отложен)**
+
+**Текущие проблемы в `pairwise_transform.py` (без изменений):**
+
+- `fit()` не создаёт `preprocessing_` для X;
+- `transform()` вызывает `self.preprocessing_.transform(X)` → AttributeError при реальном использовании;
+- для `y` вызывается `preprocessing_.transform(y)` вместо `preprocessing_y_.transform(y)` (~102–103);
+- `warnings.catch_warnings()` (~196) без `import warnings`.
+
+**Сделано вместо починки:** добавлены контракт-тесты с `@pytest.mark.xfail` в `test_pdl.py` → `TestPDCDataTransformerContracts`:
+
+- `test_pdc_data_transformer_initializes_x_preprocessor`
+- `test_pdc_data_transformer_uses_y_preprocessor_for_target`
+
+Тесты документируют ожидаемое поведение; после фикса transformer — снять `xfail`.
+
+---
+
+### 6. Недостающие imports
+
+**Статус: N/A для production-кода PR 1; Issue 2 — не исправлен**
+
+В `pairwise_transform.py` по-прежнему отсутствует `import warnings` (баг Issue 2).
+
+В тестах добавлены импорты: `_predict_same_probability`, `PDCDataTransformer`, `StandardScaler`, `patch` (`test_pdl.py`).
+
+---
+
+### 7. Тесты на deterministic toy arrays
+
+**Статус: выполнено**
+
+#### `tests/unit/core/models/test_pdl.py`
+
+| Тест | Класс | Что проверяет |
+|---|---|---|
+| `test_regression_pair_target_is_left_minus_anchor` | `TestPairwiseDifferenceEstimator` | legacy `pair_output`: `[0, -2, 2, 0]` |
+| `test_classification_pair_target_semantics_same_is_zero_current_contract` | `TestPairwiseDifferenceEstimator` | legacy `pair_output_difference`: `[0, 0, 1]` |
+| `test_pair_output_difference` | `TestPairwiseDifferenceEstimator` | расширенный кейс 3×2 пар (оставлен) |
+| `test_predict_same_probability_uses_same_label_column` | `TestPDLContracts` | столбец class 0 из `predict_proba` |
+| `test_predict_same_probability_falls_back_to_hard_predictions` | `TestPDLContracts` | `predict` без `predict_proba` |
+| `test_pair_target_semantics_is_reported_in_diagnostics_classifier` | `TestPDLDiagnostics` | semantics после `Classifier.fit` |
+| `test_pair_target_semantics_is_reported_in_diagnostics_regressor` | `TestPDLDiagnostics` | semantics после `Regressor.fit` |
+| `test_pdc_data_transformer_*` | `TestPDCDataTransformerContracts` | Issue 2, xfail |
+
+Заглушки `_PairProbaStub`, `_HardLabelStub` вместо `MagicMock` — проще читать и стабильнее в CI.
+
+#### `tests/unit/core/models/test_pairwise_learning_core.py`
+
+| Тест | Что проверяет |
+|---|---|
+| `test_classification_pair_target_semantics_same_is_zero_current_contract` | `build_classification_pairs` → `[0, 0, 1]` |
+| `test_pair_target_semantics_is_reported_in_diagnostics` | `batch.diagnostics` clf + reg |
+| `test_predict_same_probability_uses_same_label_column` | `_predict_same_probability` на уровне core |
+| `test_regression_pair_target_uses_left_minus_anchor_sign_convention` | delta + feature blocks |
+
+**Запуск:**
+
+```bash
+pytest tests/unit/core/models/test_pdl.py tests/unit/core/models/test_pairwise_learning_core.py -v
+```
+
+---
+
+## Соответствие Issue 1 — acceptance criteria
+
+| Критерий | Статус | Где проверено |
+|---|---|---|
+| Контракт classification target явно описан | ✅ | константы, `_pair_target_semantics`, docstring `pair_output_difference` |
+| Контракт regression target явно описан | ✅ | `delta_left_minus_anchor`, `REGRESSION_DELTA_SIGN`, diagnostics |
+| Diagnostics возвращает `pair_target_semantics` | ✅ | `_pair_diagnostics`, тесты `TestPDLDiagnostics` |
+| Backward compatibility сохранена | ✅ | публичное поведение clf/reg не менялось; `PairwiseBatch.target` — то же поле |
+| Тесты проверяют values и interpretation | ✅ | exact arrays на toy data |
+
+**Non-goals соблюдены:** classification target `0=same, 1=different` не менялся; posterior aggregation не добавлялась.
+
+---
+
+## Соответствие Issue 2 — acceptance criteria
+
+| Критерий | Статус |
+|---|---|
+| `fit().transform()` не падает на базовых сценариях | ❌ `preprocessing_` не инициализируется |
+| X и y — разные pipelines | ❌ `y` идёт через `preprocessing_` |
+| Нет обращения к неинициализированным attributes | ❌ |
+| Тесты `test_pdc_data_transformer_*` | ✅ добавлены (xfail) |
+| `test_pdc_data_transformer_handles_numeric/categorical` | ❌ не добавлены |
+
+**Рекомендация для следующего PR:** починить `PDCDataTransformer` или перенести в `legacy.py`; снять `xfail` с двух тестов.
+
+---
+
+## Критерии приёмки PR 1 — итог
+
+| Критерий | Статус |
+|---|---|
+| Поведение default classifier/regressor не меняется | ✅ |
+| Diagnostics явно сообщает target semantics | ✅ |
+| Нет обращения к неинициализированным attributes в transformer | ❌ Issue 2 |
+| Все PDL unit tests проходят | ✅ (кроме 2 xfail по PDC) |
+
+---
+
+## Остаточный техдолг (вне scope закрытого PR 1)
+
+- Удалить закомментированную строку `# pair_target = ...` в `build_classification_pairs` (`pairwise_core.py` ~142).
+- Module-level docstring в `pairwise_core.py`.
+- TypedContract для `PairwiseBatch.diagnostics` (TODO в коде).
+- Починка `PDCDataTransformer` (Issue 2).
+- Переименовать `similarity` → `same_probability_matrix` в `_predict_encoded_proba` (косметика).
+

--- a/docs/pr_plans/pdl-time-series/pr_1_safety_and_contracts.md
+++ b/docs/pr_plans/pdl-time-series/pr_1_safety_and_contracts.md
@@ -132,27 +132,19 @@ flowchart TB
 
 ## Отчёт по выполнению PR 1
 
-Статус: **Issue 1 — выполнен** (с оговорками ниже). **Issue 2 — выполнен** (код transformer пернесён в legacy, тесты добавлены и адаптированы под перенос модуля в legacy).
+Статус: **Issue 1 — выполнен**. **Issue 2 — выполнен**.
 
 Затронутые файлы:
 
 ```text
 * fedot_ind/core/models/pdl/pairwise_core.py — контракты, diagnostics, имена
-* fedot_ind/core/models/pdl/pairwise_model.py — legacy API, score_difference
-* tests/unit/core/models/test_pdl.py  — estimator + legacy + PDC (xfail)
+* fedot_ind/core/models/pdl/pairwise_model.py — score_difference
+* tests/unit/core/models/test_pdl.py  — контракты, estimator/classifier/regressor
 * tests/unit/core/models/test_pairwise_learning_core.py — core-level контракты
 
 * fedot_ind/core/models/pdl/legacy_pairwise_transform.py — модуль transform перенесённый в legacy
 * tests/unit/core/models/test_pdl_transform.py — пересобранные тесты для legacy transform
 ```
-
-Не изменялись в рамках PR 1:
-
-```text
-fedot_ind/core/models/pdl/__init__.py
-```
-
----
 
 ### 1. Явные constants/metadata для classification target semantics
 
@@ -176,7 +168,6 @@ REGRESSION_DELTA_SIGN = "left_minus_anchor"
 | `CLASSIFICATION_SAME_LABEL`, `CLASSIFICATION_DIFFERENT_LABEL` | `pairwise_core.py` | `_pair_target_semantics(task="classification")` → поля `same_label`, `different_label` |
 | `REGRESSION_DELTA_SIGN` | `pairwise_core.py` | `_pair_target_semantics(task="regression")` → поле `delta_sign` |
 
-**Не сделано (non-blocking):** module-level docstring в начале `pairwise_core.py` (в Issue 1 указан, но не блокирует acceptance).
 
 ---
 
@@ -246,8 +237,6 @@ inference               = anchor_target + predicted_delta
 | `_build_pair_features_numpy` (`left - anchors`) | `pairwise_core.py` ~282 |
 | Legacy `pair_output` | `pairwise_model.py` ~60–63 |
 
-**Тесты:** `test_regression_pair_target_is_left_minus_anchor` (`test_pdl.py`), `test_regression_pair_target_uses_left_minus_anchor_sign_convention` (`test_pairwise_learning_core.py`).
-
 **Удалено из тестов:** старый `test_pair_output` с ожиданием `anchor - left` (`y2 - y1`); заменён на `test_regression_pair_target_is_left_minus_anchor`.
 
 ---
@@ -274,7 +263,7 @@ build_*_pairs → batch.diagnostics["pair_target_semantics"]
     → get_diagnostics()
 ```
 
-**Пример classification:**
+**Для classification:**
 
 ```json
 {
@@ -287,7 +276,7 @@ build_*_pairs → batch.diagnostics["pair_target_semantics"]
 }
 ```
 
-**Пример regression:**
+** Для regression:**
 
 ```json
 {
@@ -296,6 +285,14 @@ build_*_pairs → batch.diagnostics["pair_target_semantics"]
   "target_formula": "target_left - target_anchor",
   "inference_reconstruction": "anchor_target + predicted_delta"
 }
+
+*_pair_diagnostics* кладётся в PairwiseBatch.diagnostics на этапе построения пар,
+источник pairwise_core.py.
+В pairwise_model.py: в fit к batch‑диагностике добавляются runtime‑поля модели (diagnostics_).
+
+Опционально доработать: нет типизированного контракта диагностики, оставлены TODO для PairwiseBatch.diagnostics, _pair_diagnostics, и в обоих fit. Сейчас это dict.
+
+
 ```
 
 **Тесты:**
@@ -337,7 +334,7 @@ build_*_pairs → batch.diagnostics["pair_target_semantics"]
 | `test_pair_target_semantics_is_reported_in_diagnostics_classifier` | `TestPDLDiagnostics` | semantics после `Classifier.fit` |
 | `test_pair_target_semantics_is_reported_in_diagnostics_regressor` | `TestPDLDiagnostics` | semantics после `Regressor.fit` |
 
-Заглушки `_PairProbaStub`, `_HardLabelStub` вместо `MagicMock` — проще читать и стабильнее в CI.
+Заглушки `_PairProbaStub`, `_HardLabelStub` вместо `MagicMock`.
 
 #### `tests/unit/core/models/test_pairwise_learning_core.py`
 
@@ -348,52 +345,9 @@ build_*_pairs → batch.diagnostics["pair_target_semantics"]
 | `test_predict_same_probability_uses_same_label_column` | `_predict_same_probability` на уровне core |
 | `test_regression_pair_target_uses_left_minus_anchor_sign_convention` | delta + feature blocks |
 
-**Запуск:**
-
-```bash
-pytest tests/unit/core/models/test_pdl.py tests/unit/core/models/test_pairwise_learning_core.py -v
-```
-
----
-
-## Соответствие Issue 1 — acceptance criteria
-
-| Критерий | Статус | Где проверено |
-|---|---|---|
-| Контракт classification target явно описан | ✅ | константы, `_pair_target_semantics`, docstring `pair_output_difference` |
-| Контракт regression target явно описан | ✅ | `delta_left_minus_anchor`, `REGRESSION_DELTA_SIGN`, diagnostics |
-| Diagnostics возвращает `pair_target_semantics` | ✅ | `_pair_diagnostics`, тесты `TestPDLDiagnostics` |
-| Backward compatibility сохранена | ✅ | публичное поведение clf/reg не менялось; `PairwiseBatch.target` — то же поле |
-| Тесты проверяют values и interpretation | ✅ | exact arrays на toy data |
-
-**Non-goals соблюдены:** classification target `0=same, 1=different` не менялся; posterior aggregation не добавлялась.
-
----
-
-## Соответствие Issue 2 — acceptance criteria
-
-| Критерий | Статус |
-|---|---|
-| Вынести в legacy и удалить из production path | ✅ |
-| Тесты `test_pdl_transform.py` | ✅ |
-
----
-
-## Критерии приёмки PR 1 — итог
-
-| Критерий | Статус |
-|---|---|
-| Поведение default classifier/regressor не меняется | ✅ |
-| Diagnostics явно сообщает target semantics | ✅ |
-| Нет обращения к неинициализированным attributes в transformer | ✅ |
-| Все PDL unit tests проходят | ✅ |
-
----
-
-## Остаточный техдолг (вне scope закрытого PR 1)
-
-- Удалить закомментированную строку `# pair_target = ...` в `build_classification_pairs` (`pairwise_core.py` ~142).
-- Module-level docstring в `pairwise_core.py`.
-- TypedContract для `PairwiseBatch.diagnostics` (TODO в коде).
-- Переименовать `similarity` → `same_probability_matrix` в `_predict_encoded_proba` (косметика).
-
+Опционально следовало бы когда-нибудь сделать: 
+classification_data/regression_data используют np.random.rand без фиксированного сидирования numpy (сид есть только в train_test_split)
+для воспроизводимости где-нибудь в фикстурах зафиксировать.
+### 8. Импорты
+«Добавить недостающие imports». 
+import warnings присутствует (legacy_pairwise_transform.py:12) это был исходный баг из Issue 2 (использование warnings.catch_warnings() без импорта).

--- a/fedot_ind/core/models/pdl/__init__.py
+++ b/fedot_ind/core/models/pdl/__init__.py
@@ -1,5 +1,10 @@
-from fedot_ind.core.models.pdl.pairwise_core import PairwiseLearningConfig
-from fedot_ind.core.models.pdl.pairwise_model import PairwiseDifferenceClassifier, PairwiseDifferenceRegressor
+# from fedot_ind.core.models.pdl.pairwise_core import PairwiseLearningConfig
+# from fedot_ind.core.models.pdl.pairwise_model import PairwiseDifferenceClassifier, PairwiseDifferenceRegressor
+
+# replacement with relative imports
+
+from .pairwise_core import PairwiseLearningConfig
+from .pairwise_model import PairwiseDifferenceClassifier, PairwiseDifferenceRegressor
 
 __all__ = [
     "PairwiseDifferenceClassifier",

--- a/fedot_ind/core/models/pdl/legacy_pairwise_transform.py
+++ b/fedot_ind/core/models/pdl/legacy_pairwise_transform.py
@@ -58,7 +58,6 @@ class PDCDataTransformer:
         self.y_type = y_type
 
     def fit(self, X, y=None):
-        # TODO: что?
         # y = y.astype('category').cat.codes.astype(np.float32) # todo since I
         # cannot transform the output at least add raise type error on it
         if self.numeric_features is None and self.ordinal_features is None and self.string_features is None:

--- a/fedot_ind/core/models/pdl/legacy_pairwise_transform.py
+++ b/fedot_ind/core/models/pdl/legacy_pairwise_transform.py
@@ -1,9 +1,21 @@
+"""Legacy pandas preprocessing helpers for PDL (not used in production).
+
+This module is deprecated. The active PDL path uses:
+
+- ``fedot_ind.core.models.pdl.pairwise_core.normalize_feature_matrix``
+- ``PairwiseDifferenceClassifier`` / ``PairwiseDifferenceRegressor`` from ``pairwise_model``
+
+Former module name: ``pairwise_transform.py``.
+"""
+
 import functools
+import warnings
 from typing import Iterable, Optional
 
 import numpy as np
 import pandas as pd
 import sklearn.base
+import sklearn.metrics
 from fedot.core.operations.operation_parameters import OperationParameters
 from scipy.optimize import LinearConstraint, minimize
 from scipy.spatial.distance import cdist
@@ -12,11 +24,24 @@ from sklearn.cluster import KMeans
 from sklearn.compose import ColumnTransformer
 from sklearn.utils.validation import check_is_fitted
 
+_LEGACY_USAGE_MESSAGE = (
+    "PDCDataTransformer and SampleWeights are legacy and not part of the active PDL path. "
+    "Use PairwiseDifferenceClassifier/PairwiseDifferenceRegressor with "
+    "pairwise_core.normalize_feature_matrix instead."
+)
 
-class PDCDataTransformer: # TODO: Починить PDCDataTransformer или вывести его из active path как legacy
-    """
-    Transform the data so that it can be processed by PDL models.
-    """
+
+def _warn_legacy_usage(class_name: str) -> None:
+    warnings.warn(
+        f"{class_name}: {_LEGACY_USAGE_MESSAGE}",
+        category=DeprecationWarning,
+        stacklevel=3,
+    )
+
+
+class PDCDataTransformer:
+    """Deprecated tabular preprocessor prototype; not wired into production PDL estimators."""
+
     preprocessing_: ColumnTransformer
     preprocessing_y_: ColumnTransformer  # todo fix the ColumnTransformer annotation
 
@@ -24,6 +49,7 @@ class PDCDataTransformer: # TODO: Починить PDCDataTransformer или в�
                  ordinal_features: Iterable = None,
                  string_features: Iterable = None,
                  y_type: str = None):
+        _warn_legacy_usage(self.__class__.__name__)
         self.numeric_features = numeric_features
         self.ordinal_features = ordinal_features
         self.string_features = string_features
@@ -64,11 +90,12 @@ class PDCDataTransformer: # TODO: Починить PDCDataTransformer или в�
             from sklearn.preprocessing import OneHotEncoder
             self.preprocessing_y_ = OneHotEncoder()
 
-        if y is not None and self.preprocessing_y_ is not None:
+        if y is not None and getattr(self, "preprocessing_y_", None) is not None:
             if isinstance(y, pd.Series):
                 y = pd.DataFrame(y)
             self.preprocessing_y_.fit(y)
 
+        self._legacy_fit_complete_ = True
         return self
 
     def cast_uint(self, X: pd.DataFrame, y: pd.Series = None):
@@ -82,33 +109,41 @@ class PDCDataTransformer: # TODO: Починить PDCDataTransformer или в�
         return X, y
 
     def transform(self, X, y=None):
-        check_is_fitted(self)
-        X, _ = self.cast_uint(X)
-        X = pd.DataFrame(self.preprocessing_.transform(X))
-        from scipy.sparse import csr_matrix
-        if any(isinstance(e, csr_matrix) for e in X.values.flatten()):
-            raise NotImplementedError('error in data \t X contains sparse features (csr_matrix)')
-        X = X.dropna(axis=1, how='all')  # Drop columns with all NaN values
-        X = X.astype(np.float32)
+        # check_is_fitted(self)
+        # X, _ = self.cast_uint(X)
+        # X = pd.DataFrame(self.preprocessing_.transform(X))
+        # from scipy.sparse import csr_matrix
+        # if any(isinstance(e, csr_matrix) for e in X.values.flatten()):
+        #     raise NotImplementedError('error in data \t X contains sparse features (csr_matrix)')
+        # X = X.dropna(axis=1, how='all')  # Drop columns with all NaN values
+        # X = X.astype(np.float32)
 
-        if len(X.columns) == 0:
-            raise ValueError('error in data \t X no features left after pre-processing')
-        # if X.isna().any().any():
-        #     raise NotImplementedError('error in data \t Some features are NaNs in the X set')
-        if any(x in pd.Series(X.values.flatten()).apply(type).unique() for x in
-               ('csr_matrix', 'date',)):  # todo think about adding  'str'
-            raise NotImplementedError('error in data \t Dataset contains sparse data')
+        # if len(X.columns) == 0:
+        #     raise ValueError('error in data \t X no features left after pre-processing')
+        # # if X.isna().any().any():
+        # #     raise NotImplementedError('error in data \t Some features are NaNs in the X set')
+        # if any(x in pd.Series(X.values.flatten()).apply(type).unique() for x in
+        #        ('csr_matrix', 'date',)):  # todo think about adding  'str'
+        #     raise NotImplementedError('error in data \t Dataset contains sparse data')
 
-        if y is not None and self.preprocessing_ is not None:
-            y = pd.Series(self.preprocessing_.transform(y), name='y')
-        if y is None:
-            return X.values
-        return X.values, y.values
+        # if y is not None and self.preprocessing_ is not None:
+        #     y = pd.Series(self.preprocessing_.transform(y), name='y')
+        # if y is None:
+        #     return X.values
+        # return X.values, y.values
+        """Raise because X preprocessing was never completed in this legacy prototype."""
+        check_is_fitted(self, attributes=["_legacy_fit_complete_"])
+        raise NotImplementedError(
+            f"PDCDataTransformer.transform is not available in the legacy module. {_LEGACY_USAGE_MESSAGE}"
+        )
 
 
 class SampleWeights:
+    """Deprecated anchor weighting prototype; requires a fitted PDL estimator context."""
+
     def __init__(self, params: Optional[OperationParameters] = None):
-        # Save information about the weighting methods as here for better availability
+        _warn_legacy_usage(self.__class__.__name__)
+        params = params or {}
         self.method = params.get('method', 'L2')
 
         self.method_dict = {

--- a/fedot_ind/core/models/pdl/legacy_pairwise_transform.py
+++ b/fedot_ind/core/models/pdl/legacy_pairwise_transform.py
@@ -45,22 +45,31 @@ class PDCDataTransformer:
     preprocessing_: ColumnTransformer
     preprocessing_y_: ColumnTransformer  # todo fix the ColumnTransformer annotation
 
-    def __init__(self, numeric_features: Iterable = None,
-                 ordinal_features: Iterable = None,
-                 string_features: Iterable = None,
-                 y_type: str = None):
+    def __init__(
+        self,
+        numeric_features: Iterable = None,
+        ordinal_features: Iterable = None,
+        string_features: Iterable = None,
+        y_type: str = None,
+    ):
         _warn_legacy_usage(self.__class__.__name__)
         self.numeric_features = numeric_features
         self.ordinal_features = ordinal_features
         self.string_features = string_features
-        if y_type is not None and y_type not in ('numeric', 'ordinal', 'string'):
-            raise ValueError(f"y_type must be one of 'numeric', 'ordinal', 'string' but got {y_type}")
+        if y_type is not None and y_type not in ("numeric", "ordinal", "string"):
+            raise ValueError(
+                f"y_type must be one of 'numeric', 'ordinal', 'string' but got {y_type}"
+            )
         self.y_type = y_type
 
     def fit(self, X, y=None):
         # y = y.astype('category').cat.codes.astype(np.float32) # todo since I
         # cannot transform the output at least add raise type error on it
-        if self.numeric_features is None and self.ordinal_features is None and self.string_features is None:
+        if (
+            self.numeric_features is None
+            and self.ordinal_features is None
+            and self.string_features is None
+        ):
             self.numeric_features = []
             self.ordinal_features = []  # todo fix name, will be processed a ordinal
             self.string_features = []
@@ -73,20 +82,25 @@ class PDCDataTransformer:
                         self.ordinal_features.append(column)  # ordinal...
                     else:
                         self.string_features.append(column)
-                elif pd.api.types.is_bool_dtype(dtype):  # pd.api.types.is_categorical_dtype(dtype) deprecated
+                elif pd.api.types.is_bool_dtype(
+                    dtype
+                ):  # pd.api.types.is_categorical_dtype(dtype) deprecated
                     self.string_features.append(column)
                 elif pd.api.types.is_string_dtype(dtype):
                     self.string_features.append(column)
 
         X, _ = self.cast_uint(X)
-        if self.y_type == 'numeric':
+        if self.y_type == "numeric":
             from sklearn.preprocessing import StandardScaler
+
             self.preprocessing_y_ = StandardScaler()
-        elif self.y_type == 'ordinal':  # string
+        elif self.y_type == "ordinal":  # string
             from sklearn.preprocessing import OrdinalEncoder
+
             self.preprocessing_y_ = OrdinalEncoder()
-        elif self.y_type == 'string':
+        elif self.y_type == "string":
             from sklearn.preprocessing import OneHotEncoder
+
             self.preprocessing_y_ = OneHotEncoder()
 
         if y is not None and getattr(self, "preprocessing_y_", None) is not None:
@@ -98,13 +112,13 @@ class PDCDataTransformer:
         return self
 
     def cast_uint(self, X: pd.DataFrame, y: pd.Series = None):
-        numeric_cols = X.select_dtypes(include=['number']).columns
+        numeric_cols = X.select_dtypes(include=["number"]).columns
 
         for col in numeric_cols:
-            X[col] = X[col].astype('float32')
+            X[col] = X[col].astype("float32")
 
         if y is not None:
-            y = y.astype('float32')
+            y = y.astype("float32")
         return X, y
 
     def transform(self, X, y=None):
@@ -143,22 +157,24 @@ class SampleWeights:
     def __init__(self, params: Optional[OperationParameters] = None):
         _warn_legacy_usage(self.__class__.__name__)
         params = params or {}
-        self.method = params.get('method', 'L2')
+        self.method = params.get("method", "L2")
 
         self.method_dict = {
             # Optimization based methods:
-            'L2': functools.partial(self._sample_weight_optimize, l2_lambda=0.1),
-            'KLD': functools.partial(self._sample_weight_optimize, kld_lambda=0.05),
-            'Optimize': self._sample_weight_optimize,
-            'L1L2': functools.partial(self._sample_weight_optimize, l1_lambda=0.05, l2_lambda=0.025),
-            'L1': functools.partial(self._sample_weight_optimize, l1_lambda=0.1),
-            'ExtremeWeightPruning': self._sample_weight_extreme_pruning,
+            "L2": functools.partial(self._sample_weight_optimize, l2_lambda=0.1),
+            "KLD": functools.partial(self._sample_weight_optimize, kld_lambda=0.05),
+            "Optimize": self._sample_weight_optimize,
+            "L1L2": functools.partial(
+                self._sample_weight_optimize, l1_lambda=0.05, l2_lambda=0.025
+            ),
+            "L1": functools.partial(self._sample_weight_optimize, l1_lambda=0.1),
+            "ExtremeWeightPruning": self._sample_weight_extreme_pruning,
             # Heuristic methods
-            'NegativeError': self._sample_weight_negative_error,
-            'InverseError': self._sample_weight_inverse_error,
-            'OrderedVoting': self._sample_weight_ordered_votes,
+            "NegativeError": self._sample_weight_negative_error,
+            "InverseError": self._sample_weight_inverse_error,
+            "OrderedVoting": self._sample_weight_ordered_votes,
             # Other Methods:
-            'KMeansClusterCenters': self._sample_weight_by_kmeans_prototypes,
+            "KMeansClusterCenters": self._sample_weight_by_kmeans_prototypes,
         }
 
     def _normalize_weights(self, weights: np.ndarray) -> pd.Series:
@@ -167,23 +183,25 @@ class SampleWeights:
         :param weights: The weights to be normalized as a pd.Series
         """
         if all(np.isclose(weights, weights.values[0])):
-            weights = pd.Series(1., index=weights.index)
-        assert weights.min() >= 0, f'Negative weights found: {weights[weights < 0]}'
+            weights = pd.Series(1.0, index=weights.index)
+        assert weights.min() >= 0, f"Negative weights found: {weights[weights < 0]}"
         weights /= weights.sum()
         return weights
 
-    def __objective_function(self,
-                             weights: np.ndarray,
-                             pred_val_samples_np: np.ndarray,
-                             y_val: np.ndarray,
-                             initial_mae: float,
-                             kld_lambda=0.,
-                             l1_lambda=0.,
-                             l2_lambda=0.) -> float:
-        assert kld_lambda >= 0, f'kld_lambda should be >=0, got {kld_lambda}'
-        assert l1_lambda >= 0, f'l1_lambda should be >=0, got {l1_lambda}'
-        assert l2_lambda >= 0, f'l2_lambda should be >=0, got {l2_lambda}'
-        assert initial_mae >= 0, f'initial_mae should be >=0, got {initial_mae}'
+    def __objective_function(
+        self,
+        weights: np.ndarray,
+        pred_val_samples_np: np.ndarray,
+        y_val: np.ndarray,
+        initial_mae: float,
+        kld_lambda=0.0,
+        l1_lambda=0.0,
+        l2_lambda=0.0,
+    ) -> float:
+        assert kld_lambda >= 0, f"kld_lambda should be >=0, got {kld_lambda}"
+        assert l1_lambda >= 0, f"l1_lambda should be >=0, got {l1_lambda}"
+        assert l2_lambda >= 0, f"l2_lambda should be >=0, got {l2_lambda}"
+        assert initial_mae >= 0, f"initial_mae should be >=0, got {initial_mae}"
 
         predictions = np.matmul(pred_val_samples_np, weights / sum(weights))
         mae = sklearn.metrics.mean_absolute_error(y_val, predictions)
@@ -192,9 +210,13 @@ class SampleWeights:
         if kld_lambda > 0:
             train_size = len(weights)
             weights_initial_guess = np.ones(train_size) / train_size
-            regularisation += kld_lambda * entropy(weights, weights_initial_guess) / train_size
+            regularisation += (
+                kld_lambda * entropy(weights, weights_initial_guess) / train_size
+            )
         if l1_lambda > 0:
-            regularisation += l1_lambda * (np.linalg.norm(weights, ord=1) - max(weights))
+            regularisation += l1_lambda * (
+                np.linalg.norm(weights, ord=1) - max(weights)
+            )
         if l2_lambda > 0:
             regularisation += l2_lambda * np.linalg.norm(weights, ord=2)
 
@@ -202,8 +224,15 @@ class SampleWeights:
         loss = mae + regularisation
         return loss
 
-    def _sample_weight_optimize(self, X_val: pd.DataFrame, y_val: pd.Series, kld_lambda=0., l1_lambda=0., l2_lambda=0.,
-                                **kwargs) -> pd.Series:
+    def _sample_weight_optimize(
+        self,
+        X_val: pd.DataFrame,
+        y_val: pd.Series,
+        kld_lambda=0.0,
+        l1_lambda=0.0,
+        l2_lambda=0.0,
+        **kwargs,
+    ) -> pd.Series:
         """
         Minimize the validation MAE using SLSQP optimizer
         with a linear constraint on the sum of the weights.
@@ -217,20 +246,33 @@ class SampleWeights:
         pred_val_samples_np = prediction_samples_df.values
         train_size = len(self.X_train_)
         weights_initial_guess = np.ones(train_size) / train_size
-        initial_mae = sklearn.metrics.mean_absolute_error(y_val, np.matmul(pred_val_samples_np, weights_initial_guess))
+        initial_mae = sklearn.metrics.mean_absolute_error(
+            y_val, np.matmul(pred_val_samples_np, weights_initial_guess)
+        )
 
         def objective_function(weights: np.ndarray) -> float:
-            return self.__objective_function(weights=weights, pred_val_samples_np=pred_val_samples_np, y_val=y_val,
-                                             initial_mae=initial_mae, kld_lambda=kld_lambda, l1_lambda=l1_lambda,
-                                             l2_lambda=l2_lambda)
+            return self.__objective_function(
+                weights=weights,
+                pred_val_samples_np=pred_val_samples_np,
+                y_val=y_val,
+                initial_mae=initial_mae,
+                kld_lambda=kld_lambda,
+                l1_lambda=l1_lambda,
+                l2_lambda=l2_lambda,
+            )
 
-        variable_bounds = [(0., 1.) for _ in range(train_size)]
+        variable_bounds = [(0.0, 1.0) for _ in range(train_size)]
         sum_constraint = LinearConstraint(np.ones(train_size), lb=1, ub=1)
 
         with warnings.catch_warnings():
             warnings.simplefilter("ignore")
-            result = minimize(objective_function, weights_initial_guess, method='SLSQP', bounds=variable_bounds,
-                              constraints=[sum_constraint])
+            result = minimize(
+                objective_function,
+                weights_initial_guess,
+                method="SLSQP",
+                bounds=variable_bounds,
+                constraints=[sum_constraint],
+            )
         # Extract the solution
         optimal_weight = result.x
 
@@ -239,11 +281,15 @@ class SampleWeights:
         sample_weights = pd.Series(optimal_weight, index=self.X_train_.index)
         return sample_weights
 
-    def _sample_weight_extreme_pruning(self, X_val: pd.DataFrame, y_val: pd.Series, **kwargs) -> pd.Series:
+    def _sample_weight_extreme_pruning(
+        self, X_val: pd.DataFrame, y_val: pd.Series, **kwargs
+    ) -> pd.Series:
         l1 = 0.8
         while l1 > 0.0001:
-            weights = self._sample_weight_optimize(X_val=X_val, y_val=y_val, l1_lambda=l1)
-            if sum(weights == 0) / len(weights) > .9:
+            weights = self._sample_weight_optimize(
+                X_val=X_val, y_val=y_val, l1_lambda=l1
+            )
+            if sum(weights == 0) / len(weights) > 0.9:
                 l1 *= 0.5
             else:
                 break
@@ -258,19 +304,27 @@ class SampleWeights:
         :return:
         """
         pred_val_samples, _ = self._predict_samples(X_val)
-        errors = pred_val_samples.apply(lambda one_val_samples: abs(y_val - one_val_samples), axis=0)
+        errors = pred_val_samples.apply(
+            lambda one_val_samples: abs(y_val - one_val_samples), axis=0
+        )
         val_mae = errors.mean()
         np.testing.assert_array_equal(val_mae.index, self.X_train_.index)
         return val_mae
 
-    def _sample_weight_inverse_error(self, X_val: pd.DataFrame, y_val: pd.Series, **kwargs) -> pd.Series:
+    def _sample_weight_inverse_error(
+        self, X_val: pd.DataFrame, y_val: pd.Series, **kwargs
+    ) -> pd.Series:
         val_mae = self._error(X_val=X_val, y_val=y_val)
-        sample_weights = 1. / (val_mae + 0.0001)
+        sample_weights = 1.0 / (val_mae + 0.0001)
         sample_weights = sample_weights / sample_weights.sum()
         return sample_weights
 
-    def _sample_weight_negative_error(self, X_val: pd.DataFrame, y_val: pd.Series, **kwargs) -> pd.Series:
-        uniform_weights = pd.Series([1 / len(self.X_train_)] * len(self.X_train_), index=self.X_train_.index)
+    def _sample_weight_negative_error(
+        self, X_val: pd.DataFrame, y_val: pd.Series, **kwargs
+    ) -> pd.Series:
+        uniform_weights = pd.Series(
+            [1 / len(self.X_train_)] * len(self.X_train_), index=self.X_train_.index
+        )
         val_mae = self._error(X_val=X_val, y_val=y_val)
         if sum(val_mae) == 0:
             return uniform_weights
@@ -282,7 +336,7 @@ class SampleWeights:
 
     @staticmethod
     def _sample_weight_ordered_votes_from_weights(received_weights):
-        errors = - received_weights
+        errors = -received_weights
         k = len(errors)
         ranks = np.argsort(np.argsort(errors)) + 1
         weights = (k - ranks + 1) / (k * (k + 1) / 2)
@@ -296,7 +350,9 @@ class SampleWeights:
         :param force_symmetry: Sets the force_symmetry parameter of the prediction function
         :return: The weights as np.NDarray
         """
-        weights = self._sample_weight_negative_error(X_val, y_val, force_symmetry=force_symmetry)
+        weights = self._sample_weight_negative_error(
+            X_val, y_val, force_symmetry=force_symmetry
+        )
         return self._sample_weight_ordered_votes_from_weights(weights)
 
     def _sample_weight_by_kmeans_prototypes(self, k=None, **kwargs):
@@ -309,14 +365,22 @@ class SampleWeights:
         :return: The weights as np.NDarray
         """
         if not k:
-            k = max(int(len(self.X_train_) / 10), 3)  # 10% and min 3 of the training set data points is used as weights
+            k = max(
+                int(len(self.X_train_) / 10), 3
+            )  # 10% and min 3 of the training set data points is used as weights
 
         kmeans = KMeans(n_clusters=k, n_init="auto", random_state=0)
         kmeans.fit(self.X_train_)
 
-        cluster_centers = kmeans.cluster_centers_  # Get the cluster centers (prototypical data points)
-        distances = cdist(self.X_train_, cluster_centers)  # distance between each data point and each cluster center
-        closest_indices = np.argmin(distances, axis=0)  # Get the index of the closest data points to the clusters
+        cluster_centers = (
+            kmeans.cluster_centers_
+        )  # Get the cluster centers (prototypical data points)
+        distances = cdist(
+            self.X_train_, cluster_centers
+        )  # distance between each data point and each cluster center
+        closest_indices = np.argmin(
+            distances, axis=0
+        )  # Get the index of the closest data points to the clusters
 
         # Create an array to mark the closest data points
         closest_array = np.zeros(len(self.X_train_))
@@ -324,5 +388,5 @@ class SampleWeights:
 
         s = pd.Series(closest_array, index=self.X_train_.index)
         s = s.fillna(0)  # I don't know why there are NaNs rather than 0s
-        assert not s.isna().any(), f'Nans values in sample_weights using KMeans\n {s}'
+        assert not s.isna().any(), f"Nans values in sample_weights using KMeans\n {s}"
         return s

--- a/fedot_ind/core/models/pdl/pairwise_core.py
+++ b/fedot_ind/core/models/pdl/pairwise_core.py
@@ -1,6 +1,22 @@
+"""Core utilities for Pairwise Difference Learning (PDL).
+
+This module implements the task-agnostic building blocks of PDL: anchor
+selection, pair construction, pair-feature generation, chunked inference and
+diagnostics. The estimator facades live in ``pairwise_model``.
+
+Pair-target contracts (kept backward compatible):
+    * Classification: ``0 = same`` (``CLASSIFICATION_SAME_LABEL``),
+      ``1 = different`` (``CLASSIFICATION_DIFFERENT_LABEL``). The training
+      target is a *dissimilarity* label and inference returns the probability
+      of the ``same`` class.
+    * Regression: ``delta = target_left - target_anchor``
+      (``REGRESSION_DELTA_SIGN = "left_minus_anchor"``); predictions are
+      reconstructed as ``anchor_target + predicted_delta``.
+"""
+
 from __future__ import annotations
 
-from dataclasses import asdict, dataclass
+from dataclasses import asdict, dataclass, replace
 from typing import Any, Iterable
 
 import numpy as np
@@ -14,6 +30,30 @@ SUPPORTED_PAIR_FEATURE_MODES = ("concat_diff", "concat_absdiff", "diff_only")
 CLASSIFICATION_SAME_LABEL = 0
 CLASSIFICATION_DIFFERENT_LABEL = 1
 REGRESSION_DELTA_SIGN = "left_minus_anchor"
+SUPPORTED_AGGREGATION_POLICIES = (
+    "mean_similarity",
+    "paper_posterior",
+    "weighted_posterior",
+)
+AGGREGATION_POLICY_ALIASES = {
+    "posterior": "paper_posterior",
+    "mean": "mean_similarity",
+    "weighted": "weighted_posterior",
+}
+PRIOR_EPS = 1e-12
+
+
+def resolve_aggregation_policy(raw: str) -> str:
+    key = str(raw).strip().lower()
+    canonical = AGGREGATION_POLICY_ALIASES.get(key, key)
+    if canonical not in SUPPORTED_AGGREGATION_POLICIES:
+        raise ValueError(
+            f"Unsupported aggregation_policy={raw!r}. "
+            f"Supported policies: {SUPPORTED_AGGREGATION_POLICIES}. "
+            f"Aliases: {sorted(AGGREGATION_POLICY_ALIASES)}."
+        )
+    return canonical
+
 
 @dataclass(frozen=True)
 class PairwiseLearningConfig:
@@ -24,6 +64,9 @@ class PairwiseLearningConfig:
     pair_feature_mode: str = "concat_diff"
     chunk_size: int = 8192
     random_state: int = 42
+    aggregation_policy: str = "mean_similarity"
+    symmetric_inference: bool = False
+    class_prior_mode: str = "empirical"
 
     def normalized(self) -> "PairwiseLearningConfig":
         if self.max_pairs <= 0:
@@ -39,7 +82,17 @@ class PairwiseLearningConfig:
             )
         if self.pairing_policy not in {"adaptive_anchors", "all_pairs", "exact", "stratified_anchors"}:
             raise ValueError(f"Unsupported pairing_policy={self.pairing_policy!r}.")
-        return self
+        resolved_policy = resolve_aggregation_policy(self.aggregation_policy)
+        if self.class_prior_mode not in {"empirical", "uniform"}:
+            raise ValueError(
+                f"Unsupported class_prior_mode={self.class_prior_mode!r}. "
+                f"Supported modes: 'empirical', 'uniform'."
+            )
+        if not isinstance(self.symmetric_inference, bool):
+            raise ValueError(
+                f"symmetric_inference must be bool, got {type(self.symmetric_inference).__name__}."
+            )
+        return replace(self, aggregation_policy=resolved_policy)
 
     def to_dict(self) -> dict[str, Any]:
         return asdict(self)
@@ -51,7 +104,8 @@ class PairwiseBatch:
     target: np.ndarray
     left_indices: np.ndarray
     anchor_indices: np.ndarray
-    diagnostics: dict[str, Any] # TODO: TypedContract добавить 
+    # TODO: replace ``diagnostics`` with a typed contract.
+    diagnostics: dict[str, Any]
 
 
 def normalize_feature_matrix(features: Any) -> np.ndarray:
@@ -88,8 +142,7 @@ def resolve_pairwise_backend(backend: str = "auto") -> tuple[str, Any | None]:
         return "torch_cpu", torch.device("cpu")
     raise ValueError(f"Unsupported PDL backend={backend!r}.")
 
-# TODO not need srcond if
-# TODO test target without some class
+
 def select_classification_anchor_indices(
         encoded_target: Any,
         config: PairwiseLearningConfig,
@@ -111,7 +164,7 @@ def select_classification_anchor_indices(
     return np.asarray(sorted(set(selected)), dtype=int)
 
 
-def select_regression_anchor_indices( # TODO: in the feature add choice anchor method
+def select_regression_anchor_indices(
         target: Any,
         config: PairwiseLearningConfig,
 ) -> np.ndarray:
@@ -140,7 +193,6 @@ def build_classification_pairs(
     anchors = np.asarray(tuple(anchor_indices), dtype=int)
     pair_features = build_pair_features(feature_matrix, feature_matrix[anchors], config)
     left_indices, repeated_anchor_indices = _pair_indices(len(feature_matrix), anchors)
-    # pair_target = (target[left_indices] != target[repeated_anchor_indices]).astype(int)
     dissimilarity_target = (target[left_indices] != target[repeated_anchor_indices]).astype(int)
     diagnostics = _pair_diagnostics(
         config=config,
@@ -289,7 +341,7 @@ def _build_pair_features_torch(left: np.ndarray, anchors: np.ndarray, mode: str,
     anchor_tensor = torch.as_tensor(anchors, dtype=torch.float32, device=device)
     left_repeated = left_tensor.repeat_interleave(anchor_tensor.shape[0], dim=0)
     anchors_tiled = anchor_tensor.repeat(left_tensor.shape[0], 1)
-    difference = left_repeated - anchors_tiled # 
+    difference = left_repeated - anchors_tiled
     if mode == "concat_diff":
         paired = torch.cat((left_repeated, anchors_tiled, difference), dim=1)
     elif mode == "concat_absdiff":
@@ -350,8 +402,8 @@ def _pair_diagnostics(
         n_anchors: int,
         pair_feature_dim: int,
         anchor_indices: np.ndarray,
-        task: str
-) -> dict[str, Any]: # TODO: add typed contract diagnostic
+        task: str,
+) -> dict[str, Any]:  # TODO: add typed contract diagnostic
     backend_name, _ = resolve_pairwise_backend(config.backend)
     return {
         "backend": backend_name,

--- a/fedot_ind/core/models/pdl/pairwise_core.py
+++ b/fedot_ind/core/models/pdl/pairwise_core.py
@@ -80,7 +80,12 @@ class PairwiseLearningConfig:
                 f"Unsupported pair_feature_mode={self.pair_feature_mode!r}. "
                 f"Supported modes: {SUPPORTED_PAIR_FEATURE_MODES}."
             )
-        if self.pairing_policy not in {"adaptive_anchors", "all_pairs", "exact", "stratified_anchors"}:
+        if self.pairing_policy not in {
+            "adaptive_anchors",
+            "all_pairs",
+            "exact",
+            "stratified_anchors",
+        }:
             raise ValueError(f"Unsupported pairing_policy={self.pairing_policy!r}.")
         resolved_policy = resolve_aggregation_policy(self.aggregation_policy)
         if self.class_prior_mode not in {"empirical", "uniform"}:
@@ -131,11 +136,15 @@ def resolve_pairwise_backend(backend: str = "auto") -> tuple[str, Any | None]:
     if normalized in {"auto", "torch", "cpu", "cuda"}:
         if torch is None:
             if normalized == "cuda":
-                raise RuntimeError("PDL backend='cuda' was requested, but torch is unavailable.")
+                raise RuntimeError(
+                    "PDL backend='cuda' was requested, but torch is unavailable."
+                )
             return "numpy", None
         if normalized == "cuda":
             if not torch.cuda.is_available():
-                raise RuntimeError("PDL backend='cuda' was requested, but CUDA is unavailable.")
+                raise RuntimeError(
+                    "PDL backend='cuda' was requested, but CUDA is unavailable."
+                )
             return "torch_cuda", torch.device("cuda")
         if normalized == "auto" and torch.cuda.is_available():
             return "torch_cuda", torch.device("cuda")
@@ -144,15 +153,18 @@ def resolve_pairwise_backend(backend: str = "auto") -> tuple[str, Any | None]:
 
 
 def select_classification_anchor_indices(
-        encoded_target: Any,
-        config: PairwiseLearningConfig,
+    encoded_target: Any,
+    config: PairwiseLearningConfig,
 ) -> np.ndarray:
     config = config.normalized()
     target = normalize_target_vector(encoded_target).astype(int)
     n_samples = len(target)
     if n_samples == 0:
         raise ValueError("Cannot select PDL anchors for an empty target.")
-    if config.pairing_policy in {"all_pairs", "exact"} and n_samples * n_samples <= config.max_pairs:
+    if (
+        config.pairing_policy in {"all_pairs", "exact"}
+        and n_samples * n_samples <= config.max_pairs
+    ):
         return np.arange(n_samples, dtype=int)
     if n_samples * n_samples <= config.max_pairs:
         return np.arange(n_samples, dtype=int)
@@ -165,15 +177,18 @@ def select_classification_anchor_indices(
 
 
 def select_regression_anchor_indices(
-        target: Any,
-        config: PairwiseLearningConfig,
+    target: Any,
+    config: PairwiseLearningConfig,
 ) -> np.ndarray:
     config = config.normalized()
     target_vector = normalize_target_vector(target)
     n_samples = len(target_vector)
     if n_samples == 0:
         raise ValueError("Cannot select PDL anchors for an empty target.")
-    if config.pairing_policy in {"all_pairs", "exact"} and n_samples * n_samples <= config.max_pairs:
+    if (
+        config.pairing_policy in {"all_pairs", "exact"}
+        and n_samples * n_samples <= config.max_pairs
+    ):
         return np.arange(n_samples, dtype=int)
     if n_samples * n_samples <= config.max_pairs:
         return np.arange(n_samples, dtype=int)
@@ -183,17 +198,19 @@ def select_regression_anchor_indices(
 
 
 def build_classification_pairs(
-        features: Any,
-        encoded_target: Any,
-        anchor_indices: Iterable[int],
-        config: PairwiseLearningConfig,
+    features: Any,
+    encoded_target: Any,
+    anchor_indices: Iterable[int],
+    config: PairwiseLearningConfig,
 ) -> PairwiseBatch:
     feature_matrix = normalize_feature_matrix(features)
     target = normalize_target_vector(encoded_target).astype(int)
     anchors = np.asarray(tuple(anchor_indices), dtype=int)
     pair_features = build_pair_features(feature_matrix, feature_matrix[anchors], config)
     left_indices, repeated_anchor_indices = _pair_indices(len(feature_matrix), anchors)
-    dissimilarity_target = (target[left_indices] != target[repeated_anchor_indices]).astype(int)
+    dissimilarity_target = (
+        target[left_indices] != target[repeated_anchor_indices]
+    ).astype(int)
     diagnostics = _pair_diagnostics(
         config=config,
         n_left=len(feature_matrix),
@@ -202,21 +219,29 @@ def build_classification_pairs(
         anchor_indices=anchors,
         task="classification",
     )
-    return PairwiseBatch(pair_features, dissimilarity_target, left_indices, repeated_anchor_indices, diagnostics)
+    return PairwiseBatch(
+        pair_features,
+        dissimilarity_target,
+        left_indices,
+        repeated_anchor_indices,
+        diagnostics,
+    )
 
 
 def build_regression_pairs(
-        features: Any,
-        target: Any,
-        anchor_indices: Iterable[int],
-        config: PairwiseLearningConfig,
+    features: Any,
+    target: Any,
+    anchor_indices: Iterable[int],
+    config: PairwiseLearningConfig,
 ) -> PairwiseBatch:
     feature_matrix = normalize_feature_matrix(features)
     target_vector = normalize_target_vector(target).astype(float)
     anchors = np.asarray(tuple(anchor_indices), dtype=int)
     pair_features = build_pair_features(feature_matrix, feature_matrix[anchors], config)
     left_indices, repeated_anchor_indices = _pair_indices(len(feature_matrix), anchors)
-    delta_left_minus_anchor = target_vector[left_indices] - target_vector[repeated_anchor_indices]
+    delta_left_minus_anchor = (
+        target_vector[left_indices] - target_vector[repeated_anchor_indices]
+    )
     diagnostics = _pair_diagnostics(
         config=config,
         n_left=len(feature_matrix),
@@ -225,19 +250,27 @@ def build_regression_pairs(
         anchor_indices=anchors,
         task="regression",
     )
-    return PairwiseBatch(pair_features, delta_left_minus_anchor.astype(float), left_indices, repeated_anchor_indices, diagnostics)
+    return PairwiseBatch(
+        pair_features,
+        delta_left_minus_anchor.astype(float),
+        left_indices,
+        repeated_anchor_indices,
+        diagnostics,
+    )
 
 
 def build_pair_features(
-        left_features: Any,
-        anchor_features: Any,
-        config: PairwiseLearningConfig,
+    left_features: Any,
+    anchor_features: Any,
+    config: PairwiseLearningConfig,
 ) -> np.ndarray:
     config = config.normalized()
     left = normalize_feature_matrix(left_features)
     anchors = normalize_feature_matrix(anchor_features)
     if left.shape[1] != anchors.shape[1]:
-        raise ValueError(f"Pair matrices must have equal feature counts: {left.shape[1]} != {anchors.shape[1]}.")
+        raise ValueError(
+            f"Pair matrices must have equal feature counts: {left.shape[1]} != {anchors.shape[1]}."
+        )
     backend_name, device = resolve_pairwise_backend(config.backend)
     if backend_name == "numpy":
         return _build_pair_features_numpy(left, anchors, config.pair_feature_mode)
@@ -245,10 +278,10 @@ def build_pair_features(
 
 
 def predict_similarity_by_chunks(
-        base_model: Any,
-        features: Any,
-        anchor_features: Any,
-        config: PairwiseLearningConfig,
+    base_model: Any,
+    features: Any,
+    anchor_features: Any,
+    config: PairwiseLearningConfig,
 ) -> np.ndarray:
     feature_matrix = normalize_feature_matrix(features)
     anchors = normalize_feature_matrix(anchor_features)
@@ -259,7 +292,7 @@ def predict_similarity_by_chunks(
     rows_per_chunk = max(1, int(config.chunk_size) // max(1, n_anchors))
     chunks = []
     for start in range(0, n_samples, rows_per_chunk):
-        chunk = feature_matrix[start:start + rows_per_chunk]
+        chunk = feature_matrix[start : start + rows_per_chunk]
         pair_features = build_pair_features(chunk, anchors, config)
         same_probability = _predict_same_probability(base_model, pair_features)
         chunks.append(same_probability.reshape(len(chunk), n_anchors))
@@ -267,11 +300,11 @@ def predict_similarity_by_chunks(
 
 
 def predict_regression_by_chunks(
-        base_model: Any,
-        features: Any,
-        anchor_features: Any,
-        anchor_target: Any,
-        config: PairwiseLearningConfig,
+    base_model: Any,
+    features: Any,
+    anchor_features: Any,
+    anchor_target: Any,
+    config: PairwiseLearningConfig,
 ) -> np.ndarray:
     feature_matrix = normalize_feature_matrix(features)
     anchors = normalize_feature_matrix(anchor_features)
@@ -281,17 +314,23 @@ def predict_regression_by_chunks(
     rows_per_chunk = max(1, int(config.chunk_size) // max(1, n_anchors))
     predictions = []
     for start in range(0, n_samples, rows_per_chunk):
-        chunk = feature_matrix[start:start + rows_per_chunk]
+        chunk = feature_matrix[start : start + rows_per_chunk]
         pair_features = build_pair_features(chunk, anchors, config)
-        deltas = np.asarray(base_model.predict(pair_features), dtype=float).reshape(len(chunk), n_anchors)
+        deltas = np.asarray(base_model.predict(pair_features), dtype=float).reshape(
+            len(chunk), n_anchors
+        )
         predictions.append(anchor_target.reshape(1, -1) + deltas)
-    return np.concatenate([chunk.mean(axis=1) for chunk in predictions]) if predictions else np.empty(0, dtype=float)
+    return (
+        np.concatenate([chunk.mean(axis=1) for chunk in predictions])
+        if predictions
+        else np.empty(0, dtype=float)
+    )
 
 
 def aggregate_similarity_to_class_proba(
-        similarity: Any,
-        anchor_labels: Any,
-        n_classes: int,
+    similarity: Any,
+    anchor_labels: Any,
+    n_classes: int,
 ) -> np.ndarray:
     similarity_matrix = np.asarray(similarity, dtype=float)
     anchor_labels = normalize_target_vector(anchor_labels).astype(int)
@@ -323,20 +362,26 @@ def _evenly_spaced_indices(indices: np.ndarray, max_count: int) -> np.ndarray:
     return indices[positions].astype(int)
 
 
-def _pair_indices(n_left: int, anchor_indices: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
+def _pair_indices(
+    n_left: int, anchor_indices: np.ndarray
+) -> tuple[np.ndarray, np.ndarray]:
     left_indices = np.repeat(np.arange(n_left, dtype=int), len(anchor_indices))
     repeated_anchor_indices = np.tile(anchor_indices.astype(int), n_left)
     return left_indices, repeated_anchor_indices
 
 
-def _build_pair_features_numpy(left: np.ndarray, anchors: np.ndarray, mode: str) -> np.ndarray:
+def _build_pair_features_numpy(
+    left: np.ndarray, anchors: np.ndarray, mode: str
+) -> np.ndarray:
     left_repeated = np.repeat(left, len(anchors), axis=0)
     anchors_tiled = np.tile(anchors, (len(left), 1))
     difference = left_repeated - anchors_tiled
     return _combine_pair_blocks(left_repeated, anchors_tiled, difference, mode)
 
 
-def _build_pair_features_torch(left: np.ndarray, anchors: np.ndarray, mode: str, device: Any) -> np.ndarray:
+def _build_pair_features_torch(
+    left: np.ndarray, anchors: np.ndarray, mode: str, device: Any
+) -> np.ndarray:
     left_tensor = torch.as_tensor(left, dtype=torch.float32, device=device)
     anchor_tensor = torch.as_tensor(anchors, dtype=torch.float32, device=device)
     left_repeated = left_tensor.repeat_interleave(anchor_tensor.shape[0], dim=0)
@@ -373,11 +418,15 @@ def _pair_target_semantics(*, task: str) -> dict[str, Any]:
     raise ValueError(f"Unsupported PDL task={task!r}.")
 
 
-def _combine_pair_blocks(left: np.ndarray, anchors: np.ndarray, difference: np.ndarray, mode: str) -> np.ndarray:
+def _combine_pair_blocks(
+    left: np.ndarray, anchors: np.ndarray, difference: np.ndarray, mode: str
+) -> np.ndarray:
     if mode == "concat_diff":
         return np.hstack((left, anchors, difference)).astype(np.float32, copy=False)
     if mode == "concat_absdiff":
-        return np.hstack((left, anchors, np.abs(difference))).astype(np.float32, copy=False)
+        return np.hstack((left, anchors, np.abs(difference))).astype(
+            np.float32, copy=False
+        )
     if mode == "diff_only":
         return difference.astype(np.float32, copy=False)
     raise ValueError(f"Unsupported pair feature mode={mode!r}.")
@@ -386,7 +435,9 @@ def _combine_pair_blocks(left: np.ndarray, anchors: np.ndarray, difference: np.n
 def _predict_same_probability(base_model: Any, pair_features: np.ndarray) -> np.ndarray:
     if hasattr(base_model, "predict_proba"):
         probability = np.asarray(base_model.predict_proba(pair_features), dtype=float)
-        classes = np.asarray(getattr(base_model, "classes_", np.arange(probability.shape[1])))
+        classes = np.asarray(
+            getattr(base_model, "classes_", np.arange(probability.shape[1]))
+        )
         same_columns = np.flatnonzero(classes == CLASSIFICATION_SAME_LABEL)
         if len(same_columns) == 0:
             return np.zeros(pair_features.shape[0], dtype=float)
@@ -396,13 +447,13 @@ def _predict_same_probability(base_model: Any, pair_features: np.ndarray) -> np.
 
 
 def _pair_diagnostics(
-        *,
-        config: PairwiseLearningConfig,
-        n_left: int,
-        n_anchors: int,
-        pair_feature_dim: int,
-        anchor_indices: np.ndarray,
-        task: str,
+    *,
+    config: PairwiseLearningConfig,
+    n_left: int,
+    n_anchors: int,
+    pair_feature_dim: int,
+    anchor_indices: np.ndarray,
+    task: str,
 ) -> dict[str, Any]:  # TODO: add typed contract diagnostic
     backend_name, _ = resolve_pairwise_backend(config.backend)
     return {

--- a/fedot_ind/core/models/pdl/pairwise_core.py
+++ b/fedot_ind/core/models/pdl/pairwise_core.py
@@ -88,7 +88,8 @@ def resolve_pairwise_backend(backend: str = "auto") -> tuple[str, Any | None]:
         return "torch_cpu", torch.device("cpu")
     raise ValueError(f"Unsupported PDL backend={backend!r}.")
 
-
+# TODO нет смысла во втором if так как в третьем делается то же самое и можно убрать первую часть второго if
+# TODO а если в target не будет какого-то класса, то мб сломается 
 def select_classification_anchor_indices(
         encoded_target: Any,
         config: PairwiseLearningConfig,

--- a/fedot_ind/core/models/pdl/pairwise_core.py
+++ b/fedot_ind/core/models/pdl/pairwise_core.py
@@ -11,7 +11,9 @@ except Exception:  # pragma: no cover
     torch = None
 
 SUPPORTED_PAIR_FEATURE_MODES = ("concat_diff", "concat_absdiff", "diff_only")
-
+CLASSIFICATION_SAME_LABEL = 0
+CLASSIFICATION_DIFFERENT_LABEL = 1
+REGRESSION_DELTA_SIGN = "left_minus_anchor"
 
 @dataclass(frozen=True)
 class PairwiseLearningConfig:
@@ -137,15 +139,17 @@ def build_classification_pairs(
     anchors = np.asarray(tuple(anchor_indices), dtype=int)
     pair_features = build_pair_features(feature_matrix, feature_matrix[anchors], config)
     left_indices, repeated_anchor_indices = _pair_indices(len(feature_matrix), anchors)
-    pair_target = (target[left_indices] != target[repeated_anchor_indices]).astype(int)
+    # pair_target = (target[left_indices] != target[repeated_anchor_indices]).astype(int)
+    dissimilarity_target = (target[left_indices] != target[repeated_anchor_indices]).astype(int)
     diagnostics = _pair_diagnostics(
         config=config,
         n_left=len(feature_matrix),
         n_anchors=len(anchors),
         pair_feature_dim=pair_features.shape[1],
         anchor_indices=anchors,
-    ) # TODO: сюда тоже идет контракт
-    return PairwiseBatch(pair_features, pair_target, left_indices, repeated_anchor_indices, diagnostics)
+        task="classification",
+    )
+    return PairwiseBatch(pair_features, dissimilarity_target, left_indices, repeated_anchor_indices, diagnostics)
 
 
 def build_regression_pairs(
@@ -159,15 +163,16 @@ def build_regression_pairs(
     anchors = np.asarray(tuple(anchor_indices), dtype=int)
     pair_features = build_pair_features(feature_matrix, feature_matrix[anchors], config)
     left_indices, repeated_anchor_indices = _pair_indices(len(feature_matrix), anchors)
-    pair_target = target_vector[left_indices] - target_vector[repeated_anchor_indices]
+    delta_left_minus_anchor = target_vector[left_indices] - target_vector[repeated_anchor_indices]
     diagnostics = _pair_diagnostics(
         config=config,
         n_left=len(feature_matrix),
         n_anchors=len(anchors),
         pair_feature_dim=pair_features.shape[1],
         anchor_indices=anchors,
+        task="regression",
     )
-    return PairwiseBatch(pair_features, pair_target.astype(float), left_indices, repeated_anchor_indices, diagnostics)
+    return PairwiseBatch(pair_features, delta_left_minus_anchor.astype(float), left_indices, repeated_anchor_indices, diagnostics)
 
 
 def build_pair_features(
@@ -283,7 +288,7 @@ def _build_pair_features_torch(left: np.ndarray, anchors: np.ndarray, mode: str,
     anchor_tensor = torch.as_tensor(anchors, dtype=torch.float32, device=device)
     left_repeated = left_tensor.repeat_interleave(anchor_tensor.shape[0], dim=0)
     anchors_tiled = anchor_tensor.repeat(left_tensor.shape[0], 1)
-    difference = left_repeated - anchors_tiled
+    difference = left_repeated - anchors_tiled # 
     if mode == "concat_diff":
         paired = torch.cat((left_repeated, anchors_tiled, difference), dim=1)
     elif mode == "concat_absdiff":
@@ -295,8 +300,25 @@ def _build_pair_features_torch(left: np.ndarray, anchors: np.ndarray, mode: str,
     return paired.detach().cpu().numpy()
 
 
-def _pair_target_semantics():
-    pass
+def _pair_target_semantics(*, task: str) -> dict[str, Any]:
+    # TODO: заменить через монады?
+    if task == "classification":
+        return {
+            "task": "classification",
+            "same_label": CLASSIFICATION_SAME_LABEL,
+            "different_label": CLASSIFICATION_DIFFERENT_LABEL,
+            "target_type": "dissimilarity",
+            "target_formula": "int(left_class != anchor_class)",
+            "inference_output": "same_probability",  # P(same_label)
+        }
+    if task == "regression":
+        return {
+            "task": "regression",
+            "delta_sign": REGRESSION_DELTA_SIGN,
+            "target_formula": "target_left - target_anchor",
+            "inference_reconstruction": "anchor_target + predicted_delta",
+        }
+    raise ValueError(f"Unsupported PDL task={task!r}.")
 
 
 def _combine_pair_blocks(left: np.ndarray, anchors: np.ndarray, difference: np.ndarray, mode: str) -> np.ndarray:
@@ -313,12 +335,12 @@ def _predict_same_probability(base_model: Any, pair_features: np.ndarray) -> np.
     if hasattr(base_model, "predict_proba"):
         probability = np.asarray(base_model.predict_proba(pair_features), dtype=float)
         classes = np.asarray(getattr(base_model, "classes_", np.arange(probability.shape[1])))
-        same_columns = np.flatnonzero(classes == 0)
+        same_columns = np.flatnonzero(classes == CLASSIFICATION_SAME_LABEL)
         if len(same_columns) == 0:
             return np.zeros(pair_features.shape[0], dtype=float)
         return probability[:, int(same_columns[0])]
     prediction = np.asarray(base_model.predict(pair_features)).reshape(-1)
-    return (prediction == 0).astype(float)
+    return (prediction == CLASSIFICATION_SAME_LABEL).astype(float)
 
 
 def _pair_diagnostics(
@@ -328,9 +350,9 @@ def _pair_diagnostics(
         n_anchors: int,
         pair_feature_dim: int,
         anchor_indices: np.ndarray,
+        task: str
 ) -> dict[str, Any]: # TODO: добавть контракт на все использование diagnostic
     backend_name, _ = resolve_pairwise_backend(config.backend)
-    # TODO: добавить pair_target_semantics 
     return {
         "backend": backend_name,
         "pairing_policy": config.pairing_policy,
@@ -340,5 +362,5 @@ def _pair_diagnostics(
         "pair_feature_dim": int(pair_feature_dim),
         "anchor_indices": [int(index) for index in anchor_indices],
         "config": config.to_dict(),
-        # pair_target_semantics
+        "pair_target_semantics": _pair_target_semantics(task=task),
     }

--- a/fedot_ind/core/models/pdl/pairwise_core.py
+++ b/fedot_ind/core/models/pdl/pairwise_core.py
@@ -49,7 +49,7 @@ class PairwiseBatch:
     target: np.ndarray
     left_indices: np.ndarray
     anchor_indices: np.ndarray
-    diagnostics: dict[str, Any]
+    diagnostics: dict[str, Any] # TODO: TypedContract добавить 
 
 
 def normalize_feature_matrix(features: Any) -> np.ndarray:
@@ -108,7 +108,7 @@ def select_classification_anchor_indices(
     return np.asarray(sorted(set(selected)), dtype=int)
 
 
-def select_regression_anchor_indices(
+def select_regression_anchor_indices( # TODO: реализовать механизмы выбора якорей
         target: Any,
         config: PairwiseLearningConfig,
 ) -> np.ndarray:
@@ -144,7 +144,7 @@ def build_classification_pairs(
         n_anchors=len(anchors),
         pair_feature_dim=pair_features.shape[1],
         anchor_indices=anchors,
-    )
+    ) # TODO: сюда тоже идет контракт
     return PairwiseBatch(pair_features, pair_target, left_indices, repeated_anchor_indices, diagnostics)
 
 
@@ -295,6 +295,10 @@ def _build_pair_features_torch(left: np.ndarray, anchors: np.ndarray, mode: str,
     return paired.detach().cpu().numpy()
 
 
+def _pair_target_semantics():
+    pass
+
+
 def _combine_pair_blocks(left: np.ndarray, anchors: np.ndarray, difference: np.ndarray, mode: str) -> np.ndarray:
     if mode == "concat_diff":
         return np.hstack((left, anchors, difference)).astype(np.float32, copy=False)
@@ -324,8 +328,9 @@ def _pair_diagnostics(
         n_anchors: int,
         pair_feature_dim: int,
         anchor_indices: np.ndarray,
-) -> dict[str, Any]:
+) -> dict[str, Any]: # TODO: добавть контракт на все использование diagnostic
     backend_name, _ = resolve_pairwise_backend(config.backend)
+    # TODO: добавить pair_target_semantics 
     return {
         "backend": backend_name,
         "pairing_policy": config.pairing_policy,
@@ -335,4 +340,5 @@ def _pair_diagnostics(
         "pair_feature_dim": int(pair_feature_dim),
         "anchor_indices": [int(index) for index in anchor_indices],
         "config": config.to_dict(),
+        # pair_target_semantics
     }

--- a/fedot_ind/core/models/pdl/pairwise_core.py
+++ b/fedot_ind/core/models/pdl/pairwise_core.py
@@ -88,8 +88,8 @@ def resolve_pairwise_backend(backend: str = "auto") -> tuple[str, Any | None]:
         return "torch_cpu", torch.device("cpu")
     raise ValueError(f"Unsupported PDL backend={backend!r}.")
 
-# TODO нет смысла во втором if так как в третьем делается то же самое и можно убрать первую часть второго if
-# TODO а если в target не будет какого-то класса, то мб сломается 
+# TODO not need srcond if
+# TODO test target without some class
 def select_classification_anchor_indices(
         encoded_target: Any,
         config: PairwiseLearningConfig,
@@ -111,7 +111,7 @@ def select_classification_anchor_indices(
     return np.asarray(sorted(set(selected)), dtype=int)
 
 
-def select_regression_anchor_indices( # TODO: реализовать механизмы выбора якорей
+def select_regression_anchor_indices( # TODO: in the feature add choice anchor method
         target: Any,
         config: PairwiseLearningConfig,
 ) -> np.ndarray:
@@ -302,7 +302,6 @@ def _build_pair_features_torch(left: np.ndarray, anchors: np.ndarray, mode: str,
 
 
 def _pair_target_semantics(*, task: str) -> dict[str, Any]:
-    # TODO: заменить через монады?
     if task == "classification":
         return {
             "task": "classification",
@@ -352,7 +351,7 @@ def _pair_diagnostics(
         pair_feature_dim: int,
         anchor_indices: np.ndarray,
         task: str
-) -> dict[str, Any]: # TODO: добавть контракт на все использование diagnostic
+) -> dict[str, Any]: # TODO: add typed contract diagnostic
     backend_name, _ = resolve_pairwise_backend(config.backend)
     return {
         "backend": backend_name,

--- a/fedot_ind/core/models/pdl/pairwise_model.py
+++ b/fedot_ind/core/models/pdl/pairwise_model.py
@@ -1,3 +1,10 @@
+"""Estimator facades for Pairwise Difference Learning (PDL).
+
+This module wires the task-agnostic core in ``pairwise_core`` into
+scikit-learn / FEDOT compatible classifier and regressor classes, plus a thin
+legacy helper (``PairwiseDifferenceEstimator``) kept for backward compatibility.
+"""
+
 from __future__ import annotations
 
 from copy import deepcopy
@@ -23,16 +30,23 @@ from .pairwise_core import (
     select_classification_anchor_indices,
     select_regression_anchor_indices,
 )
-# from fedot_ind.core.repository.constanst_repository import SKLEARN_CLF_IMP, SKLEARN_REG_IMP
 from .pdl_model_registry import SKLEARN_CLF_IMP, SKLEARN_REG_IMP
+
 
 class PairwiseDifferenceEstimator:
     """Compatibility helper exposing the legacy pair construction methods without pandas cross-merge."""
 
     def __init__(self, config: PairwiseLearningConfig | None = None):
+        """Initialize the helper with a normalized configuration.
+
+        Args:
+            config: Optional pairwise learning configuration; defaults are used
+                when omitted.
+        """
         self.config = (config or PairwiseLearningConfig()).normalized()
 
     def _convert_to_pandas(self, arr1: Any, arr2: Any) -> tuple[pd.DataFrame, pd.DataFrame]:
+        """Coerce two array-like inputs to ``pandas.DataFrame`` objects."""
         if not isinstance(arr1, pd.DataFrame):
             arr1 = pd.DataFrame(arr1)
         if not isinstance(arr2, pd.DataFrame):
@@ -40,6 +54,16 @@ class PairwiseDifferenceEstimator:
         return arr1, arr2
 
     def pair_input(self, X1: Any, X2: Any) -> tuple[pd.DataFrame, pd.DataFrame]:
+        """Build pair-feature frames and their symmetric counterparts.
+
+        Args:
+            X1: Left samples.
+            X2: Anchor samples.
+
+        Returns:
+            A tuple ``(pair_frame, symmetric_frame)`` of pair-feature
+            DataFrames.
+        """
         x1_frame, x2_frame = self._convert_to_pandas(X1, X2)
         x1 = normalize_feature_matrix(x1_frame.values)
         x2 = normalize_feature_matrix(x2_frame.values)
@@ -55,30 +79,50 @@ class PairwiseDifferenceEstimator:
         return pair_frame, sym_frame
 
     def pair_output(self, y1: Any, y2: Any) -> np.ndarray:
+        """Build regression pair targets using the left-minus-anchor sign.
+
+        Args:
+            y1: Left target values.
+            y2: Anchor target values.
+
+        Returns:
+            Per-pair deltas (``target_left - target_anchor``) in cross-product
+            order.
+        """
         left = normalize_target_vector(y1).astype(float)
         anchors = normalize_target_vector(y2).astype(float)
         delta_left_minus_anchor = (
-        np.repeat(left, len(anchors)) - np.tile(anchors, len(left))
+            np.repeat(left, len(anchors)) - np.tile(anchors, len(left))
         ).astype(float)
         return delta_left_minus_anchor
 
     def pair_output_difference(self, y1: Any, y2: Any, nb_classes: int | None = None) -> np.ndarray:
-        """Build classification pair targets (dissimilarity) for legacy pandas API.
-        Contract (aligned with active PDL path):
-            0 = same class  (CLASSIFICATION_SAME_LABEL)
-            1 = different class  (CLASSIFICATION_DIFFERENT_LABEL)
-        Returns one value per (left, anchor) pair in cross-product order.
+        """Build classification pair targets (dissimilarity) for the legacy API.
+
+        The contract is aligned with the active PDL path: ``0`` means the same
+        class (``CLASSIFICATION_SAME_LABEL``) and ``1`` means different classes
+        (``CLASSIFICATION_DIFFERENT_LABEL``).
+
+        Args:
+            y1: Left class labels.
+            y2: Anchor class labels.
+            nb_classes: Unused; kept for backward-compatible signatures.
+
+        Returns:
+            One dissimilarity value per ``(left, anchor)`` pair in cross-product
+            order.
         """
         del nb_classes
         left = normalize_target_vector(y1)
         anchors = normalize_target_vector(y2)
         dissimilarity_target = (
-        np.repeat(left, len(anchors)) != np.tile(anchors, len(left))
+            np.repeat(left, len(anchors)) != np.tile(anchors, len(left))
         ).astype(int)
         return dissimilarity_target
 
     @staticmethod
     def _pair_frame(left: np.ndarray, right: np.ndarray, difference: np.ndarray, columns: Any) -> pd.DataFrame:
+        """Assemble a labelled pair DataFrame from left/right/difference blocks."""
         column_names = [str(column) for column in columns]
         payload = np.hstack((left, right, difference))
         return pd.DataFrame(
@@ -92,6 +136,18 @@ class PairwiseDifferenceEstimator:
 
     @staticmethod
     def predict(y_prob: np.ndarray, output_mode: str = "default", min_label_zero: bool = True) -> np.ndarray:
+        """Convert probabilities to labels or pass them through unchanged.
+
+        Args:
+            y_prob: Probability matrix of shape ``(n_samples, n_classes)``.
+            output_mode: When it contains ``"label"`` return argmax labels,
+                otherwise return ``y_prob`` unchanged.
+            min_label_zero: If ``False`` shift labels so the minimum label is
+                one.
+
+        Returns:
+            Either class labels or the original probability matrix.
+        """
         if "label" in output_mode:
             predicted_classes = np.argmax(y_prob, axis=1).reshape(-1, 1)
             return predicted_classes if min_label_zero else predicted_classes + 1
@@ -102,6 +158,13 @@ class PairwiseDifferenceClassifier:
     """Pairwise Difference Learning classifier with deterministic anchors and torch/numpy pair generation."""
 
     def __init__(self, params: Optional[OperationParameters] = None):
+        """Initialize the classifier and its base pair model.
+
+        Args:
+            params: Optional FEDOT operation parameters. Configuration keys are
+                routed into ``PairwiseLearningConfig`` and the remaining keys are
+                forwarded to the base estimator.
+        """
         raw_params = _operation_params_to_dict(params)
         self.config = _extract_pairwise_config(raw_params)
         self.model_name = raw_params.pop("model", "rf")
@@ -109,9 +172,22 @@ class PairwiseDifferenceClassifier:
         self.base_model = SKLEARN_CLF_IMP[self.model_name](**self.base_model_params)
         self.pde = PairwiseDifferenceEstimator(self.config)
         self.sample_weight_ = None
-        self.diagnostics_: dict[str, Any] = {} # TODO: определить единство diagnostics и типконтракт
+        # TODO: unify the diagnostics payload behind a typed contract.
+        self.diagnostics_: dict[str, Any] = {}
 
     def fit(self, input_data: InputData | np.ndarray, target: Any | None = None):
+        """Fit the base pair classifier on anchor-relative classification pairs.
+
+        Args:
+            input_data: FEDOT ``InputData`` or a raw feature matrix.
+            target: Class labels when ``input_data`` is a raw matrix.
+
+        Returns:
+            The fitted estimator (``self``).
+
+        Raises:
+            ValueError: If labels are missing or fewer than two classes exist.
+        """
         features, raw_target, _ = _extract_features_target(input_data, target)
         if raw_target is None:
             raise ValueError("PairwiseDifferenceClassifier.fit expects target labels.")
@@ -148,6 +224,16 @@ class PairwiseDifferenceClassifier:
         return self
 
     def predict(self, input_data: InputData | np.ndarray, output_mode: str = "labels") -> np.ndarray:
+        """Predict class labels or probabilities.
+
+        Args:
+            input_data: FEDOT ``InputData`` or a raw feature matrix.
+            output_mode: When it contains ``"label"`` return decoded labels,
+                otherwise return the probability matrix.
+
+        Returns:
+            Decoded labels of shape ``(n_samples, 1)`` or a probability matrix.
+        """
         probabilities = self._predict_encoded_proba(_extract_features(input_data))
         if "label" not in output_mode:
             return probabilities
@@ -156,31 +242,57 @@ class PairwiseDifferenceClassifier:
         return labels.reshape(-1, 1)
 
     def predict_proba(self, input_data: InputData | np.ndarray, output_mode: str = "default") -> np.ndarray:
+        """Predict class probabilities (or labels when requested).
+
+        Args:
+            input_data: FEDOT ``InputData`` or a raw feature matrix.
+            output_mode: When it contains ``"label"`` delegate to ``predict``.
+
+        Returns:
+            A probability matrix of shape ``(n_samples, n_classes)``.
+        """
         probabilities = self._predict_encoded_proba(_extract_features(input_data))
         if "label" in output_mode:
             return self.predict(input_data, output_mode=output_mode)
         return probabilities
 
     def predict_for_fit(self, input_data: InputData | np.ndarray, output_mode: str = "default") -> np.ndarray:
+        """Predict probabilities (or labels) for the FEDOT fit pipeline."""
         if "label" in output_mode:
             return self.predict(input_data, output_mode=output_mode)
         return self.predict_proba(input_data)
 
     def score_difference(self, input_data: InputData | np.ndarray, target: Any | None = None) -> float:
+        """Return the mean absolute error between target and predicted dissimilarity.
+
+        Args:
+            input_data: FEDOT ``InputData`` or a raw feature matrix.
+            target: Class labels when ``input_data`` is a raw matrix.
+
+        Returns:
+            Mean absolute dissimilarity error, where ``1.0 = different`` and
+            ``0.0 = same``.
+
+        Raises:
+            ValueError: If labels are missing.
+        """
         features, raw_target, _ = _extract_features_target(input_data, target)
         if raw_target is None:
             raise ValueError("score_difference expects target labels.")
         encoded_target = self.label_encoder_.transform(normalize_target_vector(raw_target))
         same_probability = predict_similarity_by_chunks(self.base_model, features, self.anchor_features_, self.config)
+        # Dissimilarity target: 1.0 = different, 0.0 = same.
         dissimilarity_target = (np.repeat(encoded_target, len(self.anchor_labels_)) !=
-                             np.tile(self.anchor_labels_, len(encoded_target))).astype(float) # 1.0 = different, 0.0 = same
+                                np.tile(self.anchor_labels_, len(encoded_target))).astype(float)
         predicted_dissimilarity = 1.0 - same_probability.reshape(-1)
         return float(np.mean(np.abs(dissimilarity_target - predicted_dissimilarity)))
 
     def get_diagnostics(self) -> dict[str, Any]:
+        """Return a copy of the diagnostics collected during ``fit``."""
         return dict(self.diagnostics_)
 
     def _predict_encoded_proba(self, features: Any) -> np.ndarray:
+        """Predict encoded class probabilities for already-extracted features."""
         _check_is_fitted(self, ("anchor_features_", "anchor_labels_", "label_encoder_"))
         similarity = predict_similarity_by_chunks(self.base_model, features, self.anchor_features_, self.config)
         return aggregate_similarity_to_class_proba(similarity, self.anchor_labels_, self.num_classes)
@@ -190,6 +302,13 @@ class PairwiseDifferenceRegressor:
     """Pairwise Difference Learning regressor with deterministic anchor aggregation."""
 
     def __init__(self, params: Optional[OperationParameters] = None):
+        """Initialize the regressor and its base pair model.
+
+        Args:
+            params: Optional FEDOT operation parameters. Configuration keys are
+                routed into ``PairwiseLearningConfig`` and the remaining keys are
+                forwarded to the base estimator.
+        """
         raw_params = _operation_params_to_dict(params)
         self.config = _extract_pairwise_config(raw_params)
         self.model_name = raw_params.pop("model", "treg")
@@ -200,6 +319,18 @@ class PairwiseDifferenceRegressor:
         self.diagnostics_: dict[str, Any] = {}
 
     def fit(self, input_data: InputData | np.ndarray, target: Any | None = None):
+        """Fit the base pair regressor on anchor-relative delta pairs.
+
+        Args:
+            input_data: FEDOT ``InputData`` or a raw feature matrix.
+            target: Target values when ``input_data`` is a raw matrix.
+
+        Returns:
+            The fitted estimator (``self``).
+
+        Raises:
+            ValueError: If target values are missing.
+        """
         features, raw_target, _ = _extract_features_target(input_data, target)
         if raw_target is None:
             raise ValueError("PairwiseDifferenceRegressor.fit expects target values.")
@@ -216,7 +347,8 @@ class PairwiseDifferenceRegressor:
 
         batch = build_regression_pairs(self.train_features_, self.target_, self.anchor_indices_, self.config)
         self.base_model.fit(batch.features, batch.target)
-        self.diagnostics_ = { # TODO: переопределение diagnostic + типкотракты
+        # TODO: unify the diagnostics payload behind a typed contract.
+        self.diagnostics_ = {
             **batch.diagnostics,
             "task": "regression",
             "base_model": self.model_name,
@@ -225,6 +357,15 @@ class PairwiseDifferenceRegressor:
         return self
 
     def predict(self, input_data: InputData | np.ndarray, output_mode: str = "default") -> np.ndarray:
+        """Predict regression targets via anchor-relative delta aggregation.
+
+        Args:
+            input_data: FEDOT ``InputData`` or a raw feature matrix.
+            output_mode: Unused; kept for interface compatibility.
+
+        Returns:
+            Predicted target vector of shape ``(n_samples,)``.
+        """
         del output_mode
         _check_is_fitted(self, ("anchor_features_", "anchor_target_"))
         return predict_regression_by_chunks(
@@ -236,16 +377,29 @@ class PairwiseDifferenceRegressor:
         ).reshape(-1)
 
     def predict_proba(self, input_data: InputData | np.ndarray) -> np.ndarray:
+        """Return point predictions; provided for interface compatibility."""
         return self.predict(input_data)
 
     def predict_for_fit(self, input_data: InputData | np.ndarray, output_mode: str = "default") -> np.ndarray:
+        """Return point predictions for the FEDOT fit pipeline."""
         del output_mode
         return self.predict(input_data)
 
     def get_diagnostics(self) -> dict[str, Any]:
+        """Return a copy of the diagnostics collected during ``fit``."""
         return dict(self.diagnostics_)
 
     def _predict_samples(self, input_data: InputData | np.ndarray, force_symmetry: bool = False):
+        """Return per-anchor reconstructed samples and their raw deltas.
+
+        Args:
+            input_data: FEDOT ``InputData`` or a raw feature matrix.
+            force_symmetry: Unused; reserved for symmetric inference.
+
+        Returns:
+            A tuple ``(samples, deltas)`` of DataFrames shaped
+            ``(n_samples, n_anchors)``.
+        """
         del force_symmetry
         _check_is_fitted(self, ("anchor_features_", "anchor_target_"))
         features = normalize_feature_matrix(_extract_features(input_data))
@@ -258,6 +412,18 @@ class PairwiseDifferenceRegressor:
         return pd.DataFrame(samples), pd.DataFrame(deltas)
 
     def set_sample_weight(self, sample_weight: Any):
+        """Validate and store normalized sample weights.
+
+        Args:
+            sample_weight: Either a ``pandas.Series`` matching the train size or
+                an array matching the anchor count.
+
+        Returns:
+            The estimator (``self``).
+
+        Raises:
+            ValueError: If the size mismatches or non-finite values are present.
+        """
         if isinstance(sample_weight, pd.Series):
             if len(sample_weight) != len(self.y_train_):
                 raise ValueError(
@@ -279,18 +445,21 @@ class PairwiseDifferenceRegressor:
 
 
 def _extract_features_target(input_data: InputData | np.ndarray, target: Any | None = None) -> tuple[Any, Any, Any]:
+    """Return ``(features, target, task)`` from ``InputData`` or raw inputs."""
     if isinstance(input_data, InputData):
         return input_data.features, input_data.target, input_data.task
     return input_data, target, None
 
 
 def _extract_features(input_data: InputData | np.ndarray) -> Any:
+    """Return the feature matrix from ``InputData`` or pass the input through."""
     if isinstance(input_data, InputData):
         return input_data.features
     return input_data
 
 
 def _operation_params_to_dict(params: Optional[OperationParameters]) -> dict[str, Any]:
+    """Coerce FEDOT operation parameters into a plain dictionary."""
     if params is None:
         return {}
     if hasattr(params, "_parameters"):
@@ -301,6 +470,7 @@ def _operation_params_to_dict(params: Optional[OperationParameters]) -> dict[str
 
 
 def _extract_pairwise_config(params: dict[str, Any]) -> PairwiseLearningConfig:
+    """Pop ``PairwiseLearningConfig`` fields out of ``params`` and build a config."""
     config_fields = PairwiseLearningConfig.__dataclass_fields__.keys()
     config_payload = {
         field_name: params.pop(field_name)
@@ -311,6 +481,7 @@ def _extract_pairwise_config(params: dict[str, Any]) -> PairwiseLearningConfig:
 
 
 def _check_is_fitted(model: Any, attributes: tuple[str, ...]) -> None:
+    """Raise if any of the required fitted attributes are missing."""
     missing = [attribute for attribute in attributes if not hasattr(model, attribute)]
     if missing:
         raise ValueError(f"{model.__class__.__name__} is not fitted yet. Missing attributes: {missing}.")

--- a/fedot_ind/core/models/pdl/pairwise_model.py
+++ b/fedot_ind/core/models/pdl/pairwise_model.py
@@ -57,13 +57,25 @@ class PairwiseDifferenceEstimator:
     def pair_output(self, y1: Any, y2: Any) -> np.ndarray:
         left = normalize_target_vector(y1).astype(float)
         anchors = normalize_target_vector(y2).astype(float)
-        return (np.tile(anchors, len(left)) - np.repeat(left, len(anchors))).astype(float)
+        delta_left_minus_anchor = (
+        np.repeat(left, len(anchors)) - np.tile(anchors, len(left))
+        ).astype(float)
+        return delta_left_minus_anchor
 
     def pair_output_difference(self, y1: Any, y2: Any, nb_classes: int | None = None) -> np.ndarray:
+        """Build classification pair targets (dissimilarity) for legacy pandas API.
+        Contract (aligned with active PDL path):
+            0 = same class  (CLASSIFICATION_SAME_LABEL)
+            1 = different class  (CLASSIFICATION_DIFFERENT_LABEL)
+        Returns one value per (left, anchor) pair in cross-product order.
+        """
         del nb_classes
         left = normalize_target_vector(y1)
         anchors = normalize_target_vector(y2)
-        return (np.repeat(left, len(anchors)) != np.tile(anchors, len(left))).astype(int)
+        dissimilarity_target = (
+        np.repeat(left, len(anchors)) != np.tile(anchors, len(left))
+        ).astype(int)
+        return dissimilarity_target
 
     @staticmethod
     def _pair_frame(left: np.ndarray, right: np.ndarray, difference: np.ndarray, columns: Any) -> pd.DataFrame:
@@ -159,11 +171,11 @@ class PairwiseDifferenceClassifier:
         if raw_target is None:
             raise ValueError("score_difference expects target labels.")
         encoded_target = self.label_encoder_.transform(normalize_target_vector(raw_target))
-        similarity = predict_similarity_by_chunks(self.base_model, features, self.anchor_features_, self.config)
-        target_difference = (np.repeat(encoded_target, len(self.anchor_labels_)) !=
-                             np.tile(self.anchor_labels_, len(encoded_target))).astype(float)
-        predicted_difference = 1.0 - similarity.reshape(-1)
-        return float(np.mean(np.abs(target_difference - predicted_difference)))
+        same_probability = predict_similarity_by_chunks(self.base_model, features, self.anchor_features_, self.config)
+        dissimilarity_target = (np.repeat(encoded_target, len(self.anchor_labels_)) !=
+                             np.tile(self.anchor_labels_, len(encoded_target))).astype(float) # 1.0 = different, 0.0 = same
+        predicted_dissimilarity = 1.0 - same_probability.reshape(-1)
+        return float(np.mean(np.abs(dissimilarity_target - predicted_dissimilarity)))
 
     def get_diagnostics(self) -> dict[str, Any]:
         return dict(self.diagnostics_)

--- a/fedot_ind/core/models/pdl/pairwise_model.py
+++ b/fedot_ind/core/models/pdl/pairwise_model.py
@@ -97,7 +97,7 @@ class PairwiseDifferenceClassifier:
         self.base_model = SKLEARN_CLF_IMP[self.model_name](**self.base_model_params)
         self.pde = PairwiseDifferenceEstimator(self.config)
         self.sample_weight_ = None
-        self.diagnostics_: dict[str, Any] = {}
+        self.diagnostics_: dict[str, Any] = {} # TODO: определить единство diagnostics и типконтракт
 
     def fit(self, input_data: InputData | np.ndarray, target: Any | None = None):
         features, raw_target, _ = _extract_features_target(input_data, target)
@@ -204,7 +204,7 @@ class PairwiseDifferenceRegressor:
 
         batch = build_regression_pairs(self.train_features_, self.target_, self.anchor_indices_, self.config)
         self.base_model.fit(batch.features, batch.target)
-        self.diagnostics_ = {
+        self.diagnostics_ = { # TODO: переопределение diagnostic + типкотракты
             **batch.diagnostics,
             "task": "regression",
             "base_model": self.model_name,

--- a/fedot_ind/core/models/pdl/pairwise_model.py
+++ b/fedot_ind/core/models/pdl/pairwise_model.py
@@ -23,8 +23,8 @@ from fedot_ind.core.models.pdl.pairwise_core import (
     select_classification_anchor_indices,
     select_regression_anchor_indices,
 )
-from fedot_ind.core.repository.constanst_repository import SKLEARN_CLF_IMP, SKLEARN_REG_IMP
-
+# from fedot_ind.core.repository.constanst_repository import SKLEARN_CLF_IMP, SKLEARN_REG_IMP
+from .pdl_model_registry import SKLEARN_CLF_IMP, SKLEARN_REG_IMP
 
 class PairwiseDifferenceEstimator:
     """Compatibility helper exposing the legacy pair construction methods without pandas cross-merge."""

--- a/fedot_ind/core/models/pdl/pairwise_model.py
+++ b/fedot_ind/core/models/pdl/pairwise_model.py
@@ -9,7 +9,7 @@ from fedot.core.data.data import InputData
 from fedot.core.operations.operation_parameters import OperationParameters
 from sklearn.preprocessing import LabelEncoder
 
-from fedot_ind.core.models.pdl.pairwise_core import (
+from .pairwise_core import (
     PairwiseLearningConfig,
     aggregate_similarity_to_class_proba,
     build_classification_pairs,

--- a/fedot_ind/core/models/pdl/pairwise_model.py
+++ b/fedot_ind/core/models/pdl/pairwise_model.py
@@ -45,7 +45,9 @@ class PairwiseDifferenceEstimator:
         """
         self.config = (config or PairwiseLearningConfig()).normalized()
 
-    def _convert_to_pandas(self, arr1: Any, arr2: Any) -> tuple[pd.DataFrame, pd.DataFrame]:
+    def _convert_to_pandas(
+        self, arr1: Any, arr2: Any
+    ) -> tuple[pd.DataFrame, pd.DataFrame]:
         """Coerce two array-like inputs to ``pandas.DataFrame`` objects."""
         if not isinstance(arr1, pd.DataFrame):
             arr1 = pd.DataFrame(arr1)
@@ -70,12 +72,16 @@ class PairwiseDifferenceEstimator:
         left_repeated = np.repeat(x1, len(x2), axis=0)
         right_tiled = np.tile(x2, (len(x1), 1))
         difference = left_repeated - right_tiled
-        pair_frame = self._pair_frame(left_repeated, right_tiled, difference, x1_frame.columns)
+        pair_frame = self._pair_frame(
+            left_repeated, right_tiled, difference, x1_frame.columns
+        )
 
         sym_left = right_tiled
         sym_right = left_repeated
         sym_difference = sym_left - sym_right
-        sym_frame = self._pair_frame(sym_left, sym_right, sym_difference, x1_frame.columns)
+        sym_frame = self._pair_frame(
+            sym_left, sym_right, sym_difference, x1_frame.columns
+        )
         return pair_frame, sym_frame
 
     def pair_output(self, y1: Any, y2: Any) -> np.ndarray:
@@ -96,7 +102,9 @@ class PairwiseDifferenceEstimator:
         ).astype(float)
         return delta_left_minus_anchor
 
-    def pair_output_difference(self, y1: Any, y2: Any, nb_classes: int | None = None) -> np.ndarray:
+    def pair_output_difference(
+        self, y1: Any, y2: Any, nb_classes: int | None = None
+    ) -> np.ndarray:
         """Build classification pair targets (dissimilarity) for the legacy API.
 
         The contract is aligned with the active PDL path: ``0`` means the same
@@ -121,7 +129,9 @@ class PairwiseDifferenceEstimator:
         return dissimilarity_target
 
     @staticmethod
-    def _pair_frame(left: np.ndarray, right: np.ndarray, difference: np.ndarray, columns: Any) -> pd.DataFrame:
+    def _pair_frame(
+        left: np.ndarray, right: np.ndarray, difference: np.ndarray, columns: Any
+    ) -> pd.DataFrame:
         """Assemble a labelled pair DataFrame from left/right/difference blocks."""
         column_names = [str(column) for column in columns]
         payload = np.hstack((left, right, difference))
@@ -135,7 +145,9 @@ class PairwiseDifferenceEstimator:
         )
 
     @staticmethod
-    def predict(y_prob: np.ndarray, output_mode: str = "default", min_label_zero: bool = True) -> np.ndarray:
+    def predict(
+        y_prob: np.ndarray, output_mode: str = "default", min_label_zero: bool = True
+    ) -> np.ndarray:
         """Convert probabilities to labels or pass them through unchanged.
 
         Args:
@@ -200,9 +212,13 @@ class PairwiseDifferenceClassifier:
         self.classes_ = self.label_encoder_.classes_
         self.num_classes = len(self.classes_)
         if self.num_classes < 2:
-            raise ValueError("PairwiseDifferenceClassifier requires at least two classes.")
+            raise ValueError(
+                "PairwiseDifferenceClassifier requires at least two classes."
+            )
 
-        self.anchor_indices_ = select_classification_anchor_indices(self.target_encoded_, self.config)
+        self.anchor_indices_ = select_classification_anchor_indices(
+            self.target_encoded_, self.config
+        )
         self.anchor_features_ = self.train_features_[self.anchor_indices_]
         self.anchor_labels_ = self.target_encoded_[self.anchor_indices_]
 
@@ -223,7 +239,9 @@ class PairwiseDifferenceClassifier:
         }
         return self
 
-    def predict(self, input_data: InputData | np.ndarray, output_mode: str = "labels") -> np.ndarray:
+    def predict(
+        self, input_data: InputData | np.ndarray, output_mode: str = "labels"
+    ) -> np.ndarray:
         """Predict class labels or probabilities.
 
         Args:
@@ -241,7 +259,9 @@ class PairwiseDifferenceClassifier:
         labels = self.label_encoder_.inverse_transform(encoded_labels)
         return labels.reshape(-1, 1)
 
-    def predict_proba(self, input_data: InputData | np.ndarray, output_mode: str = "default") -> np.ndarray:
+    def predict_proba(
+        self, input_data: InputData | np.ndarray, output_mode: str = "default"
+    ) -> np.ndarray:
         """Predict class probabilities (or labels when requested).
 
         Args:
@@ -256,13 +276,17 @@ class PairwiseDifferenceClassifier:
             return self.predict(input_data, output_mode=output_mode)
         return probabilities
 
-    def predict_for_fit(self, input_data: InputData | np.ndarray, output_mode: str = "default") -> np.ndarray:
+    def predict_for_fit(
+        self, input_data: InputData | np.ndarray, output_mode: str = "default"
+    ) -> np.ndarray:
         """Predict probabilities (or labels) for the FEDOT fit pipeline."""
         if "label" in output_mode:
             return self.predict(input_data, output_mode=output_mode)
         return self.predict_proba(input_data)
 
-    def score_difference(self, input_data: InputData | np.ndarray, target: Any | None = None) -> float:
+    def score_difference(
+        self, input_data: InputData | np.ndarray, target: Any | None = None
+    ) -> float:
         """Return the mean absolute error between target and predicted dissimilarity.
 
         Args:
@@ -279,11 +303,17 @@ class PairwiseDifferenceClassifier:
         features, raw_target, _ = _extract_features_target(input_data, target)
         if raw_target is None:
             raise ValueError("score_difference expects target labels.")
-        encoded_target = self.label_encoder_.transform(normalize_target_vector(raw_target))
-        same_probability = predict_similarity_by_chunks(self.base_model, features, self.anchor_features_, self.config)
+        encoded_target = self.label_encoder_.transform(
+            normalize_target_vector(raw_target)
+        )
+        same_probability = predict_similarity_by_chunks(
+            self.base_model, features, self.anchor_features_, self.config
+        )
         # Dissimilarity target: 1.0 = different, 0.0 = same.
-        dissimilarity_target = (np.repeat(encoded_target, len(self.anchor_labels_)) !=
-                                np.tile(self.anchor_labels_, len(encoded_target))).astype(float)
+        dissimilarity_target = (
+            np.repeat(encoded_target, len(self.anchor_labels_))
+            != np.tile(self.anchor_labels_, len(encoded_target))
+        ).astype(float)
         predicted_dissimilarity = 1.0 - same_probability.reshape(-1)
         return float(np.mean(np.abs(dissimilarity_target - predicted_dissimilarity)))
 
@@ -294,8 +324,12 @@ class PairwiseDifferenceClassifier:
     def _predict_encoded_proba(self, features: Any) -> np.ndarray:
         """Predict encoded class probabilities for already-extracted features."""
         _check_is_fitted(self, ("anchor_features_", "anchor_labels_", "label_encoder_"))
-        similarity = predict_similarity_by_chunks(self.base_model, features, self.anchor_features_, self.config)
-        return aggregate_similarity_to_class_proba(similarity, self.anchor_labels_, self.num_classes)
+        similarity = predict_similarity_by_chunks(
+            self.base_model, features, self.anchor_features_, self.config
+        )
+        return aggregate_similarity_to_class_proba(
+            similarity, self.anchor_labels_, self.num_classes
+        )
 
 
 class PairwiseDifferenceRegressor:
@@ -341,11 +375,15 @@ class PairwiseDifferenceRegressor:
         self.target = self.target_
         self.num_classes = getattr(input_data, "num_classes", None)
         self.y_train_ = pd.Series(self.target_)
-        self.anchor_indices_ = select_regression_anchor_indices(self.target_, self.config)
+        self.anchor_indices_ = select_regression_anchor_indices(
+            self.target_, self.config
+        )
         self.anchor_features_ = self.train_features_[self.anchor_indices_]
         self.anchor_target_ = self.target_[self.anchor_indices_]
 
-        batch = build_regression_pairs(self.train_features_, self.target_, self.anchor_indices_, self.config)
+        batch = build_regression_pairs(
+            self.train_features_, self.target_, self.anchor_indices_, self.config
+        )
         self.base_model.fit(batch.features, batch.target)
         # TODO: unify the diagnostics payload behind a typed contract.
         self.diagnostics_ = {
@@ -356,7 +394,9 @@ class PairwiseDifferenceRegressor:
         }
         return self
 
-    def predict(self, input_data: InputData | np.ndarray, output_mode: str = "default") -> np.ndarray:
+    def predict(
+        self, input_data: InputData | np.ndarray, output_mode: str = "default"
+    ) -> np.ndarray:
         """Predict regression targets via anchor-relative delta aggregation.
 
         Args:
@@ -380,7 +420,9 @@ class PairwiseDifferenceRegressor:
         """Return point predictions; provided for interface compatibility."""
         return self.predict(input_data)
 
-    def predict_for_fit(self, input_data: InputData | np.ndarray, output_mode: str = "default") -> np.ndarray:
+    def predict_for_fit(
+        self, input_data: InputData | np.ndarray, output_mode: str = "default"
+    ) -> np.ndarray:
         """Return point predictions for the FEDOT fit pipeline."""
         del output_mode
         return self.predict(input_data)
@@ -389,7 +431,9 @@ class PairwiseDifferenceRegressor:
         """Return a copy of the diagnostics collected during ``fit``."""
         return dict(self.diagnostics_)
 
-    def _predict_samples(self, input_data: InputData | np.ndarray, force_symmetry: bool = False):
+    def _predict_samples(
+        self, input_data: InputData | np.ndarray, force_symmetry: bool = False
+    ):
         """Return per-anchor reconstructed samples and their raw deltas.
 
         Args:
@@ -403,8 +447,12 @@ class PairwiseDifferenceRegressor:
         del force_symmetry
         _check_is_fitted(self, ("anchor_features_", "anchor_target_"))
         features = normalize_feature_matrix(_extract_features(input_data))
-        pair_features = build_pair_features(features, self.anchor_features_, self.config)
-        deltas = np.asarray(self.base_model.predict(pair_features), dtype=float).reshape(
+        pair_features = build_pair_features(
+            features, self.anchor_features_, self.config
+        )
+        deltas = np.asarray(
+            self.base_model.predict(pair_features), dtype=float
+        ).reshape(
             len(features),
             len(self.anchor_target_),
         )
@@ -444,7 +492,9 @@ class PairwiseDifferenceRegressor:
         return self
 
 
-def _extract_features_target(input_data: InputData | np.ndarray, target: Any | None = None) -> tuple[Any, Any, Any]:
+def _extract_features_target(
+    input_data: InputData | np.ndarray, target: Any | None = None
+) -> tuple[Any, Any, Any]:
     """Return ``(features, target, task)`` from ``InputData`` or raw inputs."""
     if isinstance(input_data, InputData):
         return input_data.features, input_data.target, input_data.task
@@ -484,7 +534,9 @@ def _check_is_fitted(model: Any, attributes: tuple[str, ...]) -> None:
     """Raise if any of the required fitted attributes are missing."""
     missing = [attribute for attribute in attributes if not hasattr(model, attribute)]
     if missing:
-        raise ValueError(f"{model.__class__.__name__} is not fitted yet. Missing attributes: {missing}.")
+        raise ValueError(
+            f"{model.__class__.__name__} is not fitted yet. Missing attributes: {missing}."
+        )
 
 
 __all__ = [

--- a/fedot_ind/core/models/pdl/pairwise_transform.py
+++ b/fedot_ind/core/models/pdl/pairwise_transform.py
@@ -13,7 +13,7 @@ from sklearn.compose import ColumnTransformer
 from sklearn.utils.validation import check_is_fitted
 
 
-class PDCDataTransformer:
+class PDCDataTransformer: # TODO: Починить PDCDataTransformer или вывести его из active path как legacy
     """
     Transform the data so that it can be processed by PDL models.
     """
@@ -32,7 +32,7 @@ class PDCDataTransformer:
         self.y_type = y_type
 
     def fit(self, X, y=None):
-
+        # TODO: что?
         # y = y.astype('category').cat.codes.astype(np.float32) # todo since I
         # cannot transform the output at least add raise type error on it
         if self.numeric_features is None and self.ordinal_features is None and self.string_features is None:

--- a/fedot_ind/core/models/pdl/pdl_model_registry.py
+++ b/fedot_ind/core/models/pdl/pdl_model_registry.py
@@ -1,0 +1,49 @@
+"""Lightweight registry for the standalone PDL package.
+Intentionally independent from fedot_ind.core.repository.constanst_repository
+so PDL can be installed without the full Industrial dependency tree.
+"""
+from __future__ import annotations
+from sklearn.ensemble import (
+    ExtraTreesRegressor,
+    GradientBoostingClassifier,
+    RandomForestClassifier,
+)
+from sklearn.linear_model import Lasso, LogisticRegression, Ridge, SGDRegressor
+from sklearn.neural_network import MLPClassifier
+from sklearn.tree import DecisionTreeClassifier, DecisionTreeRegressor
+def _optional(module_path: str, attr: str):
+    try:
+        module = __import__(module_path, fromlist=[attr])
+        return getattr(module, attr)
+    except Exception:
+        return None
+SKLEARN_CLF_IMP = {
+    "xgboost": GradientBoostingClassifier,  # mirrors Industrial mapping
+    "logit": LogisticRegression,
+    "dt": DecisionTreeClassifier,
+    "rf": RandomForestClassifier,
+    "mlp": MLPClassifier,
+}
+SKLEARN_REG_IMP = {
+    "sgdr": SGDRegressor,
+    "treg": ExtraTreesRegressor,
+    "ridge": Ridge,
+    "lasso": Lasso,
+    "dtreg": DecisionTreeRegressor,
+}
+
+_catboost_clf = _optional("catboost", "CatBoostClassifier")
+if _catboost_clf is not None:
+    SKLEARN_CLF_IMP["catboost"] = _catboost_clf
+_lgbm_clf = _optional("lightgbm", "LGBMClassifier")
+if _lgbm_clf is not None:
+    SKLEARN_CLF_IMP["lgbm"] = _lgbm_clf
+_xgb_reg = _optional("xgboost", "XGBRegressor")
+if _xgb_reg is not None:
+    SKLEARN_REG_IMP["xgbreg"] = _xgb_reg
+_lgbm_reg = _optional("lightgbm", "LGBMRegressor")
+if _lgbm_reg is not None:
+    SKLEARN_REG_IMP["lgbmreg"] = _lgbm_reg
+_catboost_reg = _optional("catboost", "CatBoostRegressor")
+if _catboost_reg is not None:
+    SKLEARN_REG_IMP["catboostreg"] = _catboost_reg

--- a/fedot_ind/core/models/pdl/pdl_model_registry.py
+++ b/fedot_ind/core/models/pdl/pdl_model_registry.py
@@ -2,6 +2,7 @@
 Intentionally independent from fedot_ind.core.repository.constanst_repository
 so PDL can be installed without the full Industrial dependency tree.
 """
+
 from __future__ import annotations
 from sklearn.ensemble import (
     ExtraTreesRegressor,
@@ -11,12 +12,16 @@ from sklearn.ensemble import (
 from sklearn.linear_model import Lasso, LogisticRegression, Ridge, SGDRegressor
 from sklearn.neural_network import MLPClassifier
 from sklearn.tree import DecisionTreeClassifier, DecisionTreeRegressor
+
+
 def _optional(module_path: str, attr: str):
     try:
         module = __import__(module_path, fromlist=[attr])
         return getattr(module, attr)
     except Exception:
         return None
+
+
 SKLEARN_CLF_IMP = {
     "xgboost": GradientBoostingClassifier,  # mirrors Industrial mapping
     "logit": LogisticRegression,

--- a/fedot_ind/core/models/pdl/pyproject.toml
+++ b/fedot_ind/core/models/pdl/pyproject.toml
@@ -1,0 +1,28 @@
+[build-system]
+requires = ["setuptools>=68"]
+build-backend = "setuptools.build_meta"
+[project]
+name = "fedot-ind-pdl"
+version = "0.1.0"
+description = "Pairwise Difference Learning (PDL) — standalone lightweight extract from Fedot.Industrial."
+requires-python = ">=3.10,<3.12"
+authors = [{ name = "NSS Lab", email = "itmo.nss.team@gmail.com" }]
+dependencies = [
+    "numpy",
+    "pandas",
+    "scikit-learn",
+    "scipy",
+    "fedot",
+]
+
+[project.optional-dependencies]
+torch = ["torch"]
+catboost = ["catboost"]
+lightgbm = ["lightgbm"]
+xgboost = ["xgboost"]
+all = ["torch", "catboost", "lightgbm", "xgboost"]
+# current  folder as an imported package `fedot_ind_pdl`.
+[tool.setuptools]
+packages = ["fedot_ind_pdl"]
+[tool.setuptools.package-dir]
+fedot_ind_pdl = "."

--- a/tests/unit/core/models/test_pairwise_learning_core.py
+++ b/tests/unit/core/models/test_pairwise_learning_core.py
@@ -7,6 +7,7 @@ from fedot_ind.core.models.pdl.pairwise_core import (
     build_pair_features,
     build_regression_pairs,
     select_classification_anchor_indices,
+    _predict_same_probability,
     torch,
 )
 
@@ -56,6 +57,52 @@ def test_classification_pair_targets_support_labels_not_starting_at_zero():
     )
     assert batch.features.shape == (9, 3)
     assert batch.diagnostics["n_pairs"] == 9
+
+
+def test_classification_pair_target_semantics_same_is_zero_current_contract():
+    features = np.array([[0.0], [1.0], [2.0]])
+    target = np.array([5, 5, 7])
+    config = PairwiseLearningConfig(backend="numpy", max_pairs=20)
+
+    batch = build_classification_pairs(features, target, np.array([0]), config)
+
+    np.testing.assert_array_equal(batch.target, np.array([0, 0, 1]))
+
+
+def test_pair_target_semantics_is_reported_in_diagnostics():
+    features = np.array([[0.0], [1.0]])
+    config = PairwiseLearningConfig(backend="numpy", max_pairs=20)
+
+    clf_batch = build_classification_pairs(features, np.array([0, 1]), np.array([0, 1]), config)
+    clf_semantics = clf_batch.diagnostics["pair_target_semantics"]
+    assert clf_semantics["same_label"] == 0
+    assert clf_semantics["different_label"] == 1
+    assert clf_semantics["target_type"] == "dissimilarity"
+
+    reg_batch = build_regression_pairs(features, np.array([1.0, 3.0]), np.array([0, 1]), config)
+    reg_semantics = reg_batch.diagnostics["pair_target_semantics"]
+    assert reg_semantics["delta_sign"] == "left_minus_anchor"
+    assert reg_semantics["inference_reconstruction"] == "anchor_target + predicted_delta"
+
+
+class _PairProbaStub:
+    def __init__(self, probabilities: np.ndarray, classes: np.ndarray):
+        self.classes_ = classes
+        self._probabilities = probabilities
+
+    def predict_proba(self, pair_features: np.ndarray) -> np.ndarray:
+        return self._probabilities
+
+
+def test_predict_same_probability_uses_same_label_column():
+    stub_model = _PairProbaStub(
+        probabilities=np.array([[0.9, 0.1], [0.2, 0.8]]),
+        classes=np.array([0, 1]),
+    )
+
+    same_probability = _predict_same_probability(stub_model, np.zeros((2, 1)))
+
+    np.testing.assert_allclose(same_probability, np.array([0.9, 0.2]))
 
 
 def test_regression_pair_target_uses_left_minus_anchor_sign_convention():

--- a/tests/unit/core/models/test_pdl.py
+++ b/tests/unit/core/models/test_pdl.py
@@ -132,7 +132,7 @@ class _HardLabelStub:
 class TestPDLContracts:
 
     def test_predict_same_probability_uses_same_label_column(self):
-        # predict_proba: столбец 0 = P(same), столбец 1 = P(different)
+        # predict_proba: col 0 = P(same), col 1 = P(different)
         stub_model = _PairProbaStub(
             probabilities=np.array([[0.8, 0.2], [0.3, 0.7]]),
             classes=np.array([0, 1]),
@@ -140,11 +140,11 @@ class TestPDLContracts:
 
         same_probability = _predict_same_probability(stub_model, np.zeros((2, 3)))
 
-        # Должны взять первый столбец (label 0), а не второй (label 1)
+        # get first col (label 0), not second (label 1)
         np.testing.assert_allclose(same_probability, np.array([0.8, 0.3]))
 
     def test_predict_same_probability_falls_back_to_hard_predictions(self):
-        # Без predict_proba: label 0 -> 1.0 (same), label 1 -> 0.0 (different)
+        # without predict_proba: label 0 -> 1.0 (same), label 1 -> 0.0 (different)
         stub_model = _HardLabelStub(labels=np.array([0, 1, 0]))
 
         same_probability = _predict_same_probability(stub_model, np.zeros((3, 3)))
@@ -178,6 +178,64 @@ class TestPDLDiagnostics:
         assert semantics["delta_sign"] == "left_minus_anchor"
         assert semantics["target_formula"] == "target_left - target_anchor"
         assert semantics["inference_reconstruction"] == "anchor_target + predicted_delta"
+
+    def test_classification_diagnostics_report_full_pair_contract(self):
+        """Diagnostics must expose the full runtime pair contract, not only semantics.
+
+        Deterministic toy arrays: 4 samples / 2 features, all-pairs regime (16 <= max_pairs),
+        concat_diff -> pair_feature_dim = 2 * 3 = 6.
+        """
+        features = np.array([[0.0, 0.0], [0.1, 0.1], [5.0, 5.0], [5.1, 5.1]])
+        target = np.array([0, 0, 1, 1])
+        classifier = PairwiseDifferenceClassifier(
+            OperationParameters(
+                model="rf", n_estimators=5, backend="numpy", max_pairs=10_000, pair_feature_mode="concat_diff"
+            )
+        )
+        classifier.fit(features, target)
+
+        diagnostics = classifier.get_diagnostics()
+        for key in (
+            "backend", "pairing_policy", "n_train", "n_anchors", "n_pairs",
+            "pair_feature_dim", "anchor_indices", "config", "pair_target_semantics",
+            "task", "n_classes", "base_model",
+        ):
+            assert key in diagnostics, f"missing diagnostics key: {key}"
+
+        assert diagnostics["task"] == "classification"
+        assert diagnostics["n_classes"] == 2
+        assert diagnostics["base_model"] == "rf"
+        assert diagnostics["n_train"] == 4
+        assert diagnostics["n_anchors"] == 4  # all-pairs regime
+        assert diagnostics["n_pairs"] == diagnostics["n_train"] * diagnostics["n_anchors"] == 16
+        assert diagnostics["pair_feature_dim"] == 6
+        assert diagnostics["config"]["pair_feature_mode"] == "concat_diff"
+        assert len(diagnostics["anchor_indices"]) == diagnostics["n_anchors"]
+
+    def test_regression_diagnostics_report_full_pair_contract(self):
+        """Same runtime pair contract for the regressor (1 feature -> pair_feature_dim = 3)."""
+        features = np.arange(6, dtype=float).reshape(-1, 1)
+        target = 2.0 * features.reshape(-1)
+        regressor = PairwiseDifferenceRegressor(
+            OperationParameters(
+                model="treg", n_estimators=5, backend="numpy", max_pairs=10_000, pair_feature_mode="concat_diff"
+            )
+        )
+        regressor.fit(features, target)
+
+        diagnostics = regressor.get_diagnostics()
+        for key in (
+            "backend", "pairing_policy", "n_train", "n_anchors", "n_pairs",
+            "pair_feature_dim", "anchor_indices", "config", "pair_target_semantics",
+            "task", "base_model",
+        ):
+            assert key in diagnostics, f"missing diagnostics key: {key}"
+
+        assert diagnostics["task"] == "regression"
+        assert diagnostics["n_train"] == 6
+        assert diagnostics["n_anchors"] == 6
+        assert diagnostics["n_pairs"] == 36
+        assert diagnostics["pair_feature_dim"] == 3
 
 
 # Tests for PairwiseDifferenceClassifier

--- a/tests/unit/core/models/test_pdl.py
+++ b/tests/unit/core/models/test_pdl.py
@@ -1,10 +1,15 @@
+"""Unit tests for the Pairwise Difference Learning (PDL) estimators.
+
+Covers the legacy ``PairwiseDifferenceEstimator`` helper, the PDL pair-target
+contracts (same/different labels and the left-minus-anchor delta sign), the
+diagnostics payload, and the public classifier/regressor APIs.
+"""
+
 import pytest
 import numpy as np
 import pandas as pd
 from fedot.core.operations.operation_parameters import OperationParameters
 from sklearn.model_selection import train_test_split
-from sklearn.preprocessing import StandardScaler
-from unittest.mock import patch
 
 from fedot_ind.core.operation.dummy.dummy_operation import init_input_data
 from fedot_ind.core.models.pdl.pairwise_core import _predict_same_probability
@@ -14,11 +19,14 @@ from fedot_ind.core.models.pdl.pairwise_model import (
     PairwiseDifferenceRegressor,
 )
 
-# Fixtures for test data
-
 
 @pytest.fixture
 def classification_data():
+    """Provide a random binary-classification train/test split as ``InputData``.
+
+    Returns:
+        A ``(train_data, test_data)`` tuple of FEDOT ``InputData`` objects.
+    """
     X, y = np.random.rand(50, 50), np.random.randint(0, 2, 50)
     X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.2, random_state=42)
 
@@ -31,6 +39,11 @@ def classification_data():
 
 @pytest.fixture
 def regression_data():
+    """Provide a random regression train/test split as ``InputData``.
+
+    Returns:
+        A ``(train_data, test_data)`` tuple of FEDOT ``InputData`` objects.
+    """
     X, y = np.random.rand(50, 50), np.random.rand(50)
     X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.2, random_state=42)
 
@@ -40,12 +53,12 @@ def regression_data():
 
     return train_data, test_data
 
-# Tests for PairwiseDifferenceEstimator
-
 
 class TestPairwiseDifferenceEstimator:
+    """Tests for the legacy pandas-based pair construction helper."""
 
     def test_convert_to_pandas(self):
+        """Array-like inputs are coerced into DataFrames with preserved shape."""
         pde = PairwiseDifferenceEstimator()
         arr1 = np.array([[1, 2], [3, 4]])
         arr2 = np.array([[5, 6], [7, 8]])
@@ -58,6 +71,7 @@ class TestPairwiseDifferenceEstimator:
         assert df2.shape == arr2.shape
 
     def test_pair_input(self):
+        """``pair_input`` yields the full cross product with ``_x/_y/_diff`` columns."""
         pde = PairwiseDifferenceEstimator()
         X1 = pd.DataFrame({'a': [1, 2], 'b': [3, 4]})
         X2 = pd.DataFrame({'a': [5, 6], 'b': [7, 8]})
@@ -73,6 +87,7 @@ class TestPairwiseDifferenceEstimator:
         assert all(col in X_pair.columns for col in expected_columns)
 
     def test_regression_pair_target_is_left_minus_anchor(self):
+        """``pair_output`` follows the ``left - anchor`` delta sign convention."""
         pde = PairwiseDifferenceEstimator()
         y1 = pd.Series([1.0, 3.0])
         y2 = pd.Series([1.0, 3.0])
@@ -84,6 +99,7 @@ class TestPairwiseDifferenceEstimator:
         np.testing.assert_allclose(delta, np.array([0.0, -2.0, 2.0, 0.0]))
 
     def test_classification_pair_target_semantics_same_is_zero_current_contract(self):
+        """``pair_output_difference`` encodes same class as ``0`` and different as ``1``."""
         pde = PairwiseDifferenceEstimator()
         y1 = pd.Series([5, 5, 7])
         y2 = pd.Series([5])
@@ -94,6 +110,7 @@ class TestPairwiseDifferenceEstimator:
         np.testing.assert_array_equal(dissimilarity_target, np.array([0, 0, 1]))
 
     def test_pair_output_difference(self):
+        """Dissimilarity targets are produced for every cross-product pair."""
         pde = PairwiseDifferenceEstimator()
         y1 = pd.Series([0, 1, 2])
         y2 = pd.Series([0, 2])
@@ -109,29 +126,33 @@ class TestPairwiseDifferenceEstimator:
 
 
 class _PairProbaStub:
-    """заглушка sklearn-классификатора с predict_proba."""
+    """Sklearn-like classifier stub exposing a fixed ``predict_proba`` output."""
 
     def __init__(self, probabilities: np.ndarray, classes: np.ndarray):
         self.classes_ = classes
         self._probabilities = probabilities
 
     def predict_proba(self, pair_features: np.ndarray) -> np.ndarray:
+        """Return the preset probability matrix regardless of the input."""
         return self._probabilities
 
 
 class _HardLabelStub:
-    """классификатора только с predict (без predict_proba)."""
+    """Classifier stub exposing only ``predict`` (no ``predict_proba``)."""
 
     def __init__(self, labels: np.ndarray):
         self._labels = labels
 
     def predict(self, pair_features: np.ndarray) -> np.ndarray:
+        """Return the preset hard labels regardless of the input."""
         return self._labels
 
 
 class TestPDLContracts:
+    """Tests for the inference-side same/different probability contract."""
 
     def test_predict_same_probability_uses_same_label_column(self):
+        """The same-class probability is read from the ``same_label`` (0) column."""
         # predict_proba: col 0 = P(same), col 1 = P(different)
         stub_model = _PairProbaStub(
             probabilities=np.array([[0.8, 0.2], [0.3, 0.7]]),
@@ -144,6 +165,7 @@ class TestPDLContracts:
         np.testing.assert_allclose(same_probability, np.array([0.8, 0.3]))
 
     def test_predict_same_probability_falls_back_to_hard_predictions(self):
+        """Without ``predict_proba``, hard labels map ``0 -> 1.0`` and ``1 -> 0.0``."""
         # without predict_proba: label 0 -> 1.0 (same), label 1 -> 0.0 (different)
         stub_model = _HardLabelStub(labels=np.array([0, 1, 0]))
 
@@ -153,8 +175,10 @@ class TestPDLContracts:
 
 
 class TestPDLDiagnostics:
+    """Tests asserting the diagnostics payload exposes the PDL pair contract."""
 
     def test_pair_target_semantics_is_reported_in_diagnostics_classifier(self, classification_data):
+        """Classifier diagnostics expose the classification pair-target semantics."""
         train_data, _ = classification_data
         classifier = PairwiseDifferenceClassifier(OperationParameters(model='rf', n_estimators=10, max_pairs=10_000))
         classifier.fit(train_data)
@@ -168,6 +192,7 @@ class TestPDLDiagnostics:
         assert semantics["inference_output"] == "same_probability"
 
     def test_pair_target_semantics_is_reported_in_diagnostics_regressor(self, regression_data):
+        """Regressor diagnostics expose the regression delta-sign semantics."""
         train_data, _ = regression_data
         regressor = PairwiseDifferenceRegressor(OperationParameters(model='treg', n_estimators=10, max_pairs=10_000))
         regressor.fit(train_data)
@@ -238,12 +263,11 @@ class TestPDLDiagnostics:
         assert diagnostics["pair_feature_dim"] == 3
 
 
-# Tests for PairwiseDifferenceClassifier
-
-
 class TestPairwiseDifferenceClassifier:
+    """Tests for the public ``PairwiseDifferenceClassifier`` API."""
 
     def test_init(self):
+        """Configuration keys are split from base-model params during init."""
         params = OperationParameters(model='rf', n_estimators=10)
         classifier = PairwiseDifferenceClassifier(params)
 
@@ -252,6 +276,7 @@ class TestPairwiseDifferenceClassifier:
         assert hasattr(classifier, 'pde')
 
     def test_fit_predict(self, classification_data):
+        """Fitting then predicting returns valid in-range class indices."""
         train_data, test_data = classification_data
         params = OperationParameters(model='rf', n_estimators=10)
         classifier = PairwiseDifferenceClassifier(params)
@@ -272,6 +297,7 @@ class TestPairwiseDifferenceClassifier:
         assert np.all(predictions < classifier.num_classes)
 
     def test_predict_proba(self, classification_data):
+        """``predict_proba`` returns a row-stochastic probability matrix."""
         train_data, test_data = classification_data
         params = OperationParameters(model='rf', n_estimators=10)
         classifier = PairwiseDifferenceClassifier(params)
@@ -286,6 +312,7 @@ class TestPairwiseDifferenceClassifier:
         assert np.allclose(np.sum(proba, axis=1), np.ones(len(test_data.target)), atol=1e-10)
 
     def test_score_difference(self, classification_data):
+        """``score_difference`` returns a MAE-like value within ``[0, 1]``."""
         train_data, test_data = classification_data
         params = OperationParameters(model='rf', n_estimators=10)
         classifier = PairwiseDifferenceClassifier(params)
@@ -297,12 +324,12 @@ class TestPairwiseDifferenceClassifier:
         assert isinstance(score, float)
         assert 0 <= score <= 1  # MAE value should be between 0 and 1
 
-# Tests for PairwiseDifferenceRegressor
-
 
 class TestPairwiseDifferenceRegressor:
+    """Tests for the public ``PairwiseDifferenceRegressor`` API."""
 
     def test_init(self):
+        """Configuration keys are split from base-model params during init."""
         params = OperationParameters(model='treg', n_estimators=10)
         regressor = PairwiseDifferenceRegressor(params)
 
@@ -311,6 +338,7 @@ class TestPairwiseDifferenceRegressor:
         assert hasattr(regressor, 'pde')
 
     def test_fit_predict(self, regression_data):
+        """Fitting then predicting returns one prediction per test sample."""
         train_data, test_data = regression_data
         params = OperationParameters(model='treg', n_estimators=10)
         regressor = PairwiseDifferenceRegressor(params)
@@ -326,6 +354,7 @@ class TestPairwiseDifferenceRegressor:
         assert len(predictions) == len(test_data.target)
 
     def test_predict_samples(self, regression_data):
+        """``_predict_samples`` returns per-anchor samples and deltas with matching shapes."""
         train_data, test_data = regression_data
         params = OperationParameters(model='treg', n_estimators=10)
         regressor = PairwiseDifferenceRegressor(params)
@@ -343,6 +372,7 @@ class TestPairwiseDifferenceRegressor:
     # This would require mocking _name_to_method_mapping and detailed implementation knowledge
 
     def test_set_sample_weight(self, regression_data):
+        """``set_sample_weight`` accepts matching weights and rejects wrong lengths."""
         train_data, _ = regression_data
         params = OperationParameters(model='treg', n_estimators=10)
         regressor = PairwiseDifferenceRegressor(params)

--- a/tests/unit/core/models/test_pdl.py
+++ b/tests/unit/core/models/test_pdl.py
@@ -13,7 +13,6 @@ from fedot_ind.core.models.pdl.pairwise_model import (
     PairwiseDifferenceClassifier,
     PairwiseDifferenceRegressor,
 )
-from fedot_ind.core.models.pdl.pairwise_transform import PDCDataTransformer
 
 # Fixtures for test data
 
@@ -179,44 +178,6 @@ class TestPDLDiagnostics:
         assert semantics["delta_sign"] == "left_minus_anchor"
         assert semantics["target_formula"] == "target_left - target_anchor"
         assert semantics["inference_reconstruction"] == "anchor_target + predicted_delta"
-
-
-class TestPDCDataTransformerContracts:
-
-    @pytest.fixture
-    def sample_dataframe(self):
-        return pd.DataFrame(
-            {
-                "numeric_col": [1.5, 2.7, 3.2],
-                "string_col": ["A", "B", "C"],
-            }
-        )
-
-    @pytest.mark.xfail(reason="PDCDataTransformer.fit() does not initialize preprocessing_ yet (Issue 2).")
-    def test_pdc_data_transformer_initializes_x_preprocessor(self, sample_dataframe):
-        transformer = PDCDataTransformer(y_type="numeric")
-        transformer.fit(sample_dataframe, pd.Series([1.0, 2.0, 3.0]))
-
-        assert hasattr(transformer, "preprocessing_")
-        assert transformer.preprocessing_ is not None
-        transformed = transformer.transform(sample_dataframe)
-        assert isinstance(transformed, np.ndarray)
-        assert transformed.shape[0] == len(sample_dataframe)
-
-    @pytest.mark.xfail(reason="PDCDataTransformer.transform() should use preprocessing_y_ for y (Issue 2).")
-    def test_pdc_data_transformer_uses_y_preprocessor_for_target(self, sample_dataframe):
-        y = pd.Series([1.0, 2.0, 3.0], name="target")
-        transformer = PDCDataTransformer(y_type="numeric")
-        transformer.fit(sample_dataframe, y)
-
-        assert isinstance(transformer.preprocessing_y_, StandardScaler)
-
-        with patch.object(transformer.preprocessing_y_, "transform", wraps=transformer.preprocessing_y_.transform) as y_transform:
-            with patch.object(transformer, "preprocessing_", create=True) as x_preprocessor:
-                x_preprocessor.transform.return_value = sample_dataframe.values
-                transformer.transform(sample_dataframe, y)
-
-        y_transform.assert_called_once()
 
 
 # Tests for PairwiseDifferenceClassifier

--- a/tests/unit/core/models/test_pdl.py
+++ b/tests/unit/core/models/test_pdl.py
@@ -3,13 +3,17 @@ import numpy as np
 import pandas as pd
 from fedot.core.operations.operation_parameters import OperationParameters
 from sklearn.model_selection import train_test_split
-from fedot_ind.core.operation.dummy.dummy_operation import init_input_data
+from sklearn.preprocessing import StandardScaler
+from unittest.mock import patch
 
+from fedot_ind.core.operation.dummy.dummy_operation import init_input_data
+from fedot_ind.core.models.pdl.pairwise_core import _predict_same_probability
 from fedot_ind.core.models.pdl.pairwise_model import (
     PairwiseDifferenceEstimator,
     PairwiseDifferenceClassifier,
-    PairwiseDifferenceRegressor
+    PairwiseDifferenceRegressor,
 )
+from fedot_ind.core.models.pdl.pairwise_transform import PDCDataTransformer
 
 # Fixtures for test data
 
@@ -69,19 +73,26 @@ class TestPairwiseDifferenceEstimator:
         expected_columns = ['a_x', 'b_x', 'a_y', 'b_y', 'a_diff', 'b_diff']
         assert all(col in X_pair.columns for col in expected_columns)
 
-    def test_pair_output(self):
+    def test_regression_pair_target_is_left_minus_anchor(self):
         pde = PairwiseDifferenceEstimator()
-        y1 = pd.Series([1, 2])
-        y2 = pd.Series([3, 4])
+        y1 = pd.Series([1.0, 3.0])
+        y2 = pd.Series([1.0, 3.0])
 
-        y_pair_diff = pde.pair_output(y1, y2)
+        delta = pde.pair_output(y1, y2)
 
-        # Test shape
-        assert len(y_pair_diff) == len(y1) * len(y2)
+        assert len(delta) == len(y1) * len(y2)
+        # pairs: (1,1), (1,3), (3,1), (3,3) -> left - anchor
+        np.testing.assert_allclose(delta, np.array([0.0, -2.0, 2.0, 0.0]))
 
-        # Test values (should be y2 - y1 for all combinations)
-        expected = np.array([2, 3, 1, 2])  # [3-1, 4-1, 3-2, 4-2]
-        np.testing.assert_array_equal(y_pair_diff, expected)
+    def test_classification_pair_target_semantics_same_is_zero_current_contract(self):
+        pde = PairwiseDifferenceEstimator()
+        y1 = pd.Series([5, 5, 7])
+        y2 = pd.Series([5])
+
+        dissimilarity_target = pde.pair_output_difference(y1, y2)
+
+        # pairs: (5,5), (5,5), (7,5) -> same=0, same=0, different=1
+        np.testing.assert_array_equal(dissimilarity_target, np.array([0, 0, 1]))
 
     def test_pair_output_difference(self):
         pde = PairwiseDifferenceEstimator()
@@ -96,6 +107,117 @@ class TestPairwiseDifferenceEstimator:
         # Test values (should be 1 if different, 0 if same)
         expected = np.array([0, 1, 1, 1, 1, 0])  # Comparing [0,0], [0,2], [1,0], [1,2], [2,0], [2,2]
         np.testing.assert_array_equal(y_pair_diff, expected)
+
+
+class _PairProbaStub:
+    """заглушка sklearn-классификатора с predict_proba."""
+
+    def __init__(self, probabilities: np.ndarray, classes: np.ndarray):
+        self.classes_ = classes
+        self._probabilities = probabilities
+
+    def predict_proba(self, pair_features: np.ndarray) -> np.ndarray:
+        return self._probabilities
+
+
+class _HardLabelStub:
+    """классификатора только с predict (без predict_proba)."""
+
+    def __init__(self, labels: np.ndarray):
+        self._labels = labels
+
+    def predict(self, pair_features: np.ndarray) -> np.ndarray:
+        return self._labels
+
+
+class TestPDLContracts:
+
+    def test_predict_same_probability_uses_same_label_column(self):
+        # predict_proba: столбец 0 = P(same), столбец 1 = P(different)
+        stub_model = _PairProbaStub(
+            probabilities=np.array([[0.8, 0.2], [0.3, 0.7]]),
+            classes=np.array([0, 1]),
+        )
+
+        same_probability = _predict_same_probability(stub_model, np.zeros((2, 3)))
+
+        # Должны взять первый столбец (label 0), а не второй (label 1)
+        np.testing.assert_allclose(same_probability, np.array([0.8, 0.3]))
+
+    def test_predict_same_probability_falls_back_to_hard_predictions(self):
+        # Без predict_proba: label 0 -> 1.0 (same), label 1 -> 0.0 (different)
+        stub_model = _HardLabelStub(labels=np.array([0, 1, 0]))
+
+        same_probability = _predict_same_probability(stub_model, np.zeros((3, 3)))
+
+        np.testing.assert_array_equal(same_probability, np.array([1.0, 0.0, 1.0]))
+
+
+class TestPDLDiagnostics:
+
+    def test_pair_target_semantics_is_reported_in_diagnostics_classifier(self, classification_data):
+        train_data, _ = classification_data
+        classifier = PairwiseDifferenceClassifier(OperationParameters(model='rf', n_estimators=10, max_pairs=10_000))
+        classifier.fit(train_data)
+
+        semantics = classifier.get_diagnostics()["pair_target_semantics"]
+
+        assert semantics["task"] == "classification"
+        assert semantics["same_label"] == 0
+        assert semantics["different_label"] == 1
+        assert semantics["target_type"] == "dissimilarity"
+        assert semantics["inference_output"] == "same_probability"
+
+    def test_pair_target_semantics_is_reported_in_diagnostics_regressor(self, regression_data):
+        train_data, _ = regression_data
+        regressor = PairwiseDifferenceRegressor(OperationParameters(model='treg', n_estimators=10, max_pairs=10_000))
+        regressor.fit(train_data)
+
+        semantics = regressor.get_diagnostics()["pair_target_semantics"]
+
+        assert semantics["task"] == "regression"
+        assert semantics["delta_sign"] == "left_minus_anchor"
+        assert semantics["target_formula"] == "target_left - target_anchor"
+        assert semantics["inference_reconstruction"] == "anchor_target + predicted_delta"
+
+
+class TestPDCDataTransformerContracts:
+
+    @pytest.fixture
+    def sample_dataframe(self):
+        return pd.DataFrame(
+            {
+                "numeric_col": [1.5, 2.7, 3.2],
+                "string_col": ["A", "B", "C"],
+            }
+        )
+
+    @pytest.mark.xfail(reason="PDCDataTransformer.fit() does not initialize preprocessing_ yet (Issue 2).")
+    def test_pdc_data_transformer_initializes_x_preprocessor(self, sample_dataframe):
+        transformer = PDCDataTransformer(y_type="numeric")
+        transformer.fit(sample_dataframe, pd.Series([1.0, 2.0, 3.0]))
+
+        assert hasattr(transformer, "preprocessing_")
+        assert transformer.preprocessing_ is not None
+        transformed = transformer.transform(sample_dataframe)
+        assert isinstance(transformed, np.ndarray)
+        assert transformed.shape[0] == len(sample_dataframe)
+
+    @pytest.mark.xfail(reason="PDCDataTransformer.transform() should use preprocessing_y_ for y (Issue 2).")
+    def test_pdc_data_transformer_uses_y_preprocessor_for_target(self, sample_dataframe):
+        y = pd.Series([1.0, 2.0, 3.0], name="target")
+        transformer = PDCDataTransformer(y_type="numeric")
+        transformer.fit(sample_dataframe, y)
+
+        assert isinstance(transformer.preprocessing_y_, StandardScaler)
+
+        with patch.object(transformer.preprocessing_y_, "transform", wraps=transformer.preprocessing_y_.transform) as y_transform:
+            with patch.object(transformer, "preprocessing_", create=True) as x_preprocessor:
+                x_preprocessor.transform.return_value = sample_dataframe.values
+                transformer.transform(sample_dataframe, y)
+
+        y_transform.assert_called_once()
+
 
 # Tests for PairwiseDifferenceClassifier
 
@@ -220,3 +342,5 @@ class TestPairwiseDifferenceRegressor:
         with pytest.raises(ValueError):
             invalid_weights = pd.Series([1, 2])  # Wrong length
             regressor.set_sample_weight(invalid_weights)
+
+

--- a/tests/unit/core/models/test_pdl_transform.py
+++ b/tests/unit/core/models/test_pdl_transform.py
@@ -1,11 +1,11 @@
 import pytest
 import numpy as np
 import pandas as pd
-from scipy.sparse import csr_matrix
+# from scipy.sparse import csr_matrix
 from sklearn.preprocessing import StandardScaler, OneHotEncoder, OrdinalEncoder
 from unittest.mock import MagicMock, patch
 
-from fedot_ind.core.models.pdl.pairwise_transform import PDCDataTransformer, SampleWeights
+from fedot_ind.core.models.pdl.legacy_pairwise_transform import PDCDataTransformer, SampleWeights
 from fedot.core.operations.operation_parameters import OperationParameters
 
 
@@ -35,7 +35,8 @@ class TestPDCDataTransformer:
 
     def test_init_default(self):
         """Test initialization with default parameters."""
-        transformer = PDCDataTransformer()
+        with pytest.warns(DeprecationWarning, match="PDCDataTransformer"):
+            transformer = PDCDataTransformer()
         assert transformer.numeric_features is None
         assert transformer.ordinal_features is None
         assert transformer.string_features is None
@@ -47,12 +48,13 @@ class TestPDCDataTransformer:
         ordinal = ['ord1']
         string = ['str1', 'str2']
 
-        transformer = PDCDataTransformer(
-            numeric_features=numeric,
-            ordinal_features=ordinal,
-            string_features=string,
-            y_type='numeric'
-        )
+        with pytest.warns(DeprecationWarning, match="PDCDataTransformer"):
+            transformer = PDCDataTransformer(
+                numeric_features=numeric,
+                ordinal_features=ordinal,
+                string_features=string,
+                y_type='numeric'
+            )
 
         assert transformer.numeric_features == numeric
         assert transformer.ordinal_features == ordinal
@@ -61,96 +63,107 @@ class TestPDCDataTransformer:
 
     def test_init_invalid_y_type(self):
         """Test initialization with invalid y_type parameter."""
-        with pytest.raises(ValueError) as excinfo:
-            PDCDataTransformer(y_type='invalid_type')
+        with pytest.warns(DeprecationWarning, match="PDCDataTransformer"):
+            with pytest.raises(ValueError) as excinfo:
+                PDCDataTransformer(y_type='invalid_type')
         assert "y_type must be one of 'numeric', 'ordinal', 'string'" in str(excinfo.value)
 
     def test_fit_auto_feature_detection(self, sample_dataframe):
         """Test automatic feature type detection during fit."""
-        transformer = PDCDataTransformer()
+        with pytest.warns(DeprecationWarning, match="PDCDataTransformer"):
+            transformer = PDCDataTransformer()
         transformer.fit(sample_dataframe)
 
         assert set(transformer.numeric_features) == {'numeric_col1', 'numeric_col2', 'bool_col'}
 
     def test_fit_y_transformers(self, sample_dataframe, y_numeric, y_categorical):
         """Test fitting of y preprocessors."""
-        # Test numeric target
-        transformer_num = PDCDataTransformer(y_type='numeric')
+        with pytest.warns(DeprecationWarning, match="PDCDataTransformer"):
+            transformer_num = PDCDataTransformer(y_type='numeric')
+            transformer_ord = PDCDataTransformer(y_type='ordinal')
+            transformer_str = PDCDataTransformer(y_type='string')
+
         transformer_num.fit(sample_dataframe, y_numeric)
         assert isinstance(transformer_num.preprocessing_y_, StandardScaler)
 
-        # Test ordinal target
-        transformer_ord = PDCDataTransformer(y_type='ordinal')
         transformer_ord.fit(sample_dataframe, y_categorical)
         assert isinstance(transformer_ord.preprocessing_y_, OrdinalEncoder)
 
-        # Test string target
-        transformer_str = PDCDataTransformer(y_type='string')
         transformer_str.fit(sample_dataframe, y_categorical)
+        
+        # Test string target
+        # transformer_str = PDCDataTransformer(y_type='string')
+        # assert isinstance(transformer_str.preprocessing_y_, OneHotEncoder)
         assert isinstance(transformer_str.preprocessing_y_, OneHotEncoder)
 
     def test_cast_uint(self, sample_dataframe, y_numeric):
         """Test the cast_uint method."""
-        transformer = PDCDataTransformer()
+        with pytest.warns(DeprecationWarning, match="PDCDataTransformer"):
+            transformer = PDCDataTransformer()
         X_cast, y_cast = transformer.cast_uint(sample_dataframe, y_numeric)
 
-        # Check numeric columns were converted to float32
         assert X_cast['numeric_col1'].dtype == np.float32
         assert X_cast['numeric_col2'].dtype == np.float32
-
-        # Check y was converted to float32
         assert y_cast.dtype == np.float32
 
-    @patch.object(PDCDataTransformer, 'cast_uint')
-    def test_transform(self, mock_cast_uint, sample_dataframe):
-        """Test the transform method with mocked prerequisites."""
-        # Setup
-        transformer = PDCDataTransformer()
-        transformer.preprocessing_ = MagicMock()
-        mock_transformed_data = pd.DataFrame(np.random.rand(5, 3))
-        transformer.preprocessing_.transform.return_value = mock_transformed_data
-        mock_cast_uint.return_value = (sample_dataframe, None)
+    # @patch.object(PDCDataTransformer, 'cast_uint')
+    # def test_transform(self, mock_cast_uint, sample_dataframe):
+    #     """Test the transform method with mocked prerequisites."""
+    #     # Setup
+    #     transformer = PDCDataTransformer()
+    #     transformer.preprocessing_ = MagicMock()
+    #     mock_transformed_data = pd.DataFrame(np.random.rand(5, 3))
+    #     transformer.preprocessing_.transform.return_value = mock_transformed_data
+    #     mock_cast_uint.return_value = (sample_dataframe, None)
+
 
         # Test
-        result = transformer.transform(sample_dataframe)
+    #     result = transformer.transform(sample_dataframe)
 
-        # Assertions
-        mock_cast_uint.assert_called_once_with(sample_dataframe)
-        transformer.preprocessing_.transform.assert_called_once_with(sample_dataframe)
-        assert isinstance(result, np.ndarray)
-        assert result.dtype == np.float32
+    #     # Assertions
+    #     mock_cast_uint.assert_called_once_with(sample_dataframe)
+    #     transformer.preprocessing_.transform.assert_called_once_with(sample_dataframe)
+    #     assert isinstance(result, np.ndarray)
+    #     assert result.dtype == np.float32
 
-    def test_transform_no_features(self, sample_dataframe):
-        """Test transform method when preprocessing returns no features."""
-        transformer = PDCDataTransformer()
-        transformer.preprocessing_ = MagicMock()
-        # Mock transformer returning empty dataframe
-        transformer.preprocessing_.transform.return_value = pd.DataFrame()
+    # def test_transform_no_features(self, sample_dataframe):
+    #     """Test transform method when preprocessing returns no features."""
+    #     transformer = PDCDataTransformer()
+    #     transformer.preprocessing_ = MagicMock()
+    #     # Mock transformer returning empty dataframe
+    #     transformer.preprocessing_.transform.return_value = pd.DataFrame()
 
-        # Create a mock to avoid the actual cast_uint implementation
-        with patch.object(PDCDataTransformer, 'cast_uint', return_value=(sample_dataframe, None)):
-            with pytest.raises(ValueError) as excinfo:
-                transformer.transform(sample_dataframe)
-            assert 'no features left after pre-processing' in str(excinfo.value)
+    #     # Create a mock to avoid the actual cast_uint implementation
+    #     with patch.object(PDCDataTransformer, 'cast_uint', return_value=(sample_dataframe, None)):
+    #         with pytest.raises(ValueError) as excinfo:
+    #             transformer.transform(sample_dataframe)
+    #         assert 'no features left after pre-processing' in str(excinfo.value)
 
-    def test_transform_sparse_matrix(self, sample_dataframe):
-        """Test transform method rejects sparse matrix data."""
-        transformer = PDCDataTransformer()
-        transformer.preprocessing_ = MagicMock()
+    # def test_transform_sparse_matrix(self, sample_dataframe):
+    #     """Test transform method rejects sparse matrix data."""
+    #     transformer = PDCDataTransformer()
+    #     transformer.preprocessing_ = MagicMock()
 
-        # Create a sparse matrix
-        sparse_data = csr_matrix(np.eye(5))
+    #     # Create a sparse matrix
+    #     sparse_data = csr_matrix(np.eye(5))
 
-        # Mock transformer returning DataFrame with sparse data
-        df_with_sparse = pd.DataFrame({'col1': [sparse_data[0]] * 5})
-        transformer.preprocessing_.transform.return_value = df_with_sparse
+    #     # Mock transformer returning DataFrame with sparse data
+    #     df_with_sparse = pd.DataFrame({'col1': [sparse_data[0]] * 5})
+    #     transformer.preprocessing_.transform.return_value = df_with_sparse
 
-        # Create a mock to avoid the actual cast_uint implementation
-        with patch.object(PDCDataTransformer, 'cast_uint', return_value=(sample_dataframe, None)):
-            with pytest.raises(NotImplementedError) as excinfo:
-                transformer.transform(sample_dataframe)
-            assert 'X contains sparse features' in str(excinfo.value)
+    #     # Create a mock to avoid the actual cast_uint implementation
+    #     with patch.object(PDCDataTransformer, 'cast_uint', return_value=(sample_dataframe, None)):
+    #         with pytest.raises(NotImplementedError) as excinfo:
+    #             transformer.transform(sample_dataframe)
+    #         assert 'X contains sparse features' in str(excinfo.value)
 
+    def test_transform_raises_not_implemented(self, sample_dataframe):
+        """Legacy transformer must not expose a broken production transform path."""
+        with pytest.warns(DeprecationWarning, match="PDCDataTransformer"):
+            transformer = PDCDataTransformer()
+        transformer.fit(sample_dataframe)
+        with pytest.raises(NotImplementedError, match="legacy module"):
+            transformer.transform(sample_dataframe)
 
 class TestSampleWeights:
     @pytest.fixture
@@ -162,7 +175,8 @@ class TestSampleWeights:
     @pytest.fixture
     def sample_weights_instance(self, sample_params):
         """Create SampleWeights instance with configured parameters."""
-        return SampleWeights(params=sample_params)
+        with pytest.warns(DeprecationWarning, match="SampleWeights"):
+            return SampleWeights(params=sample_params)
 
     @pytest.fixture
     def mock_training_data(self):
@@ -185,14 +199,16 @@ class TestSampleWeights:
 
     def test_init(self, sample_params):
         """Test initialization with parameters."""
-        weights = SampleWeights(params=sample_params)
+        with pytest.warns(DeprecationWarning, match="SampleWeights"):
+            weights = SampleWeights(params=sample_params)
         assert weights.method == 'L2'
         assert 'L2' in weights.method_dict
 
     def test_init_default(self):
         """Test initialization with default parameters."""
-        weights = SampleWeights(dict())
-        assert weights.method == 'L2'  # Default method
+        with pytest.warns(DeprecationWarning, match="SampleWeights"):
+            weights = SampleWeights(dict())
+        assert weights.method == 'L2' # Default method
 
     def test_normalize_weights(self, sample_weights_instance):
         """Test normalize_weights method."""
@@ -218,7 +234,8 @@ class TestSampleWeights:
     def test_method_kmeans(self, mock_kmeans):
         """Test KMeansClusterCenters method selection."""
         params = OperationParameters(**{'method': 'KMeansClusterCenters'})
-        weights = SampleWeights(params=params)
+        with pytest.warns(DeprecationWarning, match="SampleWeights"):
+            weights = SampleWeights(params=params)
 
         # Configure mock
         expected_result = pd.Series([0.2, 0.3, 0.5])
@@ -238,14 +255,16 @@ class TestSampleWeights:
     def test_method_l2(self, mock_optimize):
         """Test L2 method selection and configuration."""
         params = OperationParameters(**{'method': 'L2'})
-        weights = SampleWeights(params=params)
+        with pytest.warns(DeprecationWarning, match="SampleWeights"):
+            weights = SampleWeights(params=params)
 
         # Test partial function configuration
         partial_func = weights.method_dict['L2']
         assert partial_func.func == weights._sample_weight_optimize
         assert partial_func.keywords == {'l2_lambda': 0.1}
 
-    @patch('fedot_ind.core.models.pdl.pairwise_transform.minimize')
+    # @patch('fedot_ind.core.models.pdl.pairwise_transform.minimize')
+    @patch('fedot_ind.core.models.pdl.legacy_pairwise_transform.minimize')
     def _test_sample_weight_optimize(
             self,
             mock_minimize,

--- a/tests/unit/core/models/test_pdl_transform.py
+++ b/tests/unit/core/models/test_pdl_transform.py
@@ -106,57 +106,6 @@ class TestPDCDataTransformer:
         assert X_cast['numeric_col2'].dtype == np.float32
         assert y_cast.dtype == np.float32
 
-    # @patch.object(PDCDataTransformer, 'cast_uint')
-    # def test_transform(self, mock_cast_uint, sample_dataframe):
-    #     """Test the transform method with mocked prerequisites."""
-    #     # Setup
-    #     transformer = PDCDataTransformer()
-    #     transformer.preprocessing_ = MagicMock()
-    #     mock_transformed_data = pd.DataFrame(np.random.rand(5, 3))
-    #     transformer.preprocessing_.transform.return_value = mock_transformed_data
-    #     mock_cast_uint.return_value = (sample_dataframe, None)
-
-
-        # Test
-    #     result = transformer.transform(sample_dataframe)
-
-    #     # Assertions
-    #     mock_cast_uint.assert_called_once_with(sample_dataframe)
-    #     transformer.preprocessing_.transform.assert_called_once_with(sample_dataframe)
-    #     assert isinstance(result, np.ndarray)
-    #     assert result.dtype == np.float32
-
-    # def test_transform_no_features(self, sample_dataframe):
-    #     """Test transform method when preprocessing returns no features."""
-    #     transformer = PDCDataTransformer()
-    #     transformer.preprocessing_ = MagicMock()
-    #     # Mock transformer returning empty dataframe
-    #     transformer.preprocessing_.transform.return_value = pd.DataFrame()
-
-    #     # Create a mock to avoid the actual cast_uint implementation
-    #     with patch.object(PDCDataTransformer, 'cast_uint', return_value=(sample_dataframe, None)):
-    #         with pytest.raises(ValueError) as excinfo:
-    #             transformer.transform(sample_dataframe)
-    #         assert 'no features left after pre-processing' in str(excinfo.value)
-
-    # def test_transform_sparse_matrix(self, sample_dataframe):
-    #     """Test transform method rejects sparse matrix data."""
-    #     transformer = PDCDataTransformer()
-    #     transformer.preprocessing_ = MagicMock()
-
-    #     # Create a sparse matrix
-    #     sparse_data = csr_matrix(np.eye(5))
-
-    #     # Mock transformer returning DataFrame with sparse data
-    #     df_with_sparse = pd.DataFrame({'col1': [sparse_data[0]] * 5})
-    #     transformer.preprocessing_.transform.return_value = df_with_sparse
-
-    #     # Create a mock to avoid the actual cast_uint implementation
-    #     with patch.object(PDCDataTransformer, 'cast_uint', return_value=(sample_dataframe, None)):
-    #         with pytest.raises(NotImplementedError) as excinfo:
-    #             transformer.transform(sample_dataframe)
-    #         assert 'X contains sparse features' in str(excinfo.value)
-
     def test_transform_raises_not_implemented(self, sample_dataframe):
         """Legacy transformer must not expose a broken production transform path."""
         with pytest.warns(DeprecationWarning, match="PDCDataTransformer"):


### PR DESCRIPTION

## Отчёт по выполнению PR 1

Статус: **Issue 1 — выполнен**. **Issue 2 — выполнен**.

Затронутые файлы:

```text
* fedot_ind/core/models/pdl/pairwise_core.py — контракты, diagnostics, имена
* fedot_ind/core/models/pdl/pairwise_model.py — score_difference
* tests/unit/core/models/test_pdl.py  — контракты, estimator/classifier/regressor
* tests/unit/core/models/test_pairwise_learning_core.py — core-level контракты

* fedot_ind/core/models/pdl/legacy_pairwise_transform.py — модуль transform перенесённый в legacy
* tests/unit/core/models/test_pdl_transform.py — пересобранные тесты для legacy transform
```

### 1. Явные constants/metadata для classification target semantics

**Статус: выполнено**

**Файл:** `pairwise_core.py`, строки 14–16

**Добавлено:**

```python
CLASSIFICATION_SAME_LABEL = 0
CLASSIFICATION_DIFFERENT_LABEL = 1
REGRESSION_DELTA_SIGN = "left_minus_anchor"
```

**Где используется:**

| Константа | Файл | Функция / место |
|---|---|---|
| `CLASSIFICATION_SAME_LABEL` | `pairwise_core.py` | `_predict_same_probability` — выбор столбца P(same) из `predict_proba`; ` |
| `CLASSIFICATION_SAME_LABEL`, `CLASSIFICATION_DIFFERENT_LABEL` | `pairwise_core.py` | `_pair_target_semantics(task="classification")` → поля `same_label`, `different_label` |
| `REGRESSION_DELTA_SIGN` | `pairwise_core.py` | `_pair_target_semantics(task="regression")` → поле `delta_sign` |


---

### 2. Политика имён: `same` и `different` не смешиваются

**Статус: выполнено в active path и legacy helper**

#### Classification — training target

| Было | Стало | Файл |
|---|---|---|
| `pair_target = (left != anchor)` | `dissimilarity_target = (left != anchor)` | `pairwise_core.py`, `build_classification_pairs` (~143) |
| — | `dissimilarity_target` + docstring контракта `0=same, 1=different` | `pairwise_model.py`, `pair_output_difference` (~65–78) |

**Семантика (зафиксированный контракт):**

```text
same_label           = 0   → одинаковый класс
different_label      = 1   → разные классы
dissimilarity_target = int(left_class != anchor_class)   # 0 если same, 1 если different
```

**В `PairwiseBatch.target`** по-прежнему поле называется `target` (публичная структура не менялась), но в него кладётся `dissimilarity_target`.

#### Classification — inference / scoring

| Было | Стало | Файл |
|---|---|---|
| `similarity = predict_similarity_by_chunks(...)` | `same_probability = predict_similarity_by_chunks(...)` | `pairwise_model.py`, `score_difference` (~174) |
| `target_difference` | `dissimilarity_target` | `pairwise_model.py`, `score_difference` (~175–176) |
| `predicted_difference = 1.0 - similarity` | `predicted_dissimilarity = 1.0 - same_probability` | `pairwise_model.py`, `score_difference` (~177) |

**В `predict_similarity_by_chunks`** локальная переменная `same_probability` (~211) — это P(class == `same_label`), не «разность» и не dissimilarity.

**Не переименовано (косметика, поведение то же):**

- `aggregate_similarity_to_class_proba(similarity, ...)` — аргумент по-прежнему `similarity`, по смыслу это матрица P(same).
- `_predict_encoded_proba`: локально `similarity = predict_similarity_by_chunks(...)` (~185).

#### Regression — training target

| Было | Стало | Файл |
|---|---|---|
| `pair_target = left - anchor` | `delta_left_minus_anchor = left - anchor` | `pairwise_core.py`, `build_regression_pairs` (~166) |
| `return anchor - left` | `delta_left_minus_anchor = left - anchor` | `pairwise_model.py`, `pair_output` (~60–63) |

---

### 3. Regression sign convention `left - anchor`

**Статус: выполнено, active path и legacy выровнены**

**Формула:**

```text
delta_left_minus_anchor = target_left - target_anchor
feature difference      = left_features - anchor_features   # concat_diff, diff_only
inference               = anchor_target + predicted_delta
```

**Где зафиксировано:**

| Место | Файл |
|---|---|
| `build_regression_pairs` | `pairwise_core.py` ~166 |
| `predict_regression_by_chunks` (`anchor_target + deltas`) | `pairwise_core.py` ~233–234 |
| `_build_pair_features_numpy` (`left - anchors`) | `pairwise_core.py` ~282 |
| Legacy `pair_output` | `pairwise_model.py` ~60–63 |

**Удалено из тестов:** старый `test_pair_output` с ожиданием `anchor - left` (`y2 - y1`); заменён на `test_regression_pair_target_is_left_minus_anchor`.

---

### 4. `pair_target_semantics` в diagnostics

**Статус: выполнено**

**Добавлено:**

| Элемент | Файл | Строки |
|---|---|---|
| `_pair_target_semantics(task)` | `pairwise_core.py` | ~303–321 |
| параметр `task` в `_pair_diagnostics` | `pairwise_core.py` | ~346–366 |
| `task="classification"` в `build_classification_pairs` | `pairwise_core.py` | ~150 |
| `task="regression"` в `build_regression_pairs` | `pairwise_core.py` | ~173 |
| ключ `"pair_target_semantics"` в return diagnostics | `pairwise_core.py` | ~365 |

**Цепочка до внешнего API:**

```text
build_*_pairs → batch.diagnostics["pair_target_semantics"]
    → PairwiseDifferenceClassifier/Regressor.fit → self.diagnostics_
    → get_diagnostics()
```

**Для classification:**

```json
{
  "task": "classification",
  "same_label": 0,
  "different_label": 1,
  "target_type": "dissimilarity",
  "target_formula": "int(left_class != anchor_class)",
  "inference_output": "same_probability"
}
```

** Для regression:**

```json
{
  "task": "regression",
  "delta_sign": "left_minus_anchor",
  "target_formula": "target_left - target_anchor",
  "inference_reconstruction": "anchor_target + predicted_delta"
}
```
_pair_diagnostics кладётся в PairwiseBatch.diagnostics на этапе построения пар,
источник pairwise_core.py.
В pairwise_model.py: в fit к batch‑диагностике добавляются runtime‑поля модели (diagnostics_).

Опционально доработать: нет типизированного контракта диагностики, оставлены TODO для PairwiseBatch.diagnostics, _pair_diagnostics, и в обоих fit. Сейчас это dict.


**Тесты:**

- `test_pair_target_semantics_is_reported_in_diagnostics` — core (`test_pairwise_learning_core.py`)
- `test_pair_target_semantics_is_reported_in_diagnostics_classifier` / `_regressor` — estimator (`test_pdl.py`, `TestPDLDiagnostics`)

---

### 5. Модуль `pairwise_transform.py` выведены в legacy
- `legacy_pairwise_transform.py`
    - Исправлен module docstring: статус `deprecated`
    - Добавлены `DeprecationWarning` при создании `PDCDataTransformer` и `SampleWeights`
    - `transform` теперь явно бросает NotImplementedError вместо падения на неинициализированном  `preprocessing_`
    - `fit` помечает объект как fitted через `_legacy_fit_complete_`
    - Исправлен `fit` при отсутствии preprocessing_y_ (getattr)
    - Добавлены `import warnings` и `import sklearn.metrics` (раньше SampleWeights ссылался на  неимпортированный модуль)
- `test_pdl_transform.py`
    - Импорты переведены на `legacy_pairwise_transform`
    - Обновлён patch-путь для minimize.
    - Удалены мок-тесты сломанного `transform`; добавлен `test_transform_raises_not_implemented`
    - Все создания legacy-классов обёрнуты в `pytest.warns(DeprecationWarning, ...)`

---

### 6. Тесты на deterministic toy arrays

**Статус: выполнено**

#### `tests/unit/core/models/test_pdl.py`

| Тест | Класс | Что проверяет |
|---|---|---|
| `test_regression_pair_target_is_left_minus_anchor` | `TestPairwiseDifferenceEstimator` | legacy `pair_output`: `[0, -2, 2, 0]` |
| `test_classification_pair_target_semantics_same_is_zero_current_contract` | `TestPairwiseDifferenceEstimator` | legacy `pair_output_difference`: `[0, 0, 1]` |
| `test_pair_output_difference` | `TestPairwiseDifferenceEstimator` | расширенный кейс 3×2 пар (оставлен) |
| `test_predict_same_probability_uses_same_label_column` | `TestPDLContracts` | столбец class 0 из `predict_proba` |
| `test_predict_same_probability_falls_back_to_hard_predictions` | `TestPDLContracts` | `predict` без `predict_proba` |
| `test_pair_target_semantics_is_reported_in_diagnostics_classifier` | `TestPDLDiagnostics` | semantics после `Classifier.fit` |
| `test_pair_target_semantics_is_reported_in_diagnostics_regressor` | `TestPDLDiagnostics` | semantics после `Regressor.fit` |

Заглушки `_PairProbaStub`, `_HardLabelStub` вместо `MagicMock`.

#### `tests/unit/core/models/test_pairwise_learning_core.py`

| Тест | Что проверяет |
|---|---|
| `test_classification_pair_target_semantics_same_is_zero_current_contract` | `build_classification_pairs` → `[0, 0, 1]` |
| `test_pair_target_semantics_is_reported_in_diagnostics` | `batch.diagnostics` clf + reg |
| `test_predict_same_probability_uses_same_label_column` | `_predict_same_probability` на уровне core |
| `test_regression_pair_target_uses_left_minus_anchor_sign_convention` | delta + feature blocks |

Опционально следовало бы когда-нибудь сделать: 
classification_data/regression_data используют np.random.rand без фиксированного сидирования numpy (сид есть только в train_test_split)
для воспроизводимости где-нибудь в фикстурах зафиксировать.
### 8. Импорты
«Добавить недостающие imports». 
import warnings присутствует (legacy_pairwise_transform.py:12) это был исходный баг из Issue 2 (использование warnings.catch_warnings() без импорта).
