### PR TITLE
Feature/multi preprocessing

### DIFF
--- a/fedot_ind/core/models/base_extractor.py
+++ b/fedot_ind/core/models/base_extractor.py
@@ -152,65 +152,6 @@ class BaseExtractor(IndustrialCachableOperationImplementation):
         list_of_methods = [*STAT_METHODS_GLOBAL.items()] if add_global_features else [*STAT_METHODS.items()]
         return list(map(lambda method: method[1](time_series, axis), list_of_methods))
 
-    def get_statistical_features_torch(
-            self,
-            time_series: torch.Tensor,
-            add_global_features: bool = False,
-            axis: int = -1,
-            max_elements: int = 50000000) -> tuple:
-        """
-        Method for creating baseline statistical features for a given time series.
-        Creates batches, if number of values in time series is more than max_elements.
-
-        Args:
-            add_global_features: if True, global features are added to the feature set
-            time_series: time series for which features are generated
-            max_elements: threshold for using batches
-
-        Returns:
-            tuple: features
-
-        """
-        if self.is_multichanel:
-            if time_series.ndim == 3:
-                batch = time_series.shape[0]
-                time_series = time_series.reshape(batch, -1)
-            elif time_series.ndim > 3:
-                batch, b, *rest = time_series.shape
-                time_series = time_series.reshape(batch, b, -1)
-
-        if add_global_features:
-            list_of_methods = [*STAT_METHODS_GLOBAL_TORCH.items()]
-        else:
-            list_of_methods = [*STAT_METHODS_TORCH.items()]
-
-        if time_series.numel() <= max_elements:
-            return list(map(lambda method: method[1](time_series, axis),
-                            list_of_methods))
-        B = time_series.shape[0]
-        elems_per_sample = time_series[0].numel()
-        batch_size = max(1, max_elements // elems_per_sample)
-        accumulators = [[] for _ in list_of_methods]
-        for start in range(0, B, batch_size):
-            end = min(start + batch_size, B)
-            ts_batch = time_series[start:end]
-            batch_results = [
-                method(ts_batch, axis)
-                for _, method in list_of_methods
-            ]
-            for i, res in enumerate(batch_results):
-                accumulators[i].append(res)
-
-        merged = []
-        for parts in accumulators:
-            if isinstance(parts[0], (float, int)):
-                merged.append(
-                    torch.tensor(parts) if isinstance(parts[0], torch.Tensor) else parts
-                )
-            else:
-                merged.append(torch.cat(parts, dim=0))
-        return merged
-
     def apply_window_for_stat_feature(self,
                                       ts_data: np.array,
                                       feature_generator: callable,
@@ -255,49 +196,4 @@ class BaseExtractor(IndustrialCachableOperationImplementation):
         multi_channel_features = [extraction_func(x) for x in ts]
         features = torch.concat([channel_feature.unsqueeze(0)
                                  for channel_feature in multi_channel_features])
-        return features
-
-    def apply_window_for_stat_feature_torch(self,
-                                            ts_data: torch.Tensor,
-                                            feature_generator: callable,
-                                            window_size: int = None) -> torch.Tensor:
-        """
-        Method for creating windows and extracting base statistical features
-        for a given time series or batch of time series.
-        """
-        axis = ts_data.ndim - 1
-        if window_size is None:
-            window_size = round(ts_data.shape[axis] / 10)
-        else:
-            window_size = round(ts_data.shape[axis] * (window_size / 100))
-        window_size = max(window_size, 5)
-
-        if self.use_sliding_window:
-            if self.stride > 1:
-                subseq_set = HankelMatrix(time_series=ts_data,
-                                          window_size=window_size,
-                                          strides=self.stride).trajectory_matrix
-            else:
-                window_length = ts_data.shape[axis] - window_size
-                subseq_set = ts_data.unfold(
-                    dimension=axis,
-                    size=window_length,
-                    step=self.stride
-                )
-            if subseq_set.ndim > 2:
-                subseq_set = subseq_set.transpose(1, 2)
-            else:
-                subseq_set = subseq_set.T
-        else:
-            T = ts_data.shape[1]
-            num_windows = T // window_size
-            T_eff = num_windows * window_size
-            ts_cut = ts_data[:, :T_eff]
-            subseq_set = ts_cut.reshape(2, num_windows, window_size)
-        features = feature_generator(subseq_set)
-        features = torch.stack(features, dim=0).to(ts_data.device)
-        if features.ndim > 2:
-            features = features.permute(1, 2, 0)
-        else:
-            features = features.T
         return features

--- a/fedot_ind/core/multimodal/__init__.py
+++ b/fedot_ind/core/multimodal/__init__.py
@@ -1,0 +1,27 @@
+from fedot_ind.core.multimodal.data_bundle import MultimodalDataBundle
+from fedot_ind.core.multimodal.enums import (
+    MultimodalModality,
+    NormalizationMethod,
+    StatisticalFeature,
+)
+from fedot_ind.core.multimodal.configs import (
+    DEFAULT_STAT_FEATURES,
+    PreparationConfig,
+    default_transformation_config,
+    default_normalization_config,
+)
+from fedot_ind.core.multimodal.preparation import MultimodalDatasetPreparer
+from fedot_ind.core.multimodal.preprocessor import MultimodalPreprocessor
+
+__all__ = [
+    "DEFAULT_STAT_FEATURES",
+    "MultimodalDataBundle",
+    "MultimodalDatasetPreparer",
+    "MultimodalModality",
+    "MultimodalPreprocessor",
+    "NormalizationMethod",
+    "PreparationConfig",
+    "default_normalization_config",
+    "default_transformation_config",
+    "StatisticalFeature",
+]

--- a/fedot_ind/core/multimodal/__init__.py
+++ b/fedot_ind/core/multimodal/__init__.py
@@ -1,0 +1,9 @@
+from fedot_ind.core.multimodal.data_bundle import MultimodalDataBundle
+from fedot_ind.core.multimodal.enums import MultimodalModality
+from fedot_ind.core.multimodal.preprocessor import MultimodalPreprocessor
+
+__all__ = [
+    "MultimodalDataBundle",
+    "MultimodalModality",
+    "MultimodalPreprocessor",
+]

--- a/fedot_ind/core/multimodal/__init__.py
+++ b/fedot_ind/core/multimodal/__init__.py
@@ -1,9 +1,0 @@
-from fedot_ind.core.multimodal.data_bundle import MultimodalDataBundle
-from fedot_ind.core.multimodal.enums import MultimodalModality
-from fedot_ind.core.multimodal.preprocessor import MultimodalPreprocessor
-
-__all__ = [
-    "MultimodalDataBundle",
-    "MultimodalModality",
-    "MultimodalPreprocessor",
-]

--- a/fedot_ind/core/multimodal/__init__.py
+++ b/fedot_ind/core/multimodal/__init__.py
@@ -2,8 +2,8 @@ from fedot_ind.core.multimodal.data_bundle import MultimodalDataBundle
 from fedot_ind.core.multimodal.enums import (
     MultimodalModality,
     NormalizationMethod,
-    StatisticalFeature,
 )
+from fedot_ind.core.operation.transformation.torch_backend.enums import StatisticalFeature
 from fedot_ind.core.multimodal.configs import (
     DEFAULT_STAT_FEATURES,
     PreparationConfig,

--- a/fedot_ind/core/multimodal/configs.py
+++ b/fedot_ind/core/multimodal/configs.py
@@ -1,0 +1,249 @@
+from dataclasses import dataclass
+from typing import Any, Sequence
+
+import torch
+
+from fedot_ind.core.multimodal.enums import (
+    MultimodalModality,
+    NormalizationConfig,
+    NormalizationMethod,
+    StatisticalFeature,
+)
+from fedot_ind.core.multimodal.mapping import (
+    DEFAULT_STAT_FEATURES as MAPPING_DEFAULT_STAT_FEATURES,
+    STAT_FEATURE_TO_METHOD,
+)
+
+DEFAULT_STAT_FEATURES = tuple(MAPPING_DEFAULT_STAT_FEATURES)
+SUPPORTED_PREPARATION_MODALITIES = frozenset(
+    (
+        MultimodalModality.raw,
+        MultimodalModality.stats,
+        MultimodalModality.gaf,
+        MultimodalModality.stft,
+        MultimodalModality.mtf,
+    )
+)
+
+
+def default_normalization_config() -> NormalizationConfig:
+    return {
+        MultimodalModality.stats: (
+            NormalizationMethod.imputation,
+            NormalizationMethod.feature_standardization,
+        ),
+        MultimodalModality.gaf: (NormalizationMethod.image_standardization,),
+        MultimodalModality.stft: (
+            NormalizationMethod.log1p,
+            NormalizationMethod.image_standardization,
+        ),
+    }
+
+
+def default_transformation_config() -> dict[str, dict[str, Any]]:
+    return {
+        "raw": {
+            "per_sample_z_normalize": False,
+            "per_sample_z_normalize_eps": 1e-6,
+        },
+        "stats": {
+            "window_size": 12,
+            "stride": 50,
+            "add_global_features": True,
+            "feature_names": DEFAULT_STAT_FEATURES,
+        },
+        "gaf": {
+            "method": "summation",
+            "overlapping": True,
+            "image_size": 0.25,
+            "sample_range": None,
+        },
+        "stft": {
+            "window_size": 64,
+            "hop_length": 16,
+            "n_fft": 64,
+            "window_type": "hann",
+            "center": False,
+            "pad_mode": "reflect",
+            "power": 2.0,
+            "normalized": False,
+        },
+    }
+
+
+def _normalization_policy(steps: Sequence[NormalizationMethod]) -> str:
+    if not steps:
+        return "none"
+    if tuple(steps) == (
+        NormalizationMethod.imputation,
+        NormalizationMethod.feature_standardization,
+    ):
+        return "train_mean_imputation_then_train_mean_std"
+    if tuple(steps) == (NormalizationMethod.image_standardization,):
+        return "train_image_standardization"
+    if tuple(steps) == (
+        NormalizationMethod.log1p,
+        NormalizationMethod.image_standardization,
+    ):
+        return "log1p_then_train_image_standardization"
+    return " -> ".join(step.value for step in steps)
+
+
+def _coerce_modality(value: MultimodalModality | str) -> MultimodalModality:
+    if isinstance(value, MultimodalModality):
+        return value
+    try:
+        return MultimodalModality(str(value))
+    except ValueError as exc:
+        raise ValueError(
+            f"Unsupported modality key {value!r}. "
+            f"Supported values: {[modality.value for modality in MultimodalModality]}."
+        ) from exc
+
+
+def _coerce_stat_feature(value: StatisticalFeature | str) -> str:
+    if isinstance(value, StatisticalFeature):
+        return value.value
+    return StatisticalFeature(str(value)).value
+
+
+@dataclass(frozen=True)
+class PreparationConfig:
+    """Configuration for benchmark/DataLoader multimodal representation building."""
+
+    normalization_config: NormalizationConfig | None = None
+    transformation_config: dict[
+        MultimodalModality | str,
+        dict[str, Any],
+    ] | None = None
+    torch_device: Any = "auto"
+    preprocessor_eps: float = 1e-6
+    auto_adjust_stft: bool = True
+
+    def __post_init__(self) -> None:
+        transformation_source = (
+            default_transformation_config()
+            if self.transformation_config is None
+            else self.transformation_config
+        )
+        normalized_transform_config: dict[MultimodalModality, dict[str, Any]] = {}
+        for key, params in transformation_source.items():
+            modality = _coerce_modality(key)
+            if modality not in SUPPORTED_PREPARATION_MODALITIES:
+                raise ValueError(f"Unsupported preparation modality: {modality.value}.")
+            normalized_transform_config[modality] = dict(params)
+
+        if MultimodalModality.raw not in normalized_transform_config:
+            normalized_transform_config[MultimodalModality.raw] = dict(
+                default_transformation_config()["raw"]
+            )
+
+        raw_config = normalized_transform_config[MultimodalModality.raw]
+        if raw_config.get("per_sample_z_normalize", False):
+            eps = float(raw_config.get("per_sample_z_normalize_eps", 1e-6))
+            if eps <= 0:
+                raise ValueError("raw.per_sample_z_normalize_eps must be positive.")
+            raw_config["per_sample_z_normalize_eps"] = eps
+        else:
+            raw_config.setdefault("per_sample_z_normalize_eps", 1e-6)
+
+        stats_config = normalized_transform_config.get(MultimodalModality.stats, {})
+        stats_features = stats_config.get("feature_names", DEFAULT_STAT_FEATURES)
+        stats_config["feature_names"] = tuple(
+            _coerce_stat_feature(feature) for feature in stats_features
+        )
+        unsupported = sorted(set(stats_config["feature_names"]) - set(STAT_FEATURE_TO_METHOD))
+        if unsupported:
+            raise ValueError(f"Unsupported statistical features: {unsupported}.")
+        if MultimodalModality.stats in normalized_transform_config:
+            normalized_transform_config[MultimodalModality.stats] = stats_config
+
+        modalities = (MultimodalModality.raw,) + tuple(
+            modality
+            for modality in normalized_transform_config
+            if modality is not MultimodalModality.raw
+        )
+
+        if self.normalization_config is None:
+            defaults = default_normalization_config()
+            normalization_config = {
+                modality: defaults[modality]
+                for modality in modalities
+                if modality in defaults
+            }
+        else:
+            normalization_config = {
+                _coerce_modality(modality): tuple(steps)
+                for modality, steps in self.normalization_config.items()
+            }
+        if MultimodalModality.raw in normalization_config:
+            raise ValueError(
+                "Raw modality is not normalized by MultimodalPreprocessor. "
+                "Use transformation_config['raw']['per_sample_z_normalize']."
+            )
+        object.__setattr__(self, "transformation_config", normalized_transform_config)
+        object.__setattr__(self, "normalization_config", normalization_config)
+
+    @property
+    def modalities(self) -> tuple[MultimodalModality, ...]:
+        config = self.transformation_config or {}
+        return (MultimodalModality.raw,) + tuple(
+            modality
+            for modality in config
+            if modality is not MultimodalModality.raw
+        )
+
+    def modality_config(self, modality: MultimodalModality) -> dict[str, Any]:
+        config = self.transformation_config or {}
+        return dict(config.get(modality, {}))
+
+    def stats_feature_names(self) -> tuple[str, ...]:
+        return tuple(
+            self.modality_config(MultimodalModality.stats).get(
+                "feature_names",
+                DEFAULT_STAT_FEATURES,
+            )
+        )
+
+    def metadata(self, device: torch.device) -> dict[str, Any]:
+        normalization_config = self.normalization_config or {}
+        transform_params = {
+            modality: self.modality_config(modality)
+            for modality in self.modalities
+        }
+        return {
+            "normalization": {
+                modality: (
+                    "per_sample_z_norm"
+                    if modality is MultimodalModality.raw
+                    and bool(
+                        self.modality_config(MultimodalModality.raw).get(
+                            "per_sample_z_normalize",
+                            False,
+                        )
+                    )
+                    else _normalization_policy(
+                        tuple(normalization_config.get(modality, ()))
+                    )
+                )
+                for modality in self.modalities
+            },
+            "normalization_config": {
+                modality.value: [
+                    step.value
+                    for step in normalization_config.get(modality, ())
+                ]
+                for modality in self.modalities
+            },
+            "transform_params": transform_params,
+            "preparation_config": {
+                "modalities": tuple(modality.value for modality in self.modalities),
+                "transformation_config": {
+                    modality.value: transform_params.get(modality, {})
+                    for modality in self.modalities
+                },
+                "auto_adjust_stft": self.auto_adjust_stft,
+            },
+            "device": device,
+            "dtype": torch.float32,
+        }

--- a/fedot_ind/core/multimodal/configs.py
+++ b/fedot_ind/core/multimodal/configs.py
@@ -7,11 +7,14 @@ from fedot_ind.core.multimodal.enums import (
     MultimodalModality,
     NormalizationConfig,
     NormalizationMethod,
-    StatisticalFeature,
 )
 from fedot_ind.core.multimodal.mapping import (
+    DEFAULT_STAT_FEATURE_CONFIG,
+    DEFAULT_STAT_FEATURE_GLOBAL_CONFIG,
     DEFAULT_STAT_FEATURES as MAPPING_DEFAULT_STAT_FEATURES,
-    STAT_FEATURE_TO_METHOD,
+)
+from fedot_ind.core.operation.transformation.torch_backend.enums import (
+    StatisticalFeature,
 )
 
 DEFAULT_STAT_FEATURES = tuple(MAPPING_DEFAULT_STAT_FEATURES)
@@ -51,6 +54,8 @@ def default_transformation_config() -> dict[str, dict[str, Any]]:
             "stride": 50,
             "add_global_features": True,
             "feature_names": DEFAULT_STAT_FEATURES,
+            "stat_feature_config": DEFAULT_STAT_FEATURE_CONFIG,
+            "stat_feature_global_config": DEFAULT_STAT_FEATURE_GLOBAL_CONFIG,
         },
         "gaf": {
             "method": "summation",
@@ -107,7 +112,7 @@ def _coerce_stat_feature(value: StatisticalFeature | str) -> str:
     return StatisticalFeature(str(value)).value
 
 
-@dataclass(frozen=True)
+@dataclass
 class PreparationConfig:
     """Configuration for benchmark/DataLoader multimodal representation building."""
 
@@ -152,9 +157,14 @@ class PreparationConfig:
         stats_config["feature_names"] = tuple(
             _coerce_stat_feature(feature) for feature in stats_features
         )
-        unsupported = sorted(set(stats_config["feature_names"]) - set(STAT_FEATURE_TO_METHOD))
+        unsupported = []
+        for feature_name in stats_config["feature_names"]:
+            try:
+                StatisticalFeature(str(feature_name))
+            except ValueError:
+                unsupported.append(feature_name)
         if unsupported:
-            raise ValueError(f"Unsupported statistical features: {unsupported}.")
+            raise ValueError(f"Unsupported statistical features: {sorted(unsupported)}.")
         if MultimodalModality.stats in normalized_transform_config:
             normalized_transform_config[MultimodalModality.stats] = stats_config
 
@@ -181,8 +191,8 @@ class PreparationConfig:
                 "Raw modality is not normalized by MultimodalPreprocessor. "
                 "Use transformation_config['raw']['per_sample_z_normalize']."
             )
-        object.__setattr__(self, "transformation_config", normalized_transform_config)
-        object.__setattr__(self, "normalization_config", normalization_config)
+        self.transformation_config = normalized_transform_config
+        self.normalization_config = normalization_config
 
     @property
     def modalities(self) -> tuple[MultimodalModality, ...]:

--- a/fedot_ind/core/multimodal/data_bundle.py
+++ b/fedot_ind/core/multimodal/data_bundle.py
@@ -7,7 +7,7 @@ from fedot_ind.core.multimodal.enums import MultimodalModality
 
 
 DEFAULT_NORMALIZATION_POLICY = {
-    MultimodalModality.raw: "per_sample_z_norm",
+    MultimodalModality.raw: "none",
     MultimodalModality.stats: "train_mean_std",
     MultimodalModality.gaf: "per_sample_minmax_then_train_image_standardization",
     MultimodalModality.stft: "log1p_then_train_image_standardization",

--- a/fedot_ind/core/multimodal/data_bundle.py
+++ b/fedot_ind/core/multimodal/data_bundle.py
@@ -1,0 +1,133 @@
+from dataclasses import dataclass, field
+from typing import Any, Optional
+
+import torch
+
+from fedot_ind.core.multimodal.enums import MultimodalModality
+
+
+DEFAULT_NORMALIZATION_POLICY = {
+    MultimodalModality.raw: "per_sample_z_norm",
+    MultimodalModality.stats: "train_mean_std",
+    MultimodalModality.gaf: "per_sample_minmax_then_train_image_standardization",
+    MultimodalModality.stft: "log1p_then_train_image_standardization",
+}
+
+
+@dataclass
+class MultimodalDataBundle:
+    """Container for multimodal time-series representations.
+
+    Expected modalities:
+        {
+            "raw": torch.Tensor,
+            "stats": torch.Tensor,
+            "gaf": torch.Tensor,
+            "stft": torch.Tensor,
+        }
+
+    The first dimension of each tensor is interpreted as the number of samples.
+    """
+
+    modalities: dict[MultimodalModality, torch.Tensor]
+    target: Optional[torch.Tensor] = None
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        self._validate_modalities()
+        self._validate_target()
+        self.metadata = self._build_metadata(self.metadata)
+
+    @property
+    def available_modalities(self) -> list[MultimodalModality]:
+        return list(self.modalities.keys())
+
+    @property
+    def n_samples(self) -> int:
+        return int(next(iter(self.modalities.values())).shape[0])
+
+    @property
+    def shapes(self) -> dict[MultimodalModality, tuple[int, ...]]:
+        return {name: tuple(tensor.shape) for name, tensor in self.modalities.items()}
+
+    @property
+    def device(self) -> torch.device:
+        return next(iter(self.modalities.values())).device
+
+    @property
+    def dtype(self) -> torch.dtype:
+        return next(iter(self.modalities.values())).dtype
+
+    def _validate_modalities(self) -> None:
+        if not self.modalities:
+            raise ValueError("MultimodalDataBundle requires at least one modality.")
+
+        for name, tensor in self.modalities.items():
+            if not isinstance(name, MultimodalModality):
+                raise TypeError(
+                    f"Modality name must be MultimodalModality, got {type(name)}."
+                )
+
+            if not isinstance(tensor, torch.Tensor):
+                raise TypeError(
+                    f"Modality '{name}' must be torch.Tensor, "
+                    f"got {type(tensor)}."
+                )
+
+            if tensor.ndim == 0:
+                raise ValueError(
+                    f"Modality '{name}' must have sample dimension, "
+                    "but scalar tensor was provided."
+                )
+
+        sample_sizes = {
+            name: int(tensor.shape[0])
+            for name, tensor in self.modalities.items()
+        }
+
+        unique_sample_sizes = set(sample_sizes.values())
+
+        if len(unique_sample_sizes) != 1:
+            raise ValueError(
+                "All modalities must have the same number of samples. "
+                f"Got sample sizes: {sample_sizes}."
+            )
+
+    def _validate_target(self) -> None:
+        if self.target is None:
+            return
+
+        if not isinstance(self.target, torch.Tensor):
+            raise TypeError(
+                f"Target must be torch.Tensor or None, got {type(self.target)}."
+            )
+
+        if self.target.ndim == 0:
+            raise ValueError("Target must have sample dimension.")
+
+        if int(self.target.shape[0]) != self.n_samples:
+            raise ValueError(
+                "Target and modalities must have the same number of samples. "
+                f"Got target size {int(self.target.shape[0])}, "
+                f"modalities size {self.n_samples}."
+            )
+
+    def _build_metadata(self, metadata: dict[str, Any]) -> dict[str, Any]:
+        metadata = dict(metadata)
+
+        metadata.setdefault("modalities", self.available_modalities)
+        metadata.setdefault("shapes", self.shapes)
+
+        metadata.setdefault(
+            "normalization",
+            {
+                name: DEFAULT_NORMALIZATION_POLICY.get(name, "unknown")
+                for name in self.available_modalities
+            },
+        )
+
+        metadata.setdefault("transform_params", {})
+        metadata.setdefault("device", self.device)
+        metadata.setdefault("dtype", self.dtype)
+
+        return metadata

--- a/fedot_ind/core/multimodal/enums.py
+++ b/fedot_ind/core/multimodal/enums.py
@@ -1,0 +1,9 @@
+from enum import Enum
+
+
+class MultimodalModality(Enum):
+    raw = "raw"
+    stats = "stats"
+    gaf = "gaf"
+    stft = "stft"
+    mtf = "mtf"

--- a/fedot_ind/core/multimodal/enums.py
+++ b/fedot_ind/core/multimodal/enums.py
@@ -1,4 +1,5 @@
 from enum import Enum
+from typing import Sequence
 
 
 class MultimodalModality(Enum):
@@ -7,3 +8,12 @@ class MultimodalModality(Enum):
     gaf = "gaf"
     stft = "stft"
     mtf = "mtf"
+
+
+class NormalizationMethod(str, Enum):
+    image_standardization = "image_standardization"
+    log1p = "log1p"
+
+
+NormalizationStep = NormalizationMethod
+NormalizationConfig = dict[MultimodalModality, Sequence[NormalizationStep]]

--- a/fedot_ind/core/multimodal/enums.py
+++ b/fedot_ind/core/multimodal/enums.py
@@ -17,5 +17,35 @@ class NormalizationMethod(str, Enum):
     log1p = "log1p"
 
 
+class StatisticalFeature(str, Enum):
+    mean = "mean"
+    std = "std"
+    median = "median"
+    max = "max"
+    min = "min"
+    q5 = "q5"
+    q25 = "q25"
+    q75 = "q75"
+    q95 = "q95"
+    skewness = "skewness"
+    kurtosis = "kurtosis"
+    n_peaks = "n_peaks"
+    slope = "slope"
+    ben_corr = "ben_corr"
+    interquartile_range = "interquartile_range"
+    energy = "energy"
+    cross_rate = "cross_rate"
+    autocorrelation = "autocorrelation"
+    ptp_amplitude = "ptp_amplitude"
+    mean_ptp_distance = "mean_ptp_distance"
+    crest_factor = "crest_factor"
+    mean_ema = "mean_ema"
+    mean_moving_median = "mean_moving_median"
+    hjorth_mobility = "hjorth_mobility"
+    hjorth_complexity = "hjorth_complexity"
+    hurst_exponent = "hurst_exponent"
+    petrosian_fractal_dimension = "petrosian_fractal_dimension"
+
+
 NormalizationStep = NormalizationMethod
 NormalizationConfig = dict[MultimodalModality, Sequence[NormalizationStep]]

--- a/fedot_ind/core/multimodal/enums.py
+++ b/fedot_ind/core/multimodal/enums.py
@@ -11,6 +11,8 @@ class MultimodalModality(Enum):
 
 
 class NormalizationMethod(str, Enum):
+    imputation = "imputation"
+    feature_standardization = "feature_standardization"
     image_standardization = "image_standardization"
     log1p = "log1p"
 

--- a/fedot_ind/core/multimodal/enums.py
+++ b/fedot_ind/core/multimodal/enums.py
@@ -17,35 +17,5 @@ class NormalizationMethod(str, Enum):
     log1p = "log1p"
 
 
-class StatisticalFeature(str, Enum):
-    mean = "mean"
-    std = "std"
-    median = "median"
-    max = "max"
-    min = "min"
-    q5 = "q5"
-    q25 = "q25"
-    q75 = "q75"
-    q95 = "q95"
-    skewness = "skewness"
-    kurtosis = "kurtosis"
-    n_peaks = "n_peaks"
-    slope = "slope"
-    ben_corr = "ben_corr"
-    interquartile_range = "interquartile_range"
-    energy = "energy"
-    cross_rate = "cross_rate"
-    autocorrelation = "autocorrelation"
-    ptp_amplitude = "ptp_amplitude"
-    mean_ptp_distance = "mean_ptp_distance"
-    crest_factor = "crest_factor"
-    mean_ema = "mean_ema"
-    mean_moving_median = "mean_moving_median"
-    hjorth_mobility = "hjorth_mobility"
-    hjorth_complexity = "hjorth_complexity"
-    hurst_exponent = "hurst_exponent"
-    petrosian_fractal_dimension = "petrosian_fractal_dimension"
-
-
 NormalizationStep = NormalizationMethod
 NormalizationConfig = dict[MultimodalModality, Sequence[NormalizationStep]]

--- a/fedot_ind/core/multimodal/mapping.py
+++ b/fedot_ind/core/multimodal/mapping.py
@@ -1,0 +1,168 @@
+from typing import Any
+
+import torch
+
+from fedot_ind.core.multimodal.enums import (
+    MultimodalModality,
+    NormalizationMethod,
+    StatisticalFeature,
+)
+from fedot_ind.core.multimodal.normalization import (
+    FeatureStandardizationNormalizer,
+    ImageStandardizationNormalizer,
+    ImputationNormalizer,
+    Log1pNormalizer,
+)
+from fedot_ind.core.operation.transformation.torch_backend.image.gaf_transformation import GAF
+from fedot_ind.core.operation.transformation.torch_backend.image.mtf_transformation import MTF
+from fedot_ind.core.operation.transformation.torch_backend.image.stft_transformation import (
+    STFTSpectrogram,
+)
+from fedot_ind.core.operation.transformation.torch_backend.statistical.stat_features import (
+    interquantile_range_torch, max_torch, mean_ptp_distance_torch, mean_torch, median_torch,
+    min_torch, q25_torch, q75_torch, q5_torch, q95_torch,
+    skewness_torch, kurtosis_torch, ben_corr_torch, energy_torch, zero_crossing_rate_torch,
+    autocorrelation_torch, ptp_amp_torch, mean_ema_torch, mean_moving_median_torch,
+    hjorth_mobility_torch, hjorth_complexity_torch, hurst_exponent_torch, pfd_torch, slope_torch, std_torch,
+    crest_factor_torch, n_peaks_torch,
+)
+
+
+# "Window" stat features
+STAT_METHODS = {
+    "median_": median_torch,
+    "max_": max_torch,
+    "min_": min_torch,
+    "q5_": q5_torch,
+    "q25_": q25_torch,
+    "q75_": q75_torch,
+    "q95_": q95_torch,
+}
+
+STAT_METHODS_GLOBAL = {
+    "skewness_": skewness_torch,
+    "kurtosis_": kurtosis_torch,
+    "n_peaks_": lambda array, axis=-1: n_peaks_torch(array, axis=axis, normalized=True),
+    "slope_": slope_torch,
+    "ben_corr_": ben_corr_torch,
+    "interquartile_range_": interquantile_range_torch,
+    "energy_": energy_torch,
+    "cross_rate_": zero_crossing_rate_torch,
+    "autocorrelation_": autocorrelation_torch,
+    "ptp_amplitude_": ptp_amp_torch,
+    "mean_ptp_distance_": lambda array, axis=-1: mean_ptp_distance_torch(
+        array,
+        axis=axis,
+        normalized=True,
+    ),
+    "crest_factor_": crest_factor_torch,
+    "mean_ema_": mean_ema_torch,
+    "mean_moving_median_": mean_moving_median_torch,
+    "hjorth_mobility_": hjorth_mobility_torch,
+    "hjorth_complexity_": hjorth_complexity_torch,
+    "hurst_exponent_": hurst_exponent_torch,
+    "petrosian_fractal_dimension_": pfd_torch,
+}
+
+
+STAT_FEATURE_TO_METHOD = {
+    StatisticalFeature.mean.value: mean_torch,
+    StatisticalFeature.std.value: std_torch,
+    StatisticalFeature.median.value: STAT_METHODS["median_"],
+    StatisticalFeature.max.value: STAT_METHODS["max_"],
+    StatisticalFeature.min.value: STAT_METHODS["min_"],
+    StatisticalFeature.q5.value: STAT_METHODS["q5_"],
+    StatisticalFeature.q25.value: STAT_METHODS["q25_"],
+    StatisticalFeature.q75.value: STAT_METHODS["q75_"],
+    StatisticalFeature.q95.value: STAT_METHODS["q95_"],
+    StatisticalFeature.skewness.value: STAT_METHODS_GLOBAL["skewness_"],
+    StatisticalFeature.kurtosis.value: STAT_METHODS_GLOBAL["kurtosis_"],
+    StatisticalFeature.n_peaks.value: STAT_METHODS_GLOBAL["n_peaks_"],
+    StatisticalFeature.slope.value: STAT_METHODS_GLOBAL["slope_"],
+    StatisticalFeature.ben_corr.value: STAT_METHODS_GLOBAL["ben_corr_"],
+    StatisticalFeature.interquartile_range.value: STAT_METHODS_GLOBAL["interquartile_range_"],
+    StatisticalFeature.energy.value: STAT_METHODS_GLOBAL["energy_"],
+    StatisticalFeature.cross_rate.value: STAT_METHODS_GLOBAL["cross_rate_"],
+    StatisticalFeature.autocorrelation.value: STAT_METHODS_GLOBAL["autocorrelation_"],
+    StatisticalFeature.ptp_amplitude.value: STAT_METHODS_GLOBAL["ptp_amplitude_"],
+    StatisticalFeature.mean_ptp_distance.value: STAT_METHODS_GLOBAL["mean_ptp_distance_"],
+    StatisticalFeature.crest_factor.value: STAT_METHODS_GLOBAL["crest_factor_"],
+    StatisticalFeature.mean_ema.value: STAT_METHODS_GLOBAL["mean_ema_"],
+    StatisticalFeature.mean_moving_median.value: STAT_METHODS_GLOBAL["mean_moving_median_"],
+    StatisticalFeature.hjorth_mobility.value: STAT_METHODS_GLOBAL["hjorth_mobility_"],
+    StatisticalFeature.hjorth_complexity.value: STAT_METHODS_GLOBAL["hjorth_complexity_"],
+    StatisticalFeature.hurst_exponent.value: STAT_METHODS_GLOBAL["hurst_exponent_"],
+    StatisticalFeature.petrosian_fractal_dimension.value: STAT_METHODS_GLOBAL[
+        "petrosian_fractal_dimension_"
+    ],
+}
+
+DEFAULT_STAT_FEATURES = tuple(STAT_FEATURE_TO_METHOD.keys())
+
+
+NORMALIZATION_HANDLERS = {
+    NormalizationMethod.imputation: ImputationNormalizer,
+    NormalizationMethod.feature_standardization: FeatureStandardizationNormalizer,
+    NormalizationMethod.image_standardization: ImageStandardizationNormalizer,
+    NormalizationMethod.log1p: Log1pNormalizer,
+}
+
+
+def _coerce_stat_feature(value: StatisticalFeature | str) -> str:
+    if isinstance(value, StatisticalFeature):
+        return value.value
+    return StatisticalFeature(str(value)).value
+
+
+def transform_stats(series: torch.Tensor, params: dict[str, Any]) -> torch.Tensor:
+    feature_names = tuple(
+        _coerce_stat_feature(name)
+        for name in params.get("feature_names", DEFAULT_STAT_FEATURES)
+    )
+
+    extracted = None
+    try:
+        from fedot_ind.core.operation.transformation.torch_backend.statistical.quantile_extractor import (
+            TorchQuantileExtractor,
+        )
+
+        extractor = TorchQuantileExtractor(
+            {
+                "window_size": params.get("window_size", 0),
+                "stride": params.get("stride", 1),
+                "add_global_features": params.get("add_global_features", True),
+            }
+        )
+        extracted = extractor.generate_features_from_ts(series).to(series.device)
+    except Exception:
+        extracted = None
+
+    if extracted is not None and feature_names == DEFAULT_STAT_FEATURES:
+        return torch.nan_to_num(extracted)
+
+    vectors = []
+    for feature_name in feature_names:
+        method = STAT_FEATURE_TO_METHOD[feature_name]
+        feature = torch.as_tensor(method(series, axis=-1), dtype=torch.float32, device=series.device)
+        vectors.append(feature.reshape(series.shape[0], -1))
+    return torch.nan_to_num(torch.cat(vectors, dim=-1))
+
+
+def transform_gaf(series: torch.Tensor, params: dict[str, Any]) -> torch.Tensor:
+    return GAF(params).transform(series)
+
+
+def transform_stft(series: torch.Tensor, params: dict[str, Any]) -> torch.Tensor:
+    return STFTSpectrogram(params).transform(series)
+
+
+def transform_mtf(series: torch.Tensor, params: dict[str, Any]) -> torch.Tensor:
+    return MTF(params).transform(series)
+
+
+TRANSFORMATION_HANDLERS = {
+    MultimodalModality.stats: transform_stats,
+    MultimodalModality.gaf: transform_gaf,
+    MultimodalModality.stft: transform_stft,
+    MultimodalModality.mtf: transform_mtf,
+}

--- a/fedot_ind/core/multimodal/mapping.py
+++ b/fedot_ind/core/multimodal/mapping.py
@@ -1,11 +1,6 @@
-from typing import Any
-
-import torch
-
 from fedot_ind.core.multimodal.enums import (
     MultimodalModality,
     NormalizationMethod,
-    StatisticalFeature,
 )
 from fedot_ind.core.multimodal.normalization import (
     FeatureStandardizationNormalizer,
@@ -18,87 +13,51 @@ from fedot_ind.core.operation.transformation.torch_backend.image.mtf_transformat
 from fedot_ind.core.operation.transformation.torch_backend.image.stft_transformation import (
     STFTSpectrogram,
 )
-from fedot_ind.core.operation.transformation.torch_backend.statistical.stat_features import (
-    interquantile_range_torch, max_torch, mean_ptp_distance_torch, mean_torch, median_torch,
-    min_torch, q25_torch, q75_torch, q5_torch, q95_torch,
-    skewness_torch, kurtosis_torch, ben_corr_torch, energy_torch, zero_crossing_rate_torch,
-    autocorrelation_torch, ptp_amp_torch, mean_ema_torch, mean_moving_median_torch,
-    hjorth_mobility_torch, hjorth_complexity_torch, hurst_exponent_torch, pfd_torch, slope_torch, std_torch,
-    crest_factor_torch, n_peaks_torch,
+from fedot_ind.core.operation.transformation.torch_backend.statistical.quantile_extractor import (
+        TorchQuantileExtractor,
+    )
+from fedot_ind.core.operation.transformation.torch_backend.enums import (
+    StatisticalFeature,
+    STAT_FEATURE_CONFIG,
 )
 
 
-# "Window" stat features
-STAT_METHODS = {
-    "median_": median_torch,
-    "max_": max_torch,
-    "min_": min_torch,
-    "q5_": q5_torch,
-    "q25_": q25_torch,
-    "q75_": q75_torch,
-    "q95_": q95_torch,
+DEFAULT_STAT_FEATURE_CONFIG: STAT_FEATURE_CONFIG = {
+    StatisticalFeature.median: {},
+    StatisticalFeature.max: {},
+    StatisticalFeature.min: {},
+    StatisticalFeature.q5: {},
+    StatisticalFeature.q25: {},
+    StatisticalFeature.q75: {},
+    StatisticalFeature.q95: {},
 }
 
-STAT_METHODS_GLOBAL = {
-    "skewness_": skewness_torch,
-    "kurtosis_": kurtosis_torch,
-    "n_peaks_": lambda array, axis=-1: n_peaks_torch(array, axis=axis, normalized=True),
-    "slope_": slope_torch,
-    "ben_corr_": ben_corr_torch,
-    "interquartile_range_": interquantile_range_torch,
-    "energy_": energy_torch,
-    "cross_rate_": zero_crossing_rate_torch,
-    "autocorrelation_": autocorrelation_torch,
-    "ptp_amplitude_": ptp_amp_torch,
-    "mean_ptp_distance_": lambda array, axis=-1: mean_ptp_distance_torch(
-        array,
-        axis=axis,
-        normalized=True,
-    ),
-    "crest_factor_": crest_factor_torch,
-    "mean_ema_": mean_ema_torch,
-    "mean_moving_median_": mean_moving_median_torch,
-    "hjorth_mobility_": hjorth_mobility_torch,
-    "hjorth_complexity_": hjorth_complexity_torch,
-    "hurst_exponent_": hurst_exponent_torch,
-    "petrosian_fractal_dimension_": pfd_torch,
+DEFAULT_STAT_FEATURE_GLOBAL_CONFIG: STAT_FEATURE_CONFIG = {
+    StatisticalFeature.skewness: {},
+    StatisticalFeature.kurtosis: {},
+    StatisticalFeature.n_peaks: {"normalized": True},
+    StatisticalFeature.slope: {},
+    StatisticalFeature.ben_corr: {},
+    StatisticalFeature.interquartile_range: {},
+    StatisticalFeature.energy: {},
+    StatisticalFeature.cross_rate: {},
+    StatisticalFeature.autocorrelation: {},
+    StatisticalFeature.ptp_amplitude: {},
+    StatisticalFeature.mean_ptp_distance: {"normalized": True},
+    StatisticalFeature.crest_factor: {},
+    StatisticalFeature.mean_ema: {},
+    StatisticalFeature.mean_moving_median: {},
+    StatisticalFeature.hjorth_mobility: {},
+    StatisticalFeature.hjorth_complexity: {},
+    StatisticalFeature.hurst_exponent: {},
+    StatisticalFeature.petrosian_fractal_dimension: {},
 }
-
-
-STAT_FEATURE_TO_METHOD = {
-    StatisticalFeature.mean.value: mean_torch,
-    StatisticalFeature.std.value: std_torch,
-    StatisticalFeature.median.value: STAT_METHODS["median_"],
-    StatisticalFeature.max.value: STAT_METHODS["max_"],
-    StatisticalFeature.min.value: STAT_METHODS["min_"],
-    StatisticalFeature.q5.value: STAT_METHODS["q5_"],
-    StatisticalFeature.q25.value: STAT_METHODS["q25_"],
-    StatisticalFeature.q75.value: STAT_METHODS["q75_"],
-    StatisticalFeature.q95.value: STAT_METHODS["q95_"],
-    StatisticalFeature.skewness.value: STAT_METHODS_GLOBAL["skewness_"],
-    StatisticalFeature.kurtosis.value: STAT_METHODS_GLOBAL["kurtosis_"],
-    StatisticalFeature.n_peaks.value: STAT_METHODS_GLOBAL["n_peaks_"],
-    StatisticalFeature.slope.value: STAT_METHODS_GLOBAL["slope_"],
-    StatisticalFeature.ben_corr.value: STAT_METHODS_GLOBAL["ben_corr_"],
-    StatisticalFeature.interquartile_range.value: STAT_METHODS_GLOBAL["interquartile_range_"],
-    StatisticalFeature.energy.value: STAT_METHODS_GLOBAL["energy_"],
-    StatisticalFeature.cross_rate.value: STAT_METHODS_GLOBAL["cross_rate_"],
-    StatisticalFeature.autocorrelation.value: STAT_METHODS_GLOBAL["autocorrelation_"],
-    StatisticalFeature.ptp_amplitude.value: STAT_METHODS_GLOBAL["ptp_amplitude_"],
-    StatisticalFeature.mean_ptp_distance.value: STAT_METHODS_GLOBAL["mean_ptp_distance_"],
-    StatisticalFeature.crest_factor.value: STAT_METHODS_GLOBAL["crest_factor_"],
-    StatisticalFeature.mean_ema.value: STAT_METHODS_GLOBAL["mean_ema_"],
-    StatisticalFeature.mean_moving_median.value: STAT_METHODS_GLOBAL["mean_moving_median_"],
-    StatisticalFeature.hjorth_mobility.value: STAT_METHODS_GLOBAL["hjorth_mobility_"],
-    StatisticalFeature.hjorth_complexity.value: STAT_METHODS_GLOBAL["hjorth_complexity_"],
-    StatisticalFeature.hurst_exponent.value: STAT_METHODS_GLOBAL["hurst_exponent_"],
-    StatisticalFeature.petrosian_fractal_dimension.value: STAT_METHODS_GLOBAL[
-        "petrosian_fractal_dimension_"
-    ],
-}
-
-DEFAULT_STAT_FEATURES = tuple(STAT_FEATURE_TO_METHOD.keys())
-
+DEFAULT_STAT_FEATURES = tuple(
+    feature.value for feature in (
+        *DEFAULT_STAT_FEATURE_CONFIG.keys(),
+        *DEFAULT_STAT_FEATURE_GLOBAL_CONFIG.keys(),
+    )
+)
 
 NORMALIZATION_HANDLERS = {
     NormalizationMethod.imputation: ImputationNormalizer,
@@ -107,62 +66,9 @@ NORMALIZATION_HANDLERS = {
     NormalizationMethod.log1p: Log1pNormalizer,
 }
 
-
-def _coerce_stat_feature(value: StatisticalFeature | str) -> str:
-    if isinstance(value, StatisticalFeature):
-        return value.value
-    return StatisticalFeature(str(value)).value
-
-
-def transform_stats(series: torch.Tensor, params: dict[str, Any]) -> torch.Tensor:
-    feature_names = tuple(
-        _coerce_stat_feature(name)
-        for name in params.get("feature_names", DEFAULT_STAT_FEATURES)
-    )
-
-    extracted = None
-    try:
-        from fedot_ind.core.operation.transformation.torch_backend.statistical.quantile_extractor import (
-            TorchQuantileExtractor,
-        )
-
-        extractor = TorchQuantileExtractor(
-            {
-                "window_size": params.get("window_size", 0),
-                "stride": params.get("stride", 1),
-                "add_global_features": params.get("add_global_features", True),
-            }
-        )
-        extracted = extractor.generate_features_from_ts(series).to(series.device)
-    except Exception:
-        extracted = None
-
-    if extracted is not None and feature_names == DEFAULT_STAT_FEATURES:
-        return torch.nan_to_num(extracted)
-
-    vectors = []
-    for feature_name in feature_names:
-        method = STAT_FEATURE_TO_METHOD[feature_name]
-        feature = torch.as_tensor(method(series, axis=-1), dtype=torch.float32, device=series.device)
-        vectors.append(feature.reshape(series.shape[0], -1))
-    return torch.nan_to_num(torch.cat(vectors, dim=-1))
-
-
-def transform_gaf(series: torch.Tensor, params: dict[str, Any]) -> torch.Tensor:
-    return GAF(params).transform(series)
-
-
-def transform_stft(series: torch.Tensor, params: dict[str, Any]) -> torch.Tensor:
-    return STFTSpectrogram(params).transform(series)
-
-
-def transform_mtf(series: torch.Tensor, params: dict[str, Any]) -> torch.Tensor:
-    return MTF(params).transform(series)
-
-
 TRANSFORMATION_HANDLERS = {
-    MultimodalModality.stats: transform_stats,
-    MultimodalModality.gaf: transform_gaf,
-    MultimodalModality.stft: transform_stft,
-    MultimodalModality.mtf: transform_mtf,
+    MultimodalModality.stats: TorchQuantileExtractor,
+    MultimodalModality.gaf: GAF,
+    MultimodalModality.stft: STFTSpectrogram,
+    MultimodalModality.mtf: MTF,
 }

--- a/fedot_ind/core/multimodal/mapping.py
+++ b/fedot_ind/core/multimodal/mapping.py
@@ -14,8 +14,8 @@ from fedot_ind.core.operation.transformation.torch_backend.image.stft_transforma
     STFTSpectrogram,
 )
 from fedot_ind.core.operation.transformation.torch_backend.statistical.quantile_extractor import (
-        TorchQuantileExtractor,
-    )
+    TorchQuantileExtractor,
+)
 from fedot_ind.core.operation.transformation.torch_backend.enums import (
     StatisticalFeature,
     STAT_FEATURE_CONFIG,

--- a/fedot_ind/core/multimodal/normalization.py
+++ b/fedot_ind/core/multimodal/normalization.py
@@ -1,0 +1,102 @@
+import torch
+
+
+class AbstractNormalizer:
+    def __init__(self, eps: float = 1e-6):
+        self.eps = eps
+        self.state_: dict[str, object] = {}
+
+    def fit(self, X: torch.Tensor) -> None:
+        self.state_ = {}
+
+    def transform(self, X: torch.Tensor) -> torch.Tensor:
+        raise NotImplementedError
+
+    def fit_transform(self, X: torch.Tensor) -> torch.Tensor:
+        self.fit(X)
+        return self.transform(X)
+
+    def get_state(self) -> dict[str, object]:
+        return dict(self.state_)
+
+
+class ImputationNormalizer(AbstractNormalizer):
+    def fit(self, X: torch.Tensor) -> None:
+        values = X.float()
+        if values.ndim < 2:
+            raise ValueError(
+                "Imputation expects at least a 2D tensor (batch, features), "
+                f"got shape={tuple(values.shape)}."
+            )
+        finite = torch.isfinite(values)
+        masked = torch.where(finite, values, torch.zeros_like(values))
+        counts = finite.sum(dim=0, keepdim=True).clamp_min(1)
+        column_mean = masked.sum(dim=0, keepdim=True) / counts
+        self.state_ = {
+            "column_mean": column_mean.detach().clone(),
+        }
+
+    def transform(self, X: torch.Tensor) -> torch.Tensor:
+        if "column_mean" not in self.state_:
+            raise ValueError("ImputationNormalizer must be fitted before transform.")
+        values = X.float()
+        column_mean = self.state_["column_mean"].to(device=X.device, dtype=X.dtype)
+        invalid = ~torch.isfinite(values)
+        return torch.where(invalid, column_mean, values)
+
+
+class FeatureStandardizationNormalizer(AbstractNormalizer):
+    def fit(self, X: torch.Tensor) -> None:
+        values = X.float()
+        if values.ndim < 2:
+            raise ValueError(
+                "Feature standardization expects at least a 2D tensor (batch, features), "
+                f"got shape={tuple(values.shape)}."
+            )
+        mean = values.mean(dim=0, keepdim=True)
+        std = values.std(dim=0, unbiased=False, keepdim=True).clamp_min(self.eps)
+        self.state_ = {
+            "mean": mean.detach().clone(),
+            "std": std.detach().clone(),
+            "eps": float(self.eps),
+        }
+
+    def transform(self, X: torch.Tensor) -> torch.Tensor:
+        if "mean" not in self.state_ or "std" not in self.state_:
+            raise ValueError("FeatureStandardizationNormalizer must be fitted before transform.")
+        mean = self.state_["mean"].to(device=X.device, dtype=X.dtype)
+        std = self.state_["std"].to(device=X.device, dtype=X.dtype)
+        return torch.nan_to_num(((X.float() - mean) / std))
+
+
+class ImageStandardizationNormalizer(AbstractNormalizer):
+    def fit(self, X: torch.Tensor) -> None:
+        if X.ndim not in (3, 4):
+            raise ValueError(
+                "Image standardization expects a 3D or 4D tensor, "
+                f"got shape={tuple(X.shape)}."
+            )
+        dims = (0, 2, 3) if X.ndim == 4 else (0, 1, 2)
+        mean = X.mean(dim=dims, keepdim=True)
+        std = X.std(dim=dims, unbiased=False, keepdim=True).clamp_min(self.eps)
+        self.state_ = {
+            "mean": mean.detach().clone(),
+            "std": std.detach().clone(),
+            "dims": dims,
+            "eps": float(self.eps),
+        }
+
+    def transform(self, X: torch.Tensor) -> torch.Tensor:
+        if "mean" not in self.state_ or "std" not in self.state_:
+            raise ValueError("ImageStandardizationNormalizer must be fitted before transform.")
+        mean = self.state_["mean"].to(device=X.device, dtype=X.dtype)
+        std = self.state_["std"].to(device=X.device, dtype=X.dtype)
+        return torch.nan_to_num(((X - mean) / std).float())
+
+
+class Log1pNormalizer(AbstractNormalizer):
+    def fit(self, X: torch.Tensor) -> None:
+        self.state_ = {}
+
+    def transform(self, X: torch.Tensor) -> torch.Tensor:
+        return torch.log1p(X.float().clamp_min(0))

--- a/fedot_ind/core/multimodal/preparation.py
+++ b/fedot_ind/core/multimodal/preparation.py
@@ -15,7 +15,50 @@ from fedot_ind.core.multimodal.data_bundle import MultimodalDataBundle
 from fedot_ind.core.multimodal.enums import MultimodalModality
 from fedot_ind.core.multimodal.preprocessor import MultimodalPreprocessor
 from fedot_ind.core.multimodal.configs import PreparationConfig
-from fedot_ind.core.multimodal.mapping import TRANSFORMATION_HANDLERS
+from fedot_ind.core.multimodal.mapping import (
+    DEFAULT_STAT_FEATURE_CONFIG,
+    DEFAULT_STAT_FEATURE_GLOBAL_CONFIG,
+    TRANSFORMATION_HANDLERS,
+)
+from fedot_ind.core.operation.transformation.torch_backend.enums import (
+    StatisticalFeature,
+)
+from fedot_ind.core.operation.transformation.torch_backend.statistical.tools import (
+    normalize_feature_key,
+)
+
+# TODO: remove it
+LOCAL_STAT_FEATURES = {
+    StatisticalFeature.mean,
+    StatisticalFeature.median,
+    StatisticalFeature.std,
+    StatisticalFeature.max,
+    StatisticalFeature.min,
+    StatisticalFeature.q5,
+    StatisticalFeature.q25,
+    StatisticalFeature.q75,
+    StatisticalFeature.q95,
+}
+GLOBAL_STAT_FEATURES = {
+    StatisticalFeature.skewness,
+    StatisticalFeature.kurtosis,
+    StatisticalFeature.n_peaks,
+    StatisticalFeature.slope,
+    StatisticalFeature.ben_corr,
+    StatisticalFeature.interquartile_range,
+    StatisticalFeature.energy,
+    StatisticalFeature.cross_rate,
+    StatisticalFeature.autocorrelation,
+    StatisticalFeature.ptp_amplitude,
+    StatisticalFeature.mean_ptp_distance,
+    StatisticalFeature.crest_factor,
+    StatisticalFeature.mean_ema,
+    StatisticalFeature.mean_moving_median,
+    StatisticalFeature.hjorth_mobility,
+    StatisticalFeature.hjorth_complexity,
+    StatisticalFeature.hurst_exponent,
+    StatisticalFeature.petrosian_fractal_dimension,
+}
 
 
 def per_sample_z_normalize(series: torch.Tensor, eps: float = 1e-6) -> torch.Tensor:
@@ -24,6 +67,7 @@ def per_sample_z_normalize(series: torch.Tensor, eps: float = 1e-6) -> torch.Ten
     return torch.nan_to_num((series - mean) / std)
 
 
+# TODO @romankuklo: add marshmallow validation schema
 @dataclass
 class MultimodalDatasetPreparer:
     """Build and normalize multimodal time-series bundles from Industrial inputs."""
@@ -149,23 +193,83 @@ class MultimodalDatasetPreparer:
     ) -> torch.Tensor:
         if modality is MultimodalModality.raw:
             return series
-        handler = TRANSFORMATION_HANDLERS.get(modality)
-        if handler is None:
-            raise ValueError(f"Unsupported modality: {modality}.")
         params = self._resolve_modality_params(modality, series.shape[-1])
         params["torch_device"] = self._resolve_device()
-        return handler(series, params)
+        transformer_cls = TRANSFORMATION_HANDLERS.get(modality)
+        if transformer_cls is None and modality is MultimodalModality.stats:
+            from fedot_ind.core.operation.transformation.torch_backend.statistical.quantile_extractor import (
+                TorchQuantileExtractor,
+            )
+            transformer_cls = TorchQuantileExtractor
+        if transformer_cls is None:
+            raise ValueError(f"Unsupported modality: {modality}.")
+        transformer = transformer_cls(params)
+        return transformer.transform(series)
+
+    @staticmethod
+    def _normalize_stats_config(config: Any) -> dict[StatisticalFeature, dict[str, Any]]:
+        normalized: dict[StatisticalFeature, dict[str, Any]] = {}
+        if not config:
+            return normalized
+        for raw_key, raw_kwargs in dict(config).items():
+            key = normalize_feature_key(raw_key)
+            normalized[key] = dict(raw_kwargs or {})
+        return normalized
+
+    @staticmethod
+    def _feature_configs_from_names(
+        feature_names: Any,
+    ) -> tuple[dict[StatisticalFeature, dict[str, Any]], dict[StatisticalFeature, dict[str, Any]]]:
+        local = {}
+        global_ = {}
+        local_methods = set(normalize_feature_key(name) for name in LOCAL_STAT_FEATURES)
+        global_methods = set(normalize_feature_key(name) for name in GLOBAL_STAT_FEATURES)
+        for feature_name in feature_names:
+            feature = normalize_feature_key(feature_name)
+            if feature in local_methods:
+                local[feature] = {}
+            elif feature in global_methods:
+                global_[feature] = {}
+            else:
+                raise ValueError(f"Unsupported statistical feature: {feature_name}")
+        if StatisticalFeature.n_peaks in global_:
+            global_[StatisticalFeature.n_peaks]["normalized"] = True
+        if StatisticalFeature.mean_ptp_distance in global_:
+            global_[StatisticalFeature.mean_ptp_distance]["normalized"] = True
+        return local, global_
 
     def _resolve_modality_params(
         self,
         modality: MultimodalModality,
         n_timestamps: int,
     ) -> dict[str, Any]:
+        if modality is MultimodalModality.stats:
+            return self._resolve_stats_params()
         if modality is MultimodalModality.gaf:
             return self._resolve_gaf_params(n_timestamps)
         if modality is MultimodalModality.stft:
             return self._resolve_stft_params(n_timestamps)
         return self.config.modality_config(modality)
+
+    def _resolve_stats_params(self) -> dict[str, Any]:
+        params = self.config.modality_config(MultimodalModality.stats)
+        local_config = self._normalize_stats_config(
+            params.get("stat_feature_config", DEFAULT_STAT_FEATURE_CONFIG)
+        )
+        global_config = self._normalize_stats_config(
+            params.get("stat_feature_global_config", DEFAULT_STAT_FEATURE_GLOBAL_CONFIG)
+        )
+
+        feature_names = params.get("feature_names")
+        if feature_names is not None:
+            local_config, global_config = self._feature_configs_from_names(feature_names)
+
+        params["stat_feature_config"] = local_config
+        params["stat_feature_global_config"] = global_config
+        params["add_global_features"] = bool(params.get("add_global_features", True)) and bool(
+            global_config
+        )
+        return params
 
     def _resolve_gaf_params(self, n_timestamps: int) -> dict[str, Any]:
         if n_timestamps < 2:
@@ -217,6 +321,7 @@ class MultimodalDatasetPreparer:
         )
         return params
 
+    # TODO @romankuklo: use TensorData for this
     def _target_to_tensor(
         self,
         y: Any | None,

--- a/fedot_ind/core/multimodal/preparation.py
+++ b/fedot_ind/core/multimodal/preparation.py
@@ -1,0 +1,254 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+import math
+
+import numpy as np
+import torch
+
+from fedot_ind.core.kernel_learning.generators.adapters import (
+    normalize_time_series_tensor,
+    resolve_torch_device,
+)
+from fedot_ind.core.multimodal.data_bundle import MultimodalDataBundle
+from fedot_ind.core.multimodal.enums import MultimodalModality
+from fedot_ind.core.multimodal.preprocessor import MultimodalPreprocessor
+from fedot_ind.core.multimodal.configs import PreparationConfig
+from fedot_ind.core.multimodal.mapping import TRANSFORMATION_HANDLERS
+
+
+def per_sample_z_normalize(series: torch.Tensor, eps: float = 1e-6) -> torch.Tensor:
+    mean = series.mean(dim=-1, keepdim=True)
+    std = series.std(dim=-1, unbiased=False, keepdim=True).clamp_min(eps)
+    return torch.nan_to_num((series - mean) / std)
+
+
+@dataclass
+class MultimodalDatasetPreparer:
+    """Build and normalize multimodal time-series bundles from Industrial inputs."""
+
+    config: PreparationConfig = field(default_factory=PreparationConfig)
+    preprocessor_: MultimodalPreprocessor | None = field(default=None, init=False)
+    resolved_torch_device_: torch.device | None = field(default=None, init=False)
+    label_mapping_: dict[Any, int] | None = field(default=None, init=False)
+
+    def fit(self, X: Any, y: Any | None = None) -> "MultimodalDatasetPreparer":
+        bundle = self._build_bundle(X, y, fit_target=True)
+        self.preprocessor_ = MultimodalPreprocessor(
+            normalization_config=self.config.normalization_config,
+            eps=self.config.preprocessor_eps,
+        ).fit(bundle)
+        return self
+
+    def transform(self, X: Any, y: Any | None = None) -> MultimodalDataBundle:
+        if self.preprocessor_ is None:
+            raise ValueError("MultimodalDatasetPreparer must be fitted before transform.")
+        bundle = self._build_bundle(X, y, fit_target=False)
+        return self.preprocessor_.transform(bundle)
+
+    def fit_transform(self, X: Any, y: Any | None = None) -> MultimodalDataBundle:
+        bundle = self._build_bundle(X, y, fit_target=True)
+        self.preprocessor_ = MultimodalPreprocessor(
+            normalization_config=self.config.normalization_config,
+            eps=self.config.preprocessor_eps,
+        ).fit(bundle)
+        return self.preprocessor_.transform(bundle)
+
+    def prepare_train_test(
+        self,
+        train_data: tuple[Any, Any],
+        test_data: tuple[Any, Any],
+    ) -> tuple[MultimodalDataBundle, MultimodalDataBundle]:
+        train_features, train_target = train_data
+        test_features, test_target = test_data
+        train_bundle = self.fit_transform(train_features, train_target)
+        test_bundle = self.transform(test_features, test_target)
+        return train_bundle, test_bundle
+
+    def prepare_classification_record(
+        self,
+        record: Any,
+    ) -> tuple[MultimodalDataBundle, MultimodalDataBundle]:
+        train_bundle, test_bundle = self.prepare_train_test(
+            (record.train_features, record.train_target),
+            (record.test_features, record.test_target),
+        )
+        for bundle, split in ((train_bundle, "train"), (test_bundle, "test")):
+            bundle.metadata.setdefault("source", {})
+            bundle.metadata["source"].update(
+                {
+                    "kind": "ClassificationDatasetRecord",
+                    "benchmark": getattr(record, "benchmark", None),
+                    "dataset_name": getattr(record, "dataset_name", None),
+                    "subset": getattr(record, "subset", None),
+                    "split": split,
+                }
+            )
+        return train_bundle, test_bundle
+
+    def prepare_from_loader(
+        self,
+        loader: Any,
+    ) -> tuple[MultimodalDataBundle, MultimodalDataBundle]:
+        if not hasattr(loader, "load_data"):
+            raise TypeError("loader must provide a load_data() method.")
+        train_data, test_data = loader.load_data()
+        train_bundle, test_bundle = self.prepare_train_test(train_data, test_data)
+        for bundle, split in ((train_bundle, "train"), (test_bundle, "test")):
+            bundle.metadata.setdefault("source", {})
+            bundle.metadata["source"].update(
+                {
+                    "kind": "DataLoader",
+                    "dataset_name": getattr(loader, "dataset_name", None),
+                    "split": split,
+                }
+            )
+        return train_bundle, test_bundle
+
+    def _build_bundle(
+        self,
+        X: Any,
+        y: Any | None,
+        *,
+        fit_target: bool,
+    ) -> MultimodalDataBundle:
+        device = self._resolve_device()
+        series = torch.as_tensor(
+            normalize_time_series_tensor(X),
+            dtype=torch.float32,
+            device=device,
+        )
+        raw_config = self.config.modality_config(MultimodalModality.raw)
+        if raw_config.get("per_sample_z_normalize", False):
+            series = per_sample_z_normalize(
+                series,
+                float(raw_config.get("per_sample_z_normalize_eps", 1e-6)),
+            )
+        modalities = {
+            modality: self._build_modality(modality, series)
+            for modality in self.config.modalities
+        }
+        target, target_metadata = self._target_to_tensor(y, device, fit_target=fit_target)
+        metadata = self.config.metadata(device)
+        if MultimodalModality.stft in self.config.modalities:
+            metadata["transform_params"][MultimodalModality.stft] = (
+                self._resolve_stft_params(series.shape[-1])
+            )
+        metadata.update(target_metadata)
+        return MultimodalDataBundle(
+            modalities=modalities,
+            target=target,
+            metadata=metadata,
+        )
+
+    def _build_modality(
+        self,
+        modality: MultimodalModality,
+        series: torch.Tensor,
+    ) -> torch.Tensor:
+        if modality is MultimodalModality.raw:
+            return series
+        handler = TRANSFORMATION_HANDLERS.get(modality)
+        if handler is None:
+            raise ValueError(f"Unsupported modality: {modality}.")
+        params = self._resolve_modality_params(modality, series.shape[-1])
+        params["torch_device"] = self._resolve_device()
+        return handler(series, params)
+
+    def _resolve_modality_params(
+        self,
+        modality: MultimodalModality,
+        n_timestamps: int,
+    ) -> dict[str, Any]:
+        if modality is MultimodalModality.gaf:
+            return self._resolve_gaf_params(n_timestamps)
+        if modality is MultimodalModality.stft:
+            return self._resolve_stft_params(n_timestamps)
+        return self.config.modality_config(modality)
+
+    def _resolve_gaf_params(self, n_timestamps: int) -> dict[str, Any]:
+        if n_timestamps < 2:
+            raise ValueError(
+                f"GAF modality requires series length >= 2, got {n_timestamps}."
+            )
+        params = self.config.modality_config(MultimodalModality.gaf)
+        window_size = params.get("window_size", None)
+        if window_size is None:
+            image_size = params.get("image_size", 1.0)
+            if isinstance(image_size, float):
+                n_segments = math.ceil(float(image_size) * n_timestamps)
+            else:
+                n_segments = int(image_size)
+        else:
+            n_segments = math.ceil(n_timestamps / max(1, int(window_size)))
+        if n_segments < 2:
+            # GAF implementation requires at least two PAA segments.
+            params.pop("window_size", None)
+            params["image_size"] = 1.0
+            n_segments = 2
+        if bool(params.get("overlapping", False)) and n_segments < 2:
+            params["overlapping"] = False
+        if n_segments == 2:
+            params["overlapping"] = False
+        return params
+
+    def _resolve_stft_params(self, n_timestamps: int) -> dict[str, Any]:
+        if n_timestamps < 2:
+            raise ValueError(
+                f"STFT modality requires series length >= 2, got {n_timestamps}."
+            )
+        params = self.config.modality_config(MultimodalModality.stft)
+        if not self.config.auto_adjust_stft:
+            return params
+
+        configured_window = int(params.get("window_size", n_timestamps))
+        window_size = max(1, min(configured_window, n_timestamps))
+        configured_n_fft = int(params.get("n_fft", window_size))
+        n_fft = max(window_size, min(configured_n_fft, n_timestamps))
+        configured_hop = int(params.get("hop_length", max(1, window_size // 2)))
+        hop_length = max(1, min(configured_hop, window_size))
+        params.update(
+            {
+                "window_size": window_size,
+                "n_fft": n_fft,
+                "hop_length": hop_length,
+            }
+        )
+        return params
+
+    def _target_to_tensor(
+        self,
+        y: Any | None,
+        device: torch.device,
+        *,
+        fit_target: bool,
+    ) -> tuple[torch.Tensor | None, dict[str, Any]]:
+        if y is None:
+            return None, {}
+
+        values = np.asarray(y).reshape(-1)
+        if values.dtype.kind in {"b", "i", "u"}:
+            return torch.as_tensor(values, dtype=torch.long, device=device), {}
+        if values.dtype.kind == "f":
+            return torch.as_tensor(values, dtype=torch.float32, device=device), {}
+
+        labels = tuple(str(label) for label in values.tolist())
+        if fit_target or self.label_mapping_ is None:
+            self.label_mapping_ = {
+                label: index
+                for index, label in enumerate(sorted(set(labels)))
+            }
+        unknown = sorted(set(labels) - set(self.label_mapping_))
+        if unknown:
+            raise ValueError(f"Unknown target labels during transform: {unknown}.")
+        encoded = [self.label_mapping_[label] for label in labels]
+        return (
+            torch.as_tensor(encoded, dtype=torch.long, device=device),
+            {"target_labels": tuple(self.label_mapping_.keys())},
+        )
+
+    def _resolve_device(self) -> torch.device:
+        if self.resolved_torch_device_ is None:
+            self.resolved_torch_device_ = resolve_torch_device(self.config.torch_device)
+        return self.resolved_torch_device_

--- a/fedot_ind/core/multimodal/preprocessor.py
+++ b/fedot_ind/core/multimodal/preprocessor.py
@@ -1,0 +1,168 @@
+from __future__ import annotations
+
+from copy import deepcopy
+from dataclasses import dataclass, field
+from math import prod
+from typing import Any, Sequence
+
+import torch
+
+from fedot_ind.core.multimodal.data_bundle import MultimodalDataBundle
+from fedot_ind.core.multimodal.enums import MultimodalModality
+
+
+@dataclass
+class MultimodalPreprocessor:
+    """Train-aware preparation layer for multimodal time-series models.
+
+    The initial implementation exposes only the raw modality. The public
+    contract is intentionally shaped for adding train-fitted stats/image
+    modalities without changing benchmark data loading.
+
+    ``X`` and ``y`` must already be ``torch.Tensor`` instances. This class
+    only reshapes inputs to ``(batch, channels, timestamps)`` and applies
+    modality-specific normalization.
+    """
+
+    modalities: Sequence[MultimodalModality | str] = (MultimodalModality.raw,)
+    torch_device: Any = "auto"
+    dtype: torch.dtype = torch.float32
+    eps: float = 1e-8
+    transform_params: dict[MultimodalModality | str, dict[str, Any]] = field(
+        default_factory=dict
+    )
+    fitted_statistics_: dict[str, Any] = field(default_factory=dict, init=False)
+    is_fitted_: bool = field(default=False, init=False)
+
+    def __post_init__(self) -> None:
+        self.modalities = tuple(
+            self._normalize_modality(modality) for modality in self.modalities
+        )
+        self.transform_params = {
+            self._normalize_modality(name): dict(params)
+            for name, params in self.transform_params.items()
+        }
+        if self.eps <= 0:
+            raise ValueError("eps must be positive.")
+        if not self.modalities:
+            raise ValueError("MultimodalPreprocessor requires at least one modality.")
+
+    def fit(self, X: torch.Tensor, y: torch.Tensor | None = None) -> "MultimodalPreprocessor":
+        del y
+        raw = self._reshape_raw(X)
+        normalized_raw = self._normalize_raw(raw)
+        self.fitted_statistics_ = {
+            "raw": {
+                "normalization": "per_sample_z_norm",
+                "eps": float(self.eps),
+                "train_input_shape": tuple(int(size) for size in raw.shape),
+                "train_output_shape": tuple(int(size) for size in normalized_raw.shape),
+            }
+        }
+        self.is_fitted_ = True
+        return self
+
+    def transform(
+        self,
+        X: torch.Tensor,
+        y: torch.Tensor | None = None,
+    ) -> MultimodalDataBundle:
+        if not self.is_fitted_:
+            raise ValueError("MultimodalPreprocessor must be fitted before transform.")
+
+        raw = self._reshape_raw(X)
+        modalities: dict[MultimodalModality, torch.Tensor] = {}
+        if MultimodalModality.raw in self.modalities:
+            modalities[MultimodalModality.raw] = self._normalize_raw(raw)
+
+        metadata = {
+            "fitted_statistics": deepcopy(self.fitted_statistics_),
+            "transform_params": self._metadata_transform_params(),
+            "preprocessor": {
+                "name": self.__class__.__name__,
+                "modalities": [modality.value for modality in self.modalities],
+                "eps": float(self.eps),
+            },
+        }
+        return MultimodalDataBundle(
+            modalities=modalities,
+            target=self._validate_target(y, n_samples=raw.shape[0]),
+            metadata=metadata,
+        )
+
+    def fit_transform(
+        self,
+        X: torch.Tensor,
+        y: torch.Tensor | None = None,
+    ) -> MultimodalDataBundle:
+        self.fit(X, y)
+        return self.transform(X, y)
+
+    def _reshape_raw(self, values: torch.Tensor) -> torch.Tensor:
+        if not isinstance(values, torch.Tensor):
+            raise TypeError(
+                f"X must be torch.Tensor, got {type(values)}."
+            )
+
+        if values.ndim == 0:
+            raise ValueError("X must contain at least one sample.")
+        if values.shape[0] == 0:
+            raise ValueError("X must contain at least one sample.")
+        if values.ndim == 1:
+            return values.reshape(1, 1, -1)
+        if values.ndim == 2:
+            return values.reshape(values.shape[0], 1, values.shape[1])
+        if values.ndim == 3:
+            return values
+        return values.reshape(
+            values.shape[0],
+            prod(values.shape[1:-1]),
+            values.shape[-1],
+        )
+
+    def _normalize_raw(self, values: torch.Tensor) -> torch.Tensor:
+        mean = values.mean(dim=-1, keepdim=True)
+        std = values.std(dim=-1, keepdim=True, unbiased=False)
+        scale = torch.where(std > self.eps, std, torch.ones_like(std))
+        return (values - mean) / scale
+
+    def _validate_target(
+        self,
+        values: torch.Tensor | None,
+        *,
+        n_samples: int,
+    ) -> torch.Tensor | None:
+        if values is None:
+            return None
+        if not isinstance(values, torch.Tensor):
+            raise TypeError(
+                f"Target must be torch.Tensor or None, got {type(values)}."
+            )
+        if values.ndim == 0:
+            raise ValueError("Target must have sample dimension.")
+        if int(values.shape[0]) != int(n_samples):
+            raise ValueError(
+                "Target and modalities must have the same number of samples. "
+                f"Got target size {int(values.shape[0])}, modalities size {n_samples}."
+            )
+        return values
+
+    def _metadata_transform_params(self) -> dict[MultimodalModality, dict[str, Any]]:
+        params = {name: dict(values) for name, values in self.transform_params.items()}
+        params.setdefault(
+            MultimodalModality.raw,
+            {
+                "normalization": "per_sample_z_norm",
+                "eps": float(self.eps),
+            },
+        )
+        return params
+
+    @staticmethod
+    def _normalize_modality(value: MultimodalModality | str) -> MultimodalModality:
+        if isinstance(value, MultimodalModality):
+            return value
+        try:
+            return MultimodalModality(str(value))
+        except ValueError as exc:
+            raise ValueError(f"Unsupported multimodal modality: {value!r}") from exc

--- a/fedot_ind/core/multimodal/preprocessor.py
+++ b/fedot_ind/core/multimodal/preprocessor.py
@@ -1,4 +1,5 @@
 from typing import Any
+
 import torch
 
 from fedot_ind.core.multimodal.data_bundle import MultimodalDataBundle
@@ -38,7 +39,13 @@ class MultimodalPreprocessor:
                 "input_shape": tuple(current.shape),
             }
             for step in steps:
-                if step is NormalizationMethod.log1p:
+                if step is NormalizationMethod.imputation:
+                    self._fit_train_mean_imputation(modality, current)
+                    current = self._apply_train_mean_imputation(modality, current)
+                elif step is NormalizationMethod.feature_standardization:
+                    self._fit_feature_standardizer(modality, current)
+                    current = self._apply_feature_standardizer(modality, current)
+                elif step is NormalizationMethod.log1p:
                     current = torch.log1p(current.float().clamp_min(0))
                 elif step is NormalizationMethod.image_standardization:
                     self._fit_image_standardizer(modality, current)
@@ -57,7 +64,11 @@ class MultimodalPreprocessor:
         for modality, steps in self.normalization_config.items():
             current = modalities[modality]
             for step in steps:
-                if step is NormalizationMethod.log1p:
+                if step is NormalizationMethod.imputation:
+                    current = self._apply_train_mean_imputation(modality, current)
+                elif step is NormalizationMethod.feature_standardization:
+                    current = self._apply_feature_standardizer(modality, current)
+                elif step is NormalizationMethod.log1p:
                     current = torch.log1p(current.float().clamp_min(0))
                 elif step is NormalizationMethod.image_standardization:
                     current = self._apply_image_standardizer(modality, current)
@@ -71,6 +82,62 @@ class MultimodalPreprocessor:
 
     def fit_transform(self, bundle: MultimodalDataBundle) -> MultimodalDataBundle:
         return self.fit(bundle).transform(bundle)
+
+    def _fit_train_mean_imputation(
+        self,
+        modality: MultimodalModality,
+        tensor: torch.Tensor,
+    ) -> None:
+        values = tensor.float()
+        if values.ndim < 2:
+            raise ValueError(
+                "Imputation expects at least a 2D tensor (batch, features), "
+                f"got shape={tuple(values.shape)}."
+            )
+        column_mean = self._column_mean_ignore_invalid(values)
+        self.fitted_statistics_[modality.value]["imputation"] = {
+            "column_mean": column_mean.detach().clone(),
+        }
+
+    def _apply_train_mean_imputation(
+        self,
+        modality: MultimodalModality,
+        tensor: torch.Tensor,
+    ) -> torch.Tensor:
+        stats = self.fitted_statistics_[modality.value]["imputation"]
+        column_mean = stats["column_mean"].to(device=tensor.device, dtype=tensor.dtype)
+        values = tensor.float()
+        invalid = ~torch.isfinite(values)
+        return torch.where(invalid, column_mean, values)
+
+    def _fit_feature_standardizer(
+        self,
+        modality: MultimodalModality,
+        tensor: torch.Tensor,
+    ) -> None:
+        values = tensor.float()
+        if values.ndim < 2:
+            raise ValueError(
+                "Feature standardization expects at least a 2D tensor (batch, features), "
+                f"got shape={tuple(values.shape)}."
+            )
+        mean = values.mean(dim=0, keepdim=True)
+        std = values.std(dim=0, unbiased=False, keepdim=True).clamp_min(self.eps)
+        self.fitted_statistics_[modality.value]["feature_standardization"] = {
+            "mean": mean.detach().clone(),
+            "std": std.detach().clone(),
+            "eps": float(self.eps),
+        }
+
+    def _apply_feature_standardizer(
+        self,
+        modality: MultimodalModality,
+        tensor: torch.Tensor,
+    ) -> torch.Tensor:
+        stats = self.fitted_statistics_[modality.value]["feature_standardization"]
+        mean = stats["mean"].to(device=tensor.device, dtype=tensor.dtype)
+        std = stats["std"].to(device=tensor.device, dtype=tensor.dtype)
+        return torch.nan_to_num(((tensor.float() - mean) / std))
 
     def _fit_image_standardizer(
         self,
@@ -101,6 +168,13 @@ class MultimodalPreprocessor:
         mean = stats["mean"].to(device=tensor.device, dtype=tensor.dtype)
         std = stats["std"].to(device=tensor.device, dtype=tensor.dtype)
         return torch.nan_to_num(((tensor - mean) / std).float())
+
+    @staticmethod
+    def _column_mean_ignore_invalid(tensor: torch.Tensor) -> torch.Tensor:
+        finite = torch.isfinite(tensor)
+        masked = torch.where(finite, tensor, torch.zeros_like(tensor))
+        counts = finite.sum(dim=0, keepdim=True).clamp_min(1)
+        return masked.sum(dim=0, keepdim=True) / counts
 
     def _validate_bundle(self, bundle: MultimodalDataBundle) -> None:
         if not isinstance(bundle, MultimodalDataBundle):

--- a/fedot_ind/core/multimodal/preprocessor.py
+++ b/fedot_ind/core/multimodal/preprocessor.py
@@ -1,168 +1,118 @@
-from __future__ import annotations
-
-from copy import deepcopy
-from dataclasses import dataclass, field
-from math import prod
-from typing import Any, Sequence
-
+from typing import Any
 import torch
 
 from fedot_ind.core.multimodal.data_bundle import MultimodalDataBundle
-from fedot_ind.core.multimodal.enums import MultimodalModality
+from fedot_ind.core.multimodal.enums import (
+    MultimodalModality,
+    NormalizationConfig,
+    NormalizationMethod,
+)
 
 
-@dataclass
 class MultimodalPreprocessor:
-    """Train-aware preparation layer for multimodal time-series models.
+    """Train-aware normalization layer for multimodal time-series bundles."""
 
-    The initial implementation exposes only the raw modality. The public
-    contract is intentionally shaped for adding train-fitted stats/image
-    modalities without changing benchmark data loading.
-
-    ``X`` and ``y`` must already be ``torch.Tensor`` instances. This class
-    only reshapes inputs to ``(batch, channels, timestamps)`` and applies
-    modality-specific normalization.
-    """
-
-    modalities: Sequence[MultimodalModality | str] = (MultimodalModality.raw,)
-    torch_device: Any = "auto"
-    dtype: torch.dtype = torch.float32
-    eps: float = 1e-8
-    transform_params: dict[MultimodalModality | str, dict[str, Any]] = field(
-        default_factory=dict
-    )
-    fitted_statistics_: dict[str, Any] = field(default_factory=dict, init=False)
-    is_fitted_: bool = field(default=False, init=False)
-
-    def __post_init__(self) -> None:
-        self.modalities = tuple(
-            self._normalize_modality(modality) for modality in self.modalities
-        )
-        self.transform_params = {
-            self._normalize_modality(name): dict(params)
-            for name, params in self.transform_params.items()
-        }
-        if self.eps <= 0:
+    def __init__(
+        self,
+        normalization_config: NormalizationConfig | None = None,
+        *,
+        eps: float = 1e-6,
+    ) -> None:
+        if eps <= 0:
             raise ValueError("eps must be positive.")
-        if not self.modalities:
-            raise ValueError("MultimodalPreprocessor requires at least one modality.")
+        self.normalization_config = (
+            normalization_config if normalization_config is not None else {}
+        )
+        self.eps = eps
+        self.fitted_statistics_: dict[str, Any] = {}
+        self.is_fitted_ = False
 
-    def fit(self, X: torch.Tensor, y: torch.Tensor | None = None) -> "MultimodalPreprocessor":
-        del y
-        raw = self._reshape_raw(X)
-        normalized_raw = self._normalize_raw(raw)
-        self.fitted_statistics_ = {
-            "raw": {
-                "normalization": "per_sample_z_norm",
-                "eps": float(self.eps),
-                "train_input_shape": tuple(int(size) for size in raw.shape),
-                "train_output_shape": tuple(int(size) for size in normalized_raw.shape),
+    def fit(self, bundle: MultimodalDataBundle) -> "MultimodalPreprocessor":
+        self._validate_bundle(bundle)
+        self.fitted_statistics_ = {}
+
+        for modality, steps in self.normalization_config.items():
+            current = bundle.modalities[modality]
+            self.fitted_statistics_[modality.value] = {
+                "steps": [step.value for step in steps],
+                "input_shape": tuple(current.shape),
             }
-        }
+            for step in steps:
+                if step is NormalizationMethod.log1p:
+                    current = torch.log1p(current.float().clamp_min(0))
+                elif step is NormalizationMethod.image_standardization:
+                    self._fit_image_standardizer(modality, current)
+                    current = self._apply_image_standardizer(modality, current)
+            self.fitted_statistics_[modality.value]["output_shape"] = tuple(current.shape)
+
         self.is_fitted_ = True
         return self
 
-    def transform(
-        self,
-        X: torch.Tensor,
-        y: torch.Tensor | None = None,
-    ) -> MultimodalDataBundle:
+    def transform(self, bundle: MultimodalDataBundle) -> MultimodalDataBundle:
         if not self.is_fitted_:
             raise ValueError("MultimodalPreprocessor must be fitted before transform.")
+        self._validate_bundle(bundle)
 
-        raw = self._reshape_raw(X)
-        modalities: dict[MultimodalModality, torch.Tensor] = {}
-        if MultimodalModality.raw in self.modalities:
-            modalities[MultimodalModality.raw] = self._normalize_raw(raw)
+        modalities = dict(bundle.modalities)
+        for modality, steps in self.normalization_config.items():
+            current = modalities[modality]
+            for step in steps:
+                if step is NormalizationMethod.log1p:
+                    current = torch.log1p(current.float().clamp_min(0))
+                elif step is NormalizationMethod.image_standardization:
+                    current = self._apply_image_standardizer(modality, current)
+            modalities[modality] = current
 
-        metadata = {
-            "fitted_statistics": deepcopy(self.fitted_statistics_),
-            "transform_params": self._metadata_transform_params(),
-            "preprocessor": {
-                "name": self.__class__.__name__,
-                "modalities": [modality.value for modality in self.modalities],
-                "eps": float(self.eps),
-            },
-        }
         return MultimodalDataBundle(
             modalities=modalities,
-            target=self._validate_target(y, n_samples=raw.shape[0]),
-            metadata=metadata,
+            target=bundle.target,
+            metadata=dict(bundle.metadata),
         )
 
-    def fit_transform(
+    def fit_transform(self, bundle: MultimodalDataBundle) -> MultimodalDataBundle:
+        return self.fit(bundle).transform(bundle)
+
+    def _fit_image_standardizer(
         self,
-        X: torch.Tensor,
-        y: torch.Tensor | None = None,
-    ) -> MultimodalDataBundle:
-        self.fit(X, y)
-        return self.transform(X, y)
-
-    def _reshape_raw(self, values: torch.Tensor) -> torch.Tensor:
-        if not isinstance(values, torch.Tensor):
-            raise TypeError(
-                f"X must be torch.Tensor, got {type(values)}."
-            )
-
-        if values.ndim == 0:
-            raise ValueError("X must contain at least one sample.")
-        if values.shape[0] == 0:
-            raise ValueError("X must contain at least one sample.")
-        if values.ndim == 1:
-            return values.reshape(1, 1, -1)
-        if values.ndim == 2:
-            return values.reshape(values.shape[0], 1, values.shape[1])
-        if values.ndim == 3:
-            return values
-        return values.reshape(
-            values.shape[0],
-            prod(values.shape[1:-1]),
-            values.shape[-1],
-        )
-
-    def _normalize_raw(self, values: torch.Tensor) -> torch.Tensor:
-        mean = values.mean(dim=-1, keepdim=True)
-        std = values.std(dim=-1, keepdim=True, unbiased=False)
-        scale = torch.where(std > self.eps, std, torch.ones_like(std))
-        return (values - mean) / scale
-
-    def _validate_target(
-        self,
-        values: torch.Tensor | None,
-        *,
-        n_samples: int,
-    ) -> torch.Tensor | None:
-        if values is None:
-            return None
-        if not isinstance(values, torch.Tensor):
-            raise TypeError(
-                f"Target must be torch.Tensor or None, got {type(values)}."
-            )
-        if values.ndim == 0:
-            raise ValueError("Target must have sample dimension.")
-        if int(values.shape[0]) != int(n_samples):
+        modality: MultimodalModality,
+        tensor: torch.Tensor,
+    ) -> None:
+        dims = (0, 2, 3) if tensor.ndim == 4 else (0, 1, 2)
+        if tensor.ndim not in (3, 4):
             raise ValueError(
-                "Target and modalities must have the same number of samples. "
-                f"Got target size {int(values.shape[0])}, modalities size {n_samples}."
+                "Image standardization expects a 3D or 4D tensor, "
+                f"got shape={tuple(tensor.shape)}."
             )
-        return values
+        mean = tensor.mean(dim=dims, keepdim=True)
+        std = tensor.std(dim=dims, unbiased=False, keepdim=True).clamp_min(self.eps)
+        self.fitted_statistics_[modality.value]["image_standardization"] = {
+            "mean": mean.detach().clone(),
+            "std": std.detach().clone(),
+            "dims": dims,
+            "eps": float(self.eps),
+        }
 
-    def _metadata_transform_params(self) -> dict[MultimodalModality, dict[str, Any]]:
-        params = {name: dict(values) for name, values in self.transform_params.items()}
-        params.setdefault(
-            MultimodalModality.raw,
-            {
-                "normalization": "per_sample_z_norm",
-                "eps": float(self.eps),
-            },
-        )
-        return params
+    def _apply_image_standardizer(
+        self,
+        modality: MultimodalModality,
+        tensor: torch.Tensor,
+    ) -> torch.Tensor:
+        stats = self.fitted_statistics_[modality.value]["image_standardization"]
+        mean = stats["mean"].to(device=tensor.device, dtype=tensor.dtype)
+        std = stats["std"].to(device=tensor.device, dtype=tensor.dtype)
+        return torch.nan_to_num(((tensor - mean) / std).float())
 
-    @staticmethod
-    def _normalize_modality(value: MultimodalModality | str) -> MultimodalModality:
-        if isinstance(value, MultimodalModality):
-            return value
-        try:
-            return MultimodalModality(str(value))
-        except ValueError as exc:
-            raise ValueError(f"Unsupported multimodal modality: {value!r}") from exc
+    def _validate_bundle(self, bundle: MultimodalDataBundle) -> None:
+        if not isinstance(bundle, MultimodalDataBundle):
+            raise TypeError(
+                f"MultimodalPreprocessor expects MultimodalDataBundle, got {type(bundle)}."
+            )
+        missing = [
+            modality.value
+            for modality in self.normalization_config
+            if modality not in bundle.modalities
+        ]
+        if missing:
+            raise ValueError(
+                f"Bundle does not contain required modalities: {', '.join(missing)}."
+            )

--- a/fedot_ind/core/multimodal/preprocessor.py
+++ b/fedot_ind/core/multimodal/preprocessor.py
@@ -1,13 +1,11 @@
 from typing import Any
 
-import torch
-
 from fedot_ind.core.multimodal.data_bundle import MultimodalDataBundle
 from fedot_ind.core.multimodal.enums import (
     MultimodalModality,
     NormalizationConfig,
-    NormalizationMethod,
 )
+from fedot_ind.core.multimodal.mapping import NORMALIZATION_HANDLERS
 
 
 class MultimodalPreprocessor:
@@ -25,32 +23,29 @@ class MultimodalPreprocessor:
             normalization_config if normalization_config is not None else {}
         )
         self.eps = eps
-        self.fitted_statistics_: dict[str, Any] = {}
+        self._handlers_: dict[str, dict[str, Any]] = {}
         self.is_fitted_ = False
 
     def fit(self, bundle: MultimodalDataBundle) -> "MultimodalPreprocessor":
         self._validate_bundle(bundle)
-        self.fitted_statistics_ = {}
+        self._handlers_ = {}
 
         for modality, steps in self.normalization_config.items():
             current = bundle.modalities[modality]
-            self.fitted_statistics_[modality.value] = {
-                "steps": [step.value for step in steps],
-                "input_shape": tuple(current.shape),
-            }
+            modality_handlers: list[tuple[str, Any]] = []
             for step in steps:
-                if step is NormalizationMethod.imputation:
-                    self._fit_train_mean_imputation(modality, current)
-                    current = self._apply_train_mean_imputation(modality, current)
-                elif step is NormalizationMethod.feature_standardization:
-                    self._fit_feature_standardizer(modality, current)
-                    current = self._apply_feature_standardizer(modality, current)
-                elif step is NormalizationMethod.log1p:
-                    current = torch.log1p(current.float().clamp_min(0))
-                elif step is NormalizationMethod.image_standardization:
-                    self._fit_image_standardizer(modality, current)
-                    current = self._apply_image_standardizer(modality, current)
-            self.fitted_statistics_[modality.value]["output_shape"] = tuple(current.shape)
+                handler_cls = NORMALIZATION_HANDLERS.get(step)
+                if handler_cls is None:
+                    raise ValueError(f"Unsupported normalization step: {step}.")
+                handler = handler_cls(eps=self.eps)
+                handler.fit(current)
+                current = handler.transform(current)
+                modality_handlers.append((step.value, handler))
+            self._handlers_[modality.value] = {
+                "steps": modality_handlers,
+                "input_shape": tuple(bundle.modalities[modality].shape),
+                "output_shape": tuple(current.shape),
+            }
 
         self.is_fitted_ = True
         return self
@@ -63,15 +58,18 @@ class MultimodalPreprocessor:
         modalities = dict(bundle.modalities)
         for modality, steps in self.normalization_config.items():
             current = modalities[modality]
-            for step in steps:
-                if step is NormalizationMethod.imputation:
-                    current = self._apply_train_mean_imputation(modality, current)
-                elif step is NormalizationMethod.feature_standardization:
-                    current = self._apply_feature_standardizer(modality, current)
-                elif step is NormalizationMethod.log1p:
-                    current = torch.log1p(current.float().clamp_min(0))
-                elif step is NormalizationMethod.image_standardization:
-                    current = self._apply_image_standardizer(modality, current)
+            modality_handlers = self._handlers_.get(modality.value)
+            if modality_handlers is None:
+                raise ValueError(
+                    f"Missing fitted handlers for modality '{modality.value}'."
+                )
+            handlers = modality_handlers["steps"]
+            if len(handlers) != len(tuple(steps)):
+                raise ValueError(
+                    f"Handler count mismatch for modality '{modality.value}'."
+                )
+            for _, handler in handlers:
+                current = handler.transform(current)
             modalities[modality] = current
 
         return MultimodalDataBundle(
@@ -83,98 +81,19 @@ class MultimodalPreprocessor:
     def fit_transform(self, bundle: MultimodalDataBundle) -> MultimodalDataBundle:
         return self.fit(bundle).transform(bundle)
 
-    def _fit_train_mean_imputation(
-        self,
-        modality: MultimodalModality,
-        tensor: torch.Tensor,
-    ) -> None:
-        values = tensor.float()
-        if values.ndim < 2:
-            raise ValueError(
-                "Imputation expects at least a 2D tensor (batch, features), "
-                f"got shape={tuple(values.shape)}."
-            )
-        column_mean = self._column_mean_ignore_invalid(values)
-        self.fitted_statistics_[modality.value]["imputation"] = {
-            "column_mean": column_mean.detach().clone(),
-        }
-
-    def _apply_train_mean_imputation(
-        self,
-        modality: MultimodalModality,
-        tensor: torch.Tensor,
-    ) -> torch.Tensor:
-        stats = self.fitted_statistics_[modality.value]["imputation"]
-        column_mean = stats["column_mean"].to(device=tensor.device, dtype=tensor.dtype)
-        values = tensor.float()
-        invalid = ~torch.isfinite(values)
-        return torch.where(invalid, column_mean, values)
-
-    def _fit_feature_standardizer(
-        self,
-        modality: MultimodalModality,
-        tensor: torch.Tensor,
-    ) -> None:
-        values = tensor.float()
-        if values.ndim < 2:
-            raise ValueError(
-                "Feature standardization expects at least a 2D tensor (batch, features), "
-                f"got shape={tuple(values.shape)}."
-            )
-        mean = values.mean(dim=0, keepdim=True)
-        std = values.std(dim=0, unbiased=False, keepdim=True).clamp_min(self.eps)
-        self.fitted_statistics_[modality.value]["feature_standardization"] = {
-            "mean": mean.detach().clone(),
-            "std": std.detach().clone(),
-            "eps": float(self.eps),
-        }
-
-    def _apply_feature_standardizer(
-        self,
-        modality: MultimodalModality,
-        tensor: torch.Tensor,
-    ) -> torch.Tensor:
-        stats = self.fitted_statistics_[modality.value]["feature_standardization"]
-        mean = stats["mean"].to(device=tensor.device, dtype=tensor.dtype)
-        std = stats["std"].to(device=tensor.device, dtype=tensor.dtype)
-        return torch.nan_to_num(((tensor.float() - mean) / std))
-
-    def _fit_image_standardizer(
-        self,
-        modality: MultimodalModality,
-        tensor: torch.Tensor,
-    ) -> None:
-        dims = (0, 2, 3) if tensor.ndim == 4 else (0, 1, 2)
-        if tensor.ndim not in (3, 4):
-            raise ValueError(
-                "Image standardization expects a 3D or 4D tensor, "
-                f"got shape={tuple(tensor.shape)}."
-            )
-        mean = tensor.mean(dim=dims, keepdim=True)
-        std = tensor.std(dim=dims, unbiased=False, keepdim=True).clamp_min(self.eps)
-        self.fitted_statistics_[modality.value]["image_standardization"] = {
-            "mean": mean.detach().clone(),
-            "std": std.detach().clone(),
-            "dims": dims,
-            "eps": float(self.eps),
-        }
-
-    def _apply_image_standardizer(
-        self,
-        modality: MultimodalModality,
-        tensor: torch.Tensor,
-    ) -> torch.Tensor:
-        stats = self.fitted_statistics_[modality.value]["image_standardization"]
-        mean = stats["mean"].to(device=tensor.device, dtype=tensor.dtype)
-        std = stats["std"].to(device=tensor.device, dtype=tensor.dtype)
-        return torch.nan_to_num(((tensor - mean) / std).float())
-
-    @staticmethod
-    def _column_mean_ignore_invalid(tensor: torch.Tensor) -> torch.Tensor:
-        finite = torch.isfinite(tensor)
-        masked = torch.where(finite, tensor, torch.zeros_like(tensor))
-        counts = finite.sum(dim=0, keepdim=True).clamp_min(1)
-        return masked.sum(dim=0, keepdim=True) / counts
+    @property
+    def fitted_statistics_(self) -> dict[str, Any]:
+        statistics: dict[str, Any] = {}
+        for modality, payload in self._handlers_.items():
+            step_entries = payload.get("steps", [])
+            statistics[modality] = {
+                "steps": [step_name for step_name, _ in step_entries],
+                "input_shape": payload.get("input_shape"),
+                "output_shape": payload.get("output_shape"),
+            }
+            for step_name, handler in step_entries:
+                statistics[modality][step_name] = handler.get_state()
+        return statistics
 
     def _validate_bundle(self, bundle: MultimodalDataBundle) -> None:
         if not isinstance(bundle, MultimodalDataBundle):

--- a/fedot_ind/core/operation/transformation/torch_backend/enums.py
+++ b/fedot_ind/core/operation/transformation/torch_backend/enums.py
@@ -1,0 +1,35 @@
+from enum import Enum
+from typing import Dict, Any
+
+
+class StatisticalFeature(Enum):
+    mean = 'mean'
+    median = 'median'
+    std = 'std'
+    max = 'max'
+    min = 'min'
+    q5 = 'q5'
+    q25 = 'q25'
+    q75 = 'q75'
+    q95 = 'q95'
+    skewness = 'skewness'
+    kurtosis = 'kurtosis'
+    n_peaks = 'n_peaks'
+    slope = 'slope'
+    ben_corr = 'ben_corr'
+    interquartile_range = 'interquartile_range'
+    energy = 'energy'
+    cross_rate = 'cross_rate'
+    autocorrelation = 'autocorrelation'
+    ptp_amplitude = 'ptp_amplitude'
+    mean_ptp_distance = 'mean_ptp_distance'
+    crest_factor = 'crest_factor'
+    mean_ema = 'mean_ema'
+    mean_moving_median = 'mean_moving_median'
+    hjorth_mobility = 'hjorth_mobility'
+    hjorth_complexity = 'hjorth_complexity'
+    hurst_exponent = 'hurst_exponent'
+    petrosian_fractal_dimension = 'petrosian_fractal_dimension'
+
+
+STAT_FEATURE_CONFIG = Dict[StatisticalFeature, Dict[str, Any]]

--- a/fedot_ind/core/operation/transformation/torch_backend/image/gaf_transformation.py
+++ b/fedot_ind/core/operation/transformation/torch_backend/image/gaf_transformation.py
@@ -3,10 +3,10 @@ import math
 import torch
 
 from fedot_ind.core.operation.transformation.torch_backend.image.tools import (
-    MinMaxScalerTorch,
     PAA,
     prepare_series_input,
     convert_to_init_dim,
+    per_sample_minmax_scale,
 )
 
 
@@ -33,8 +33,11 @@ class GAF:
             ``image_size`` is derived from ``T`` and ``window_size`` instead
             of taken directly from ``image_size``.
         sample_range (tuple or None, default ``(-1, 1)``): Per-sample min-max
-            scaling range before GAF encoding. If ``None``, input values must
-            already lie in ``[-1, 1]``.
+            scaling range before GAF encoding. If ``None`` and
+            ``use_per_sample_minmax=True``, ``(-1, 1)`` is used.
+        use_per_sample_minmax (bool, default ``True``): If ``True``, apply
+            per-sample min-max scaling before GAF encoding. If ``False``, input
+            values must already lie in ``[-1, 1]``.
         return_init_dim (bool, default ``True``): If ``True``, restore batch/
             channel axes for 3D input ``(B, C, T)`` → ``(B, C, H, W)``.
             For 1D/2D inputs the output batch layout is left unchanged.
@@ -45,6 +48,7 @@ class GAF:
         params = params or {}
         self.window_size = params.get('window_size', None)
         self.sample_range = params.get('sample_range', (-1, 1))
+        self.use_per_sample_minmax = bool(params.get("use_per_sample_minmax", True))
         self.method = params.get('method', 'summation')
         self.image_size = params.get('image_size', 1.)
         self.overlapping = params.get('overlapping', False)
@@ -82,15 +86,18 @@ class GAF:
             overlapping=self.overlapping,
         )
         X_paa = paa.transform(X)
-        if self.sample_range is None:
+        if self.use_per_sample_minmax:
+            feature_range = self.sample_range if self.sample_range is not None else (-1, 1)
+            X_cos = per_sample_minmax_scale(X_paa, feature_range=feature_range, dim=1)
+        else:
             X_min, X_max = torch.min(X_paa), torch.max(X_paa)
             eps = 1e-5
             if (X_min < -1 - eps) or (X_max > 1 + eps):
-                raise ValueError("If 'sample_range' is None, all the values "
-                                 "of X must be between -1 and 1.")
+                raise ValueError(
+                    "If 'use_per_sample_minmax' is False, all the values "
+                    "of X must be between -1 and 1."
+                )
             X_cos = X_paa.clamp(-1.0, 1.0)
-        else:
-            X_cos = MinMaxScalerTorch(X_paa, self.sample_range)
         X_sin = torch.sqrt(torch.clamp(1 - X_cos**2, min=0, max=1))
 
         if method == "gasf":

--- a/fedot_ind/core/operation/transformation/torch_backend/image/tools.py
+++ b/fedot_ind/core/operation/transformation/torch_backend/image/tools.py
@@ -6,17 +6,21 @@ import warnings
 from fedot_ind.core.kernel_learning import resolve_torch_device
 
 
-def MinMaxScalerTorch(X: torch.Tensor,
-                      sample_range: Tuple[float, float] = (-1., 1.)):
-    min_val, max_val = sample_range
+def per_sample_minmax_scale(
+    X: torch.Tensor,
+    *,
+    feature_range: tuple[float, float] = (-1.0, 1.0),
+    dim: int = -1,
+    eps: float = 1e-8,
+) -> torch.Tensor:
+    min_value = X.amin(dim=dim, keepdim=True)
+    max_value = X.amax(dim=dim, keepdim=True)
+    scale = (max_value - min_value).clamp_min(eps)
 
-    X_min = X.min(dim=1, keepdim=True)[0]
-    X_max = X.max(dim=1, keepdim=True)[0]
-    X_max[X_max == X_min] = X_min[X_max == X_min] + 1e-8
-
-    X_scaled = (X - X_min) / (X_max - X_min)
-    X_scaled = X_scaled * (max_val - min_val) + min_val
-    return X_scaled
+    low, high = feature_range
+    X_scaled = (X - min_value) / scale
+    X_scaled = X_scaled * (high - low) + low
+    return torch.nan_to_num(X_scaled)
 
 
 def check_input_shape(X: Any) -> Tuple[torch.Tensor, Tuple[int, ...]]:

--- a/fedot_ind/core/operation/transformation/torch_backend/image/tools.py
+++ b/fedot_ind/core/operation/transformation/torch_backend/image/tools.py
@@ -200,11 +200,13 @@ class PAA:
         """
         if self.window_size == 1:
             return x
-            # start, end = self.segmentation(n_timestamps)
-        # start, end = segmentation_torch(x.shape[-1], self.window_size, self.overlapping, self.output_size)
-        # print("start", start.shape, "end", end.shape)
+
         start, end, _ = segmentation_torch(
-            x.shape[-1], self.window_size, self.overlapping, self.output_size
+            x.shape[-1],
+            self.window_size,
+            self.overlapping,
+            self.output_size,
+            device=x.device,
         )
         return self._paa(x, start, end)
 

--- a/fedot_ind/core/operation/transformation/torch_backend/statistical/quantile_extractor.py
+++ b/fedot_ind/core/operation/transformation/torch_backend/statistical/quantile_extractor.py
@@ -89,7 +89,7 @@ class TorchQuantileExtractor(BaseExtractor):
         else:
             return window_stat_features
 
-    def generate_features_from_ts(self, ts: torch.Tensor) -> torch.Tensor:
+    def generate_features_from_ts(self, ts: torch.Tensor, ) -> torch.Tensor:
         """
         Generate statistical features from a single time series or a batch of time series.
 

--- a/fedot_ind/core/operation/transformation/torch_backend/statistical/quantile_extractor.py
+++ b/fedot_ind/core/operation/transformation/torch_backend/statistical/quantile_extractor.py
@@ -2,7 +2,6 @@ from typing import Optional, Any
 import inspect
 import torch
 
-from fedot.core.data.data import InputData
 from fedot.core.operations.operation_parameters import OperationParameters
 from fedot_ind.core.models.base_extractor import BaseExtractor
 from fedot_ind.core.operation.transformation.data.hankel import HankelMatrix
@@ -113,7 +112,7 @@ class TorchQuantileExtractor(BaseExtractor):
             matrices.append(tensor)
         return torch.cat(matrices, dim=-1)
 
-    def extract_stats_features_torch(self, ts: torch.Tensor, axis: int) -> InputData:
+    def extract_stats_features_torch(self, ts: torch.Tensor, axis: int) -> torch.Tensor:
         """
         This method computes global statistical features and window-based features,
         then concatenates them if `add_global_features` is True.
@@ -152,8 +151,10 @@ class TorchQuantileExtractor(BaseExtractor):
                                                                         window_stat_features.shape[-1] *
                                                                         window_stat_features.shape[-2]).squeeze()
                 else:
-                    window_stat_features = window_stat_features.reshape(window_stat_features.shape[-1] *
-                                                                        window_stat_features.shape[-2]).squeeze()
+                    window_stat_features = window_stat_features.reshape(
+                        window_stat_features.shape[0],
+                        -1,
+                    )
             return torch.cat([global_features, window_stat_features], dim=-1)
         else:
             return window_stat_features
@@ -241,10 +242,7 @@ class TorchQuantileExtractor(BaseExtractor):
 
         """
         if self.is_multichanel:
-            if time_series.ndim == 3:
-                batch = time_series.shape[0]
-                time_series = time_series.reshape(batch, -1)
-            elif time_series.ndim > 3:
+            if time_series.ndim > 3:
                 batch, b, *rest = time_series.shape
                 time_series = time_series.reshape(batch, b, -1)
 
@@ -293,3 +291,7 @@ class TorchQuantileExtractor(BaseExtractor):
             else:
                 merged.append(torch.cat(parts, dim=0))
         return merged
+
+    def transform(self, X: torch.Tensor) -> torch.Tensor:
+        result = self.generate_features_from_ts(X).to(X.device)
+        return torch.nan_to_num(result)

--- a/fedot_ind/core/operation/transformation/torch_backend/statistical/quantile_extractor.py
+++ b/fedot_ind/core/operation/transformation/torch_backend/statistical/quantile_extractor.py
@@ -1,10 +1,30 @@
-from typing import Optional
-
+from typing import Optional, Any
+import inspect
 import torch
+
 from fedot.core.data.data import InputData
 from fedot.core.operations.operation_parameters import OperationParameters
-
 from fedot_ind.core.models.base_extractor import BaseExtractor
+from fedot_ind.core.operation.transformation.data.hankel import HankelMatrix
+from fedot_ind.core.operation.transformation.torch_backend.enums import (
+    STAT_FEATURE_CONFIG,
+    StatisticalFeature,
+)
+from fedot_ind.core.repository.constanst_repository import (
+    STAT_METHODS_GLOBAL_TORCH,
+    STAT_METHODS_TORCH,
+)
+from fedot_ind.core.operation.transformation.torch_backend.statistical.tools import (
+    build_default_feature_config,
+    method_registry,
+    normalize_feature_key,
+)
+
+
+DEFAULT_CONFIG = build_default_feature_config(STAT_METHODS_TORCH)
+DEFAULT_GLOBAL_CONFIG = build_default_feature_config(
+    STAT_METHODS_GLOBAL_TORCH
+)
 
 
 class TorchQuantileExtractor(BaseExtractor):
@@ -22,12 +42,61 @@ class TorchQuantileExtractor(BaseExtractor):
     """
 
     def __init__(self, params: Optional[OperationParameters] = None):
+        params = params or OperationParameters()
         super().__init__(params)
         self.window_size = params.get('window_size', 0)
         self.stride = params.get('stride', 1)
         self.add_global_features = params.get('add_global_features', True)
         self.logging_params.update({'Wsize': self.window_size,
                                     'Stride': self.stride})
+        self.config = self._normalize_feature_config(
+            params.get('stat_feature_config', DEFAULT_CONFIG)
+        )
+        self.global_config = self._normalize_feature_config(
+            params.get('stat_feature_global_config', DEFAULT_GLOBAL_CONFIG)
+        )
+        self._methods_local = method_registry(STAT_METHODS_TORCH)
+        self._methods_global = method_registry(STAT_METHODS_GLOBAL_TORCH)
+
+    @staticmethod
+    def _normalize_feature_config(config: Any) -> STAT_FEATURE_CONFIG:
+        normalized: STAT_FEATURE_CONFIG = {}
+        if not config:
+            return normalized
+        for raw_key, raw_params in dict(config).items():
+            feature = normalize_feature_key(raw_key)
+            normalized[feature] = dict(raw_params or {})
+        return normalized
+
+    @staticmethod
+    def _supports_kwargs(method: callable) -> bool:
+        signature = inspect.signature(method)
+        return any(
+            parameter.kind is inspect.Parameter.VAR_KEYWORD
+            for parameter in signature.parameters.values()
+        )
+
+    @staticmethod
+    def _apply_feature_method(
+        method: callable,
+        time_series: torch.Tensor,
+        axis: int,
+        kwargs: dict[str, Any],
+        supports_kwargs: bool,
+    ):
+        if supports_kwargs:
+            return method(time_series, axis=axis, **kwargs)
+        return method(time_series, axis)
+
+    def _select_methods(self, add_global_features: bool) -> list[tuple[callable, dict[str, Any], bool]]:
+        method_map = self._methods_global if add_global_features else self._methods_local
+        config = self.global_config if add_global_features else self.config
+        selected = []
+        for feature, feature_kwargs in config.items():
+            method = method_map.get(feature)
+            if method is not None:
+                selected.append((method, dict(feature_kwargs), self._supports_kwargs(method)))
+        return selected
 
     @staticmethod
     def _as_feature_matrix(features: list, source: torch.Tensor) -> torch.Tensor:
@@ -106,3 +175,121 @@ class TorchQuantileExtractor(BaseExtractor):
         features = self.extract_stats_features_torch(ts, axis=-1)
         features = torch.nan_to_num(features, nan=0.0, posinf=0.0, neginf=0.0)
         return features.cpu()
+
+    def apply_window_for_stat_feature_torch(self,
+                                            ts_data: torch.Tensor,
+                                            feature_generator: callable,
+                                            window_size: int = None) -> torch.Tensor:
+        """
+        Method for creating windows and extracting base statistical features
+        for a given time series or batch of time series.
+        """
+        axis = ts_data.ndim - 1
+        if window_size is None:
+            window_size = round(ts_data.shape[axis] / 10)
+        else:
+            window_size = round(ts_data.shape[axis] * (window_size / 100))
+        window_size = max(window_size, 5)
+
+        if self.use_sliding_window:
+            if self.stride > 1:
+                subseq_set = HankelMatrix(time_series=ts_data,
+                                          window_size=window_size,
+                                          strides=self.stride).trajectory_matrix
+            else:
+                window_length = ts_data.shape[axis] - window_size
+                subseq_set = ts_data.unfold(
+                    dimension=axis,
+                    size=window_length,
+                    step=self.stride
+                )
+            if subseq_set.ndim > 2:
+                subseq_set = subseq_set.transpose(1, 2)
+            else:
+                subseq_set = subseq_set.T
+        else:
+            T = ts_data.shape[1]
+            num_windows = T // window_size
+            T_eff = num_windows * window_size
+            ts_cut = ts_data[:, :T_eff]
+            subseq_set = ts_cut.reshape(2, num_windows, window_size)
+        features = feature_generator(subseq_set)
+        features = torch.stack(features, dim=0).to(ts_data.device)
+        if features.ndim > 2:
+            features = features.permute(1, 2, 0)
+        else:
+            features = features.T
+        return features
+
+    def get_statistical_features_torch(
+            self,
+            time_series: torch.Tensor,
+            add_global_features: bool = False,
+            axis: int = -1,
+            max_elements: int = 50000000) -> tuple:
+        """
+        Method for creating baseline statistical features for a given time series.
+        Creates batches, if number of values in time series is more than max_elements.
+
+        Args:
+            add_global_features: if True, global features are added to the feature set
+            time_series: time series for which features are generated
+            max_elements: threshold for using batches
+
+        Returns:
+            tuple: features
+
+        """
+        if self.is_multichanel:
+            if time_series.ndim == 3:
+                batch = time_series.shape[0]
+                time_series = time_series.reshape(batch, -1)
+            elif time_series.ndim > 3:
+                batch, b, *rest = time_series.shape
+                time_series = time_series.reshape(batch, b, -1)
+
+        if add_global_features:
+            list_of_methods = self._select_methods(add_global_features=True)
+        else:
+            list_of_methods = self._select_methods(add_global_features=False)
+
+        if time_series.numel() <= max_elements:
+            return [
+                self._apply_feature_method(
+                    method,
+                    time_series,
+                    axis,
+                    kwargs,
+                    supports_kwargs,
+                )
+                for method, kwargs, supports_kwargs in list_of_methods
+            ]
+        B = time_series.shape[0]
+        elems_per_sample = time_series[0].numel()
+        batch_size = max(1, max_elements // elems_per_sample)
+        accumulators = [[] for _ in list_of_methods]
+        for start in range(0, B, batch_size):
+            end = min(start + batch_size, B)
+            ts_batch = time_series[start:end]
+            batch_results = [
+                self._apply_feature_method(
+                    method,
+                    ts_batch,
+                    axis,
+                    kwargs,
+                    supports_kwargs,
+                )
+                for method, kwargs, supports_kwargs in list_of_methods
+            ]
+            for i, res in enumerate(batch_results):
+                accumulators[i].append(res)
+
+        merged = []
+        for parts in accumulators:
+            if isinstance(parts[0], (float, int)):
+                merged.append(
+                    torch.tensor(parts) if isinstance(parts[0], torch.Tensor) else parts
+                )
+            else:
+                merged.append(torch.cat(parts, dim=0))
+        return merged

--- a/fedot_ind/core/operation/transformation/torch_backend/statistical/stat_features.py
+++ b/fedot_ind/core/operation/transformation/torch_backend/statistical/stat_features.py
@@ -145,7 +145,7 @@ def kurtosis_torch(x: torch.Tensor, axis=-1, fisher=True):
     return kurt
 
 
-def n_peaks_torch(X: torch.Tensor, axis=-1):
+def n_peaks_torch(X: torch.Tensor, axis=-1, normalized: bool = False):
     """
     A peak is defined as a point where the signal transitions from increasing to decreasing.
     The function identifies peaks by analyzing sign changes in the first differences of the signal.
@@ -171,12 +171,15 @@ def n_peaks_torch(X: torch.Tensor, axis=-1):
     s[s == 0] = 1
     dd = torch.diff(s, axis=-1)
     n_peaks = torch.count_nonzero(dd == -2, axis=-1)
+    if normalized:
+        n_peaks = n_peaks / x.shape[-1]
     if X.ndim > 2:
         return n_peaks.reshape(*X.shape[:-1])
-    return n_peaks.item() if n_peaks.numel() == 1 else n_peaks
+    else:
+        return n_peaks.item() if n_peaks.numel() == 1 else n_peaks
 
 
-def mean_ptp_distance_torch(X: torch.Tensor, axis=-1):
+def mean_ptp_distance_torch(X: torch.Tensor, axis=-1, normalized: bool = False):
     """
     Peaks are identified as points where the signal transitions from increasing to decreasing.
     The function calculates the average distance (in samples) between these peaks.
@@ -226,6 +229,8 @@ def mean_ptp_distance_torch(X: torch.Tensor, axis=-1):
     diff_peaks = torch.diff(peak_indices, dim=-1)
     diff_peaks[diff_peaks < 0] = 0
     mean_dist = diff_peaks.sum(dim=-1) / count_peaks.float()
+    if normalized:
+        mean_dist = mean_dist / x.shape[-1]
     if X.ndim > 2:
         return mean_dist.reshape(*X.shape[:-1])
     return mean_dist.item() if mean_dist.numel() == 1 else mean_dist

--- a/fedot_ind/core/operation/transformation/torch_backend/statistical/tools.py
+++ b/fedot_ind/core/operation/transformation/torch_backend/statistical/tools.py
@@ -1,0 +1,28 @@
+from typing import Any
+from fedot_ind.core.operation.transformation.torch_backend.enums import (
+    StatisticalFeature,
+    STAT_FEATURE_CONFIG,
+)
+
+
+def normalize_feature_key(key: Any) -> StatisticalFeature:
+    if isinstance(key, StatisticalFeature):
+        return key
+    if hasattr(key, "value"):
+        key = key.value
+    return StatisticalFeature(str(key))
+
+
+def build_default_feature_config(methods: dict) -> STAT_FEATURE_CONFIG:
+    config: STAT_FEATURE_CONFIG = {}
+    for raw_key in methods:
+        feature = normalize_feature_key(raw_key)
+        config[feature] = {}
+    return config
+
+
+def method_registry(methods: dict) -> dict[StatisticalFeature, callable]:
+    registry: dict[StatisticalFeature, callable] = {}
+    for raw_key, method in methods.items():
+        registry[normalize_feature_key(raw_key)] = method
+    return registry

--- a/fedot_ind/core/repository/constanst_repository.py
+++ b/fedot_ind/core/repository/constanst_repository.py
@@ -53,6 +53,8 @@ from fedot_ind.core.operation.transformation.representation.topological.topofeat
     PersistenceDiagramsExtractor, PersistenceEntropyFeature, RadiusAtMaxBNFeature, RelevantHolesNumber, \
     SimultaneousAliveHolesFeature, SumHoleLifetimeFeature
 from fedot_ind.tools.serialisation.path_lib import PROJECT_PATH
+from fedot_ind.core.operation.transformation.torch_backend.enums import StatisticalFeature
+
 
 industrial_model_params_dict = dict(quantile_extractor={'window_size': 10,
                                                         'stride': 1,
@@ -202,16 +204,17 @@ class FeatureConstant(Enum):
         'q75_': q75,
         'q95_': q95
     }
+
     STAT_METHODS_TORCH = {
-        'mean_': mean_torch,
-        'median_': median_torch,
-        'std_': std_torch,
-        'max_': max_torch,
-        'min_': min_torch,
-        'q5_': q5_torch,
-        'q25_': q25_torch,
-        'q75_': q75_torch,
-        'q95_': q95_torch
+        StatisticalFeature.mean: mean_torch,
+        StatisticalFeature.median.value: median_torch,
+        StatisticalFeature.std.value: std_torch,
+        StatisticalFeature.max.value: max_torch,
+        StatisticalFeature.min.value: min_torch,
+        StatisticalFeature.q5.value: q5_torch,
+        StatisticalFeature.q25.value: q25_torch,
+        StatisticalFeature.q75.value: q75_torch,
+        StatisticalFeature.q95.value: q95_torch
     }
 
     BAGGING_METHOD = {
@@ -245,25 +248,24 @@ class FeatureConstant(Enum):
     }
 
     STAT_METHODS_GLOBAL_TORCH = {
-        'skewness_': skewness_torch,
-        'kurtosis_': kurtosis_torch,
-        'n_peaks_': n_peaks_torch,
-        'slope_': slope_torch,
-        'ben_corr_': ben_corr_torch,
-        'interquartile_range_': interquantile_range_torch,
-        'energy_': energy_torch,
-        'cross_rate_': zero_crossing_rate_torch,
-        'autocorrelation_': autocorrelation_torch,
-        'shannon_entropy_': shannon_entropy_torch,
-        'ptp_amplitude_': ptp_amp_torch,
-        'mean_ptp_distance_': mean_ptp_distance_torch,
-        'crest_factor_': crest_factor_torch,
-        'mean_ema_': mean_ema_torch,
-        'mean_moving_median_': mean_moving_median_torch,
-        'hjorth_mobility_': hjorth_mobility_torch,
-        'hjorth_complexity_': hjorth_complexity_torch,
-        'hurst_exponent_': hurst_exponent_torch,
-        'petrosian_fractal_dimension_': pfd_torch
+        StatisticalFeature.skewness: skewness_torch,
+        StatisticalFeature.kurtosis: kurtosis_torch,
+        StatisticalFeature.n_peaks: n_peaks_torch,
+        StatisticalFeature.slope: slope_torch,
+        StatisticalFeature.ben_corr: ben_corr_torch,
+        StatisticalFeature.interquartile_range: interquantile_range_torch,
+        StatisticalFeature.energy: energy_torch,
+        StatisticalFeature.cross_rate: zero_crossing_rate_torch,
+        StatisticalFeature.autocorrelation: autocorrelation_torch,
+        StatisticalFeature.ptp_amplitude: ptp_amp_torch,
+        StatisticalFeature.mean_ptp_distance: mean_ptp_distance_torch,
+        StatisticalFeature.crest_factor: crest_factor_torch,
+        StatisticalFeature.mean_ema: mean_ema_torch,
+        StatisticalFeature.mean_moving_median: mean_moving_median_torch,
+        StatisticalFeature.hjorth_mobility: hjorth_mobility_torch,
+        StatisticalFeature.hjorth_complexity: hjorth_complexity_torch,
+        StatisticalFeature.hurst_exponent: hurst_exponent_torch,
+        StatisticalFeature.petrosian_fractal_dimension: pfd_torch
     }
 
     METRICS_DICT = {'euclidean': euclidean,

--- a/some.py
+++ b/some.py
@@ -1,0 +1,3 @@
+from fedot_ind.core.multimodal.mapping import TRANSFORMATION_HANDLERS
+
+print(TRANSFORMATION_HANDLERS)

--- a/tests/unit/core/multimodal/test_data_bundle.py
+++ b/tests/unit/core/multimodal/test_data_bundle.py
@@ -1,0 +1,50 @@
+import pytest
+import torch
+
+from fedot_ind.core.multimodal.data_bundle import MultimodalDataBundle
+from fedot_ind.core.multimodal.enums import MultimodalModality
+
+
+def test_multimodal_data_bundle_builds_metadata():
+    bundle = MultimodalDataBundle(
+        modalities={
+            MultimodalModality.raw: torch.randn(8, 1, 128),
+            MultimodalModality.stats: torch.randn(8, 10),
+            MultimodalModality.gaf: torch.randn(8, 1, 32, 32),
+            MultimodalModality.stft: torch.randn(8, 1, 16, 20),
+        },
+        target=torch.randint(0, 2, size=(8,)),
+    )
+
+    assert bundle.n_samples == 8
+    assert bundle.metadata["modalities"] == [
+        MultimodalModality.raw,
+        MultimodalModality.stats,
+        MultimodalModality.gaf,
+        MultimodalModality.stft,
+    ]
+    assert bundle.metadata["shapes"][MultimodalModality.raw] == (8, 1, 128)
+    assert bundle.metadata["normalization"][MultimodalModality.raw] == "per_sample_z_norm"
+    assert bundle.metadata["normalization"][MultimodalModality.stats] == "train_mean_std"
+    assert bundle.metadata["device"] == torch.device("cpu")
+    assert bundle.metadata["dtype"] == torch.float32
+
+
+def test_multimodal_data_bundle_checks_sample_consistency():
+    with pytest.raises(ValueError, match="same number of samples"):
+        MultimodalDataBundle(
+            modalities={
+                MultimodalModality.raw: torch.randn(8, 1, 128),
+                MultimodalModality.stats: torch.randn(7, 10),
+            }
+        )
+
+
+def test_multimodal_data_bundle_checks_target_consistency():
+    with pytest.raises(ValueError, match="Target and modalities"):
+        MultimodalDataBundle(
+            modalities={
+                MultimodalModality.raw: torch.randn(8, 1, 128),
+            },
+            target=torch.randint(0, 2, size=(7,)),
+        )

--- a/tests/unit/core/multimodal/test_data_bundle.py
+++ b/tests/unit/core/multimodal/test_data_bundle.py
@@ -24,7 +24,7 @@ def test_multimodal_data_bundle_builds_metadata():
         MultimodalModality.stft,
     ]
     assert bundle.metadata["shapes"][MultimodalModality.raw] == (8, 1, 128)
-    assert bundle.metadata["normalization"][MultimodalModality.raw] == "per_sample_z_norm"
+    assert bundle.metadata["normalization"][MultimodalModality.raw] == "none"
     assert bundle.metadata["normalization"][MultimodalModality.stats] == "train_mean_std"
     assert bundle.metadata["device"] == torch.device("cpu")
     assert bundle.metadata["dtype"] == torch.float32

--- a/tests/unit/core/multimodal/test_preparation.py
+++ b/tests/unit/core/multimodal/test_preparation.py
@@ -1,0 +1,259 @@
+import numpy as np
+import pytest
+import torch
+
+from benchmark.industrial.core import ClassificationDatasetRecord
+from fedot_ind.core.multimodal import (
+    DEFAULT_STAT_FEATURES,
+    MultimodalDatasetPreparer,
+    MultimodalModality,
+    PreparationConfig,
+    StatisticalFeature,
+)
+
+
+def make_record() -> ClassificationDatasetRecord:
+    train_features = tuple(
+        tuple(float(value) for value in row)
+        for row in np.arange(4 * 8, dtype=float).reshape(4, 8)
+    )
+    test_features = tuple(
+        tuple(float(value) for value in row)
+        for row in (np.arange(2 * 8, dtype=float).reshape(2, 8) + 100.0)
+    )
+    return ClassificationDatasetRecord(
+        benchmark="synthetic",
+        dataset_name="TinySynthetic",
+        subset="default",
+        train_features=train_features,
+        train_target=("a", "b", "a", "b"),
+        test_features=test_features,
+        test_target=("a", "b"),
+    )
+
+
+def test_preparer_builds_default_modalities_from_classification_record():
+    record = make_record()
+    preparer = MultimodalDatasetPreparer()
+
+    train_bundle, test_bundle = preparer.prepare_classification_record(record)
+    repeated_test_bundle = preparer.transform(record.test_features, record.test_target)
+
+    assert train_bundle.n_samples == 4
+    assert test_bundle.n_samples == 2
+    assert set(train_bundle.modalities) == {
+        MultimodalModality.raw,
+        MultimodalModality.stats,
+        MultimodalModality.gaf,
+        MultimodalModality.stft,
+    }
+    assert train_bundle.target.tolist() == [0, 1, 0, 1]
+    assert test_bundle.target.tolist() == [0, 1]
+    assert train_bundle.metadata["source"]["kind"] == "ClassificationDatasetRecord"
+    assert train_bundle.metadata["normalization"][MultimodalModality.raw] == "none"
+    assert train_bundle.metadata["transform_params"][MultimodalModality.stats][
+        "feature_names"
+    ] == DEFAULT_STAT_FEATURES
+    assert train_bundle.metadata["transform_params"][MultimodalModality.stft][
+        "window_size"
+    ] == 8
+
+    for modality in test_bundle.modalities:
+        if modality is MultimodalModality.stats:
+            assert torch.allclose(
+                test_bundle.modalities[modality],
+                repeated_test_bundle.modalities[modality],
+                atol=2e-1,
+            )
+        else:
+            assert torch.allclose(
+                test_bundle.modalities[modality],
+                repeated_test_bundle.modalities[modality],
+            )
+
+
+def test_preparer_does_not_update_statistics_on_record_test_transform():
+    record = make_record()
+    preparer = MultimodalDatasetPreparer()
+    preparer.prepare_classification_record(record)
+    stats_before = {
+        modality: {
+            step: {
+                key: value.clone() if isinstance(value, torch.Tensor) else value
+                for key, value in step_stats.items()
+            }
+            for step, step_stats in modality_stats.items()
+            if isinstance(step_stats, dict)
+        }
+        for modality, modality_stats in preparer.preprocessor_.fitted_statistics_.items()
+    }
+
+    preparer.transform(record.test_features, record.test_target)
+
+    for modality, modality_stats in stats_before.items():
+        for step, step_stats in modality_stats.items():
+            current = preparer.preprocessor_.fitted_statistics_[modality][step]
+            for key, expected in step_stats.items():
+                if isinstance(expected, torch.Tensor):
+                    assert torch.equal(current[key], expected)
+                else:
+                    assert current[key] == expected
+
+
+def test_preparer_builds_modalities_from_dataloader_like_object():
+    class FakeLoader:
+        dataset_name = "FakeTiny"
+
+        def load_data(self):
+            train_x = np.arange(3 * 6, dtype=float).reshape(3, 6)
+            test_x = np.arange(2 * 6, dtype=float).reshape(2, 6)
+            return (train_x, np.array([0, 1, 0])), (test_x, np.array([1, 0]))
+
+    config = PreparationConfig(
+        transformation_config={
+            "raw": {"per_sample_z_normalize": False},
+            "stats": {"feature_names": ("mean", "std")},
+        }
+    )
+    preparer = MultimodalDatasetPreparer(config=config)
+
+    train_bundle, test_bundle = preparer.prepare_from_loader(FakeLoader())
+
+    assert train_bundle.metadata["source"]["kind"] == "DataLoader"
+    assert train_bundle.metadata["source"]["dataset_name"] == "FakeTiny"
+    assert train_bundle.modalities[MultimodalModality.raw].shape == (3, 1, 6)
+    assert test_bundle.modalities[MultimodalModality.stats].shape[0] == 2
+
+
+def test_preparer_keeps_raw_unchanged_and_builds_stats_from_input():
+    config = PreparationConfig(
+        normalization_config={},
+        transformation_config={
+            "raw": {"per_sample_z_normalize": False},
+            "stats": {"feature_names": ("mean", "std")},
+        },
+    )
+    preparer = MultimodalDatasetPreparer(config=config)
+    train_x = np.array(
+        [
+            [1.0, 2.0, 3.0],
+            [5.0, 5.0, 5.0],
+        ]
+    )
+
+    bundle = preparer.fit_transform(train_x, np.array([0, 1]))
+
+    assert torch.allclose(
+        bundle.modalities[MultimodalModality.raw],
+        torch.tensor([[[1.0, 2.0, 3.0]], [[5.0, 5.0, 5.0]]]),
+    )
+    assert torch.allclose(
+        bundle.modalities[MultimodalModality.stats],
+        torch.tensor([[2.0, 0.8165], [5.0, 0.0]]),
+        atol=1e-4,
+    )
+    assert bundle.metadata["normalization"][MultimodalModality.raw] == "none"
+
+
+def test_preparer_can_per_sample_z_normalize_before_building_modalities():
+    config = PreparationConfig(
+        normalization_config={},
+        transformation_config={
+            "raw": {"per_sample_z_normalize": True, "per_sample_z_normalize_eps": 1e-6},
+            "stats": {"feature_names": ("mean", "std")},
+        },
+    )
+    preparer = MultimodalDatasetPreparer(config=config)
+    train_x = np.array(
+        [
+            [1.0, 2.0, 3.0],
+            [5.0, 5.0, 5.0],
+        ]
+    )
+
+    bundle = preparer.fit_transform(train_x, np.array([0, 1]))
+
+    assert torch.allclose(
+        bundle.modalities[MultimodalModality.raw][0].mean(dim=-1),
+        torch.zeros(1),
+        atol=1e-6,
+    )
+    assert torch.allclose(
+        bundle.modalities[MultimodalModality.raw][0].std(dim=-1, unbiased=False),
+        torch.ones(1),
+        atol=1e-6,
+    )
+    assert torch.allclose(
+        bundle.modalities[MultimodalModality.raw][1],
+        torch.zeros(1, 3),
+        atol=1e-6,
+    )
+    assert torch.allclose(
+        bundle.modalities[MultimodalModality.stats],
+        torch.tensor([[0.0, 1.0], [0.0, 0.0]]),
+        atol=1e-6,
+    )
+    assert (
+        bundle.metadata["transform_params"][MultimodalModality.raw][
+            "per_sample_z_normalize"
+        ]
+        is True
+    )
+    assert bundle.metadata["normalization"][MultimodalModality.raw] == "per_sample_z_norm"
+
+
+def test_preparer_handles_short_constant_multichannel_series():
+    train_x = np.ones((3, 2, 2), dtype=float)
+    test_x = np.full((2, 2, 2), 5.0, dtype=float)
+    preparer = MultimodalDatasetPreparer()
+
+    train_bundle, test_bundle = preparer.prepare_train_test(
+        (train_x, np.array([0, 1, 0])),
+        (test_x, np.array([1, 0])),
+    )
+
+    assert train_bundle.modalities[MultimodalModality.raw].shape == (3, 2, 2)
+    assert train_bundle.modalities[MultimodalModality.gaf].shape == (3, 2, 2, 2)
+    assert train_bundle.modalities[MultimodalModality.stats].shape == (
+        3,
+        2 * len(DEFAULT_STAT_FEATURES),
+    )
+    assert train_bundle.metadata["transform_params"][MultimodalModality.stft][
+        "window_size"
+    ] == 2
+    assert torch.allclose(
+        train_bundle.modalities[MultimodalModality.raw],
+        torch.ones_like(train_bundle.modalities[MultimodalModality.raw]),
+    )
+    for bundle in (train_bundle, test_bundle):
+        for tensor in bundle.modalities.values():
+            assert torch.isfinite(tensor).all()
+
+
+def test_preparer_rejects_inconsistent_target_size():
+    preparer = MultimodalDatasetPreparer(
+        config=PreparationConfig(
+            transformation_config={"raw": {"per_sample_z_normalize": False}}
+        )
+    )
+
+    with pytest.raises(ValueError, match="Target and modalities"):
+        preparer.fit_transform(np.zeros((3, 4)), np.array([0, 1]))
+
+
+def test_preparer_accepts_stats_features_from_enum():
+    config = PreparationConfig(
+        normalization_config={},
+        transformation_config={
+            "raw": {"per_sample_z_normalize": False},
+            "stats": {
+                "feature_names": (
+                    StatisticalFeature.mean,
+                    StatisticalFeature.std,
+                )
+            },
+        },
+    )
+    preparer = MultimodalDatasetPreparer(config=config)
+    bundle = preparer.fit_transform(np.array([[1.0, 2.0, 3.0]]), np.array([0]))
+    assert bundle.modalities[MultimodalModality.stats].shape == (1, 2)

--- a/tests/unit/core/multimodal/test_preparation.py
+++ b/tests/unit/core/multimodal/test_preparation.py
@@ -144,11 +144,11 @@ def test_preparer_keeps_raw_unchanged_and_builds_stats_from_input():
     bundle = preparer.fit_transform(train_x, np.array([0, 1]))
 
     assert torch.allclose(
-        bundle.modalities[MultimodalModality.raw],
+        bundle.modalities[MultimodalModality.raw].cpu(),
         torch.tensor([[[1.0, 2.0, 3.0]], [[5.0, 5.0, 5.0]]]),
     )
     assert torch.allclose(
-        bundle.modalities[MultimodalModality.stats],
+        bundle.modalities[MultimodalModality.stats].cpu(),
         torch.tensor([[2.0, 0.8165], [5.0, 0.0]]),
         atol=1e-4,
     )
@@ -174,22 +174,22 @@ def test_preparer_can_per_sample_z_normalize_before_building_modalities():
     bundle = preparer.fit_transform(train_x, np.array([0, 1]))
 
     assert torch.allclose(
-        bundle.modalities[MultimodalModality.raw][0].mean(dim=-1),
+        bundle.modalities[MultimodalModality.raw][0].mean(dim=-1).cpu(),
         torch.zeros(1),
         atol=1e-6,
     )
     assert torch.allclose(
-        bundle.modalities[MultimodalModality.raw][0].std(dim=-1, unbiased=False),
+        bundle.modalities[MultimodalModality.raw][0].std(dim=-1, unbiased=False).cpu(),
         torch.ones(1),
         atol=1e-6,
     )
     assert torch.allclose(
-        bundle.modalities[MultimodalModality.raw][1],
+        bundle.modalities[MultimodalModality.raw][1].cpu(),
         torch.zeros(1, 3),
         atol=1e-6,
     )
     assert torch.allclose(
-        bundle.modalities[MultimodalModality.stats],
+        bundle.modalities[MultimodalModality.stats].cpu(),
         torch.tensor([[0.0, 1.0], [0.0, 0.0]]),
         atol=1e-6,
     )

--- a/tests/unit/core/multimodal/test_preprocessor.py
+++ b/tests/unit/core/multimodal/test_preprocessor.py
@@ -1,0 +1,98 @@
+from copy import deepcopy
+
+import pytest
+import torch
+
+from fedot_ind.core.multimodal import (
+    MultimodalDataBundle,
+    MultimodalModality,
+    MultimodalPreprocessor,
+)
+
+
+def test_multimodal_preprocessor_builds_raw_bundle_metadata():
+    X = torch.tensor(
+        [
+            [0.0, 1.0, 2.0, 3.0],
+            [2.0, 4.0, 6.0, 8.0],
+            [3.0, 3.5, 4.0, 4.5],
+        ]
+    )
+    y = torch.tensor([0, 1, 0])
+
+    bundle = MultimodalPreprocessor().fit_transform(X, y)
+
+    assert isinstance(bundle, MultimodalDataBundle)
+    assert bundle.n_samples == 3
+    assert bundle.target.tolist() == [0, 1, 0]
+    assert bundle.metadata["modalities"] == [MultimodalModality.raw]
+    assert bundle.metadata["shapes"][MultimodalModality.raw] == (3, 1, 4)
+    assert bundle.metadata["normalization"][MultimodalModality.raw] == "per_sample_z_norm"
+    assert bundle.metadata["transform_params"][MultimodalModality.raw]["eps"] == 1e-8
+    assert bundle.metadata["fitted_statistics"]["raw"]["train_input_shape"] == (3, 1, 4)
+
+    raw = bundle.modalities[MultimodalModality.raw]
+    assert torch.allclose(raw.mean(dim=-1), torch.zeros(3, 1), atol=1e-6)
+    assert torch.allclose(raw.std(dim=-1, unbiased=False), torch.ones(3, 1), atol=1e-6)
+
+
+def test_multimodal_preprocessor_does_not_update_statistics_on_transform():
+    train = torch.tensor([[0.0, 1.0, 2.0], [10.0, 11.0, 12.0]])
+    test = torch.tensor([[100.0, 101.0, 102.0]])
+    preprocessor = MultimodalPreprocessor().fit(train)
+    train_statistics = deepcopy(preprocessor.fitted_statistics_)
+
+    bundle = preprocessor.transform(test)
+
+    assert preprocessor.fitted_statistics_ == train_statistics
+    assert bundle.metadata["fitted_statistics"] == train_statistics
+    raw = bundle.modalities[MultimodalModality.raw]
+    assert raw.shape == (1, 1, 3)
+    assert torch.allclose(raw.mean(dim=-1), torch.zeros(1, 1), atol=1e-6)
+
+
+def test_multimodal_preprocessor_handles_constant_and_short_series():
+    X = torch.tensor([[5.0], [5.0]])
+
+    bundle = MultimodalPreprocessor().fit_transform(X)
+    raw = bundle.modalities[MultimodalModality.raw]
+
+    assert raw.shape == (2, 1, 1)
+    assert torch.all(torch.isfinite(raw))
+    assert torch.allclose(raw, torch.zeros_like(raw))
+
+
+def test_multimodal_preprocessor_preserves_multichannel_layout():
+    X = torch.arange(24, dtype=torch.float32).reshape(2, 3, 4)
+
+    bundle = MultimodalPreprocessor().fit_transform(X)
+    raw = bundle.modalities[MultimodalModality.raw]
+
+    assert raw.shape == (2, 3, 4)
+    assert bundle.metadata["shapes"][MultimodalModality.raw] == (2, 3, 4)
+    assert torch.allclose(raw.mean(dim=-1), torch.zeros(2, 3), atol=1e-6)
+    assert torch.allclose(raw.std(dim=-1, unbiased=False), torch.ones(2, 3), atol=1e-6)
+
+
+def test_multimodal_preprocessor_checks_target_sample_consistency():
+    with pytest.raises(ValueError, match="Target and modalities"):
+        MultimodalPreprocessor().fit_transform(
+            torch.tensor([[0.0, 1.0], [1.0, 2.0]]),
+            torch.tensor([0]),
+        )
+
+
+def test_multimodal_preprocessor_rejects_unfitted_transform():
+    with pytest.raises(ValueError, match="must be fitted"):
+        MultimodalPreprocessor().transform(torch.tensor([[0.0, 1.0]]))
+
+
+def test_multimodal_preprocessor_rejects_non_tensor_input():
+    with pytest.raises(TypeError, match="X must be torch.Tensor"):
+        MultimodalPreprocessor().fit([[0.0, 1.0]])
+
+    with pytest.raises(TypeError, match="Target must be torch.Tensor"):
+        MultimodalPreprocessor().fit_transform(
+            torch.tensor([[0.0, 1.0]]),
+            [0],
+        )

--- a/tests/unit/core/multimodal/test_preprocessor.py
+++ b/tests/unit/core/multimodal/test_preprocessor.py
@@ -1,98 +1,157 @@
-from copy import deepcopy
-
 import pytest
 import torch
 
-from fedot_ind.core.multimodal import (
-    MultimodalDataBundle,
-    MultimodalModality,
-    MultimodalPreprocessor,
-)
+from fedot_ind.core.multimodal.data_bundle import MultimodalDataBundle
+from fedot_ind.core.multimodal.enums import MultimodalModality, NormalizationMethod
+from fedot_ind.core.multimodal.preprocessor import MultimodalPreprocessor
 
 
-def test_multimodal_preprocessor_builds_raw_bundle_metadata():
-    X = torch.tensor(
+def make_bundle(
+    *,
+    raw: torch.Tensor | None = None,
+    gaf: torch.Tensor | None = None,
+    stft: torch.Tensor | None = None,
+    target: torch.Tensor | None = None,
+) -> MultimodalDataBundle:
+    modalities = {}
+    if raw is not None:
+        modalities[MultimodalModality.raw] = raw
+    if gaf is not None:
+        modalities[MultimodalModality.gaf] = gaf
+    if stft is not None:
+        modalities[MultimodalModality.stft] = stft
+    return MultimodalDataBundle(modalities=modalities, target=target)
+
+
+def test_multimodal_preprocessor_keeps_raw_unchanged():
+    raw = torch.tensor(
         [
-            [0.0, 1.0, 2.0, 3.0],
-            [2.0, 4.0, 6.0, 8.0],
-            [3.0, 3.5, 4.0, 4.5],
-        ]
+            [[-1.0, 0.0, 1.0]],
+            [[1.0, 0.0, -1.0]],
+        ],
     )
-    y = torch.tensor([0, 1, 0])
+    target = torch.tensor([0, 1])
+    source = make_bundle(raw=raw, target=target)
 
-    bundle = MultimodalPreprocessor().fit_transform(X, y)
+    preprocessor = MultimodalPreprocessor()
+    bundle = preprocessor.fit_transform(source)
 
     assert isinstance(bundle, MultimodalDataBundle)
-    assert bundle.n_samples == 3
-    assert bundle.target.tolist() == [0, 1, 0]
+    assert bundle.n_samples == 2
+    assert bundle.target is target
     assert bundle.metadata["modalities"] == [MultimodalModality.raw]
-    assert bundle.metadata["shapes"][MultimodalModality.raw] == (3, 1, 4)
+    assert bundle.metadata["shapes"][MultimodalModality.raw] == (2, 1, 3)
     assert bundle.metadata["normalization"][MultimodalModality.raw] == "per_sample_z_norm"
-    assert bundle.metadata["transform_params"][MultimodalModality.raw]["eps"] == 1e-8
-    assert bundle.metadata["fitted_statistics"]["raw"]["train_input_shape"] == (3, 1, 4)
+    assert "fitted_statistics" not in bundle.metadata
+    assert preprocessor.fitted_statistics_ == {}
+    assert torch.equal(bundle.modalities[MultimodalModality.raw], raw)
 
-    raw = bundle.modalities[MultimodalModality.raw]
-    assert torch.allclose(raw.mean(dim=-1), torch.zeros(3, 1), atol=1e-6)
-    assert torch.allclose(raw.std(dim=-1, unbiased=False), torch.ones(3, 1), atol=1e-6)
+
+def test_multimodal_preprocessor_standardizes_gaf_images_with_train_statistics():
+    train_gaf = torch.arange(2 * 1 * 3 * 4, dtype=torch.float32).reshape(2, 1, 3, 4)
+    test_gaf = train_gaf + 100.0
+    preprocessor = MultimodalPreprocessor(
+        normalization_config={
+            MultimodalModality.gaf: [NormalizationMethod.image_standardization],
+        }
+    )
+
+    train_bundle = preprocessor.fit_transform(make_bundle(gaf=train_gaf))
+    test_bundle = preprocessor.transform(make_bundle(gaf=test_gaf))
+
+    train_normalized = train_bundle.modalities[MultimodalModality.gaf]
+    test_normalized = test_bundle.modalities[MultimodalModality.gaf]
+    stats = preprocessor.fitted_statistics_["gaf"]["image_standardization"]
+
+    assert stats["mean"].shape == (1, 1, 1, 1)
+    assert stats["std"].shape == (1, 1, 1, 1)
+    assert torch.allclose(train_normalized.mean(dim=(0, 2, 3)), torch.zeros(1), atol=1e-6)
+    assert torch.allclose(
+        train_normalized.std(dim=(0, 2, 3), unbiased=False),
+        torch.ones(1),
+        atol=1e-6,
+    )
+    expected_test = torch.nan_to_num(((test_gaf - stats["mean"]) / stats["std"]).float())
+    assert torch.allclose(test_normalized, expected_test)
+    assert "fitted_statistics" not in train_bundle.metadata
+
+
+def test_multimodal_preprocessor_applies_stft_log1p_before_image_standardization():
+    train_stft = torch.arange(1, 1 + 2 * 1 * 3 * 4, dtype=torch.float32).reshape(2, 1, 3, 4)
+    test_stft = train_stft + 10.0
+    preprocessor = MultimodalPreprocessor(
+        normalization_config={
+            MultimodalModality.stft: [
+                NormalizationMethod.log1p,
+                NormalizationMethod.image_standardization,
+            ],
+        }
+    )
+
+    train_bundle = preprocessor.fit_transform(make_bundle(stft=train_stft))
+    test_bundle = preprocessor.transform(make_bundle(stft=test_stft))
+
+    stats = preprocessor.fitted_statistics_["stft"]["image_standardization"]
+    log_train = torch.log1p(train_stft.float().clamp_min(0))
+    expected_train = torch.nan_to_num(((log_train - stats["mean"]) / stats["std"]).float())
+    log_test = torch.log1p(test_stft.float().clamp_min(0))
+    expected_test = torch.nan_to_num(((log_test - stats["mean"]) / stats["std"]).float())
+
+    assert preprocessor.fitted_statistics_["stft"]["steps"] == [
+        "log1p",
+        "image_standardization",
+    ]
+    assert torch.allclose(train_bundle.modalities[MultimodalModality.stft], expected_train)
+    assert torch.allclose(test_bundle.modalities[MultimodalModality.stft], expected_test)
 
 
 def test_multimodal_preprocessor_does_not_update_statistics_on_transform():
-    train = torch.tensor([[0.0, 1.0, 2.0], [10.0, 11.0, 12.0]])
-    test = torch.tensor([[100.0, 101.0, 102.0]])
-    preprocessor = MultimodalPreprocessor().fit(train)
-    train_statistics = deepcopy(preprocessor.fitted_statistics_)
+    train_gaf = torch.arange(2 * 1 * 2 * 2, dtype=torch.float32).reshape(2, 1, 2, 2)
+    test_gaf = train_gaf + 100.0
+    preprocessor = MultimodalPreprocessor(
+        normalization_config={
+            MultimodalModality.gaf: [NormalizationMethod.image_standardization],
+        }
+    ).fit(make_bundle(gaf=train_gaf))
+    train_mean = preprocessor.fitted_statistics_["gaf"]["image_standardization"]["mean"].clone()
+    train_std = preprocessor.fitted_statistics_["gaf"]["image_standardization"]["std"].clone()
 
-    bundle = preprocessor.transform(test)
+    preprocessor.transform(make_bundle(gaf=test_gaf))
 
-    assert preprocessor.fitted_statistics_ == train_statistics
-    assert bundle.metadata["fitted_statistics"] == train_statistics
-    raw = bundle.modalities[MultimodalModality.raw]
-    assert raw.shape == (1, 1, 3)
-    assert torch.allclose(raw.mean(dim=-1), torch.zeros(1, 1), atol=1e-6)
-
-
-def test_multimodal_preprocessor_handles_constant_and_short_series():
-    X = torch.tensor([[5.0], [5.0]])
-
-    bundle = MultimodalPreprocessor().fit_transform(X)
-    raw = bundle.modalities[MultimodalModality.raw]
-
-    assert raw.shape == (2, 1, 1)
-    assert torch.all(torch.isfinite(raw))
-    assert torch.allclose(raw, torch.zeros_like(raw))
+    stats = preprocessor.fitted_statistics_["gaf"]["image_standardization"]
+    assert torch.equal(stats["mean"], train_mean)
+    assert torch.equal(stats["std"], train_std)
 
 
-def test_multimodal_preprocessor_preserves_multichannel_layout():
-    X = torch.arange(24, dtype=torch.float32).reshape(2, 3, 4)
+def test_multimodal_preprocessor_supports_configured_steps():
+    stft = torch.arange(1, 1 + 2 * 1 * 2 * 2, dtype=torch.float32).reshape(2, 1, 2, 2)
+    preprocessor = MultimodalPreprocessor(
+        normalization_config={MultimodalModality.stft: [NormalizationMethod.log1p]},
+    )
 
-    bundle = MultimodalPreprocessor().fit_transform(X)
-    raw = bundle.modalities[MultimodalModality.raw]
+    bundle = preprocessor.fit_transform(make_bundle(stft=stft))
 
-    assert raw.shape == (2, 3, 4)
-    assert bundle.metadata["shapes"][MultimodalModality.raw] == (2, 3, 4)
-    assert torch.allclose(raw.mean(dim=-1), torch.zeros(2, 3), atol=1e-6)
-    assert torch.allclose(raw.std(dim=-1, unbiased=False), torch.ones(2, 3), atol=1e-6)
-
-
-def test_multimodal_preprocessor_checks_target_sample_consistency():
-    with pytest.raises(ValueError, match="Target and modalities"):
-        MultimodalPreprocessor().fit_transform(
-            torch.tensor([[0.0, 1.0], [1.0, 2.0]]),
-            torch.tensor([0]),
-        )
+    assert torch.allclose(
+        bundle.modalities[MultimodalModality.stft],
+        torch.log1p(stft.float().clamp_min(0)),
+    )
+    assert "image_standardization" not in preprocessor.fitted_statistics_["stft"]
 
 
 def test_multimodal_preprocessor_rejects_unfitted_transform():
     with pytest.raises(ValueError, match="must be fitted"):
-        MultimodalPreprocessor().transform(torch.tensor([[0.0, 1.0]]))
+        MultimodalPreprocessor().transform(make_bundle(raw=torch.randn(2, 1, 4)))
 
 
-def test_multimodal_preprocessor_rejects_non_tensor_input():
-    with pytest.raises(TypeError, match="X must be torch.Tensor"):
-        MultimodalPreprocessor().fit([[0.0, 1.0]])
+def test_multimodal_preprocessor_rejects_non_bundle_input():
+    with pytest.raises(TypeError, match="MultimodalDataBundle"):
+        MultimodalPreprocessor().fit(torch.randn(2, 1, 4))
 
-    with pytest.raises(TypeError, match="Target must be torch.Tensor"):
-        MultimodalPreprocessor().fit_transform(
-            torch.tensor([[0.0, 1.0]]),
-            [0],
-        )
+
+def test_multimodal_preprocessor_requires_configured_modalities():
+    with pytest.raises(ValueError, match="required modalities"):
+        MultimodalPreprocessor(
+            normalization_config={
+                MultimodalModality.gaf: [NormalizationMethod.image_standardization],
+            }
+        ).fit(make_bundle(raw=torch.randn(2, 1, 4)))

--- a/tests/unit/core/multimodal/test_preprocessor.py
+++ b/tests/unit/core/multimodal/test_preprocessor.py
@@ -9,6 +9,7 @@ from fedot_ind.core.multimodal.preprocessor import MultimodalPreprocessor
 def make_bundle(
     *,
     raw: torch.Tensor | None = None,
+    stats: torch.Tensor | None = None,
     gaf: torch.Tensor | None = None,
     stft: torch.Tensor | None = None,
     target: torch.Tensor | None = None,
@@ -16,6 +17,8 @@ def make_bundle(
     modalities = {}
     if raw is not None:
         modalities[MultimodalModality.raw] = raw
+    if stats is not None:
+        modalities[MultimodalModality.stats] = stats
     if gaf is not None:
         modalities[MultimodalModality.gaf] = gaf
     if stft is not None:
@@ -136,6 +139,119 @@ def test_multimodal_preprocessor_supports_configured_steps():
         torch.log1p(stft.float().clamp_min(0)),
     )
     assert "image_standardization" not in preprocessor.fitted_statistics_["stft"]
+
+
+def test_multimodal_preprocessor_imputes_stats_with_train_column_means():
+    train_stats = torch.tensor(
+        [
+            [1.0, float("nan")],
+            [3.0, 4.0],
+        ]
+    )
+    test_stats = torch.tensor(
+        [
+            [float("inf"), 10.0],
+            [5.0, float("nan")],
+        ]
+    )
+    preprocessor = MultimodalPreprocessor(
+        normalization_config={
+            MultimodalModality.stats: [NormalizationMethod.imputation],
+        }
+    )
+
+    train_bundle = preprocessor.fit_transform(make_bundle(stats=train_stats))
+    test_bundle = preprocessor.transform(make_bundle(stats=test_stats))
+    column_mean = preprocessor.fitted_statistics_["stats"]["imputation"]["column_mean"]
+
+    assert torch.allclose(column_mean, torch.tensor([[2.0, 4.0]]))
+    assert torch.allclose(
+        train_bundle.modalities[MultimodalModality.stats],
+        torch.tensor([[1.0, 4.0], [3.0, 4.0]]),
+    )
+    assert torch.allclose(
+        test_bundle.modalities[MultimodalModality.stats],
+        torch.tensor([[2.0, 10.0], [5.0, 4.0]]),
+    )
+
+
+def test_multimodal_preprocessor_standardizes_stats_per_feature_with_train_statistics():
+    train_stats = torch.tensor([[0.0, 2.0], [2.0, 6.0]])
+    test_stats = torch.tensor([[4.0, 10.0]])
+    preprocessor = MultimodalPreprocessor(
+        normalization_config={
+            MultimodalModality.stats: [NormalizationMethod.feature_standardization],
+        }
+    )
+
+    train_bundle = preprocessor.fit_transform(make_bundle(stats=train_stats))
+    test_bundle = preprocessor.transform(make_bundle(stats=test_stats))
+    stats = preprocessor.fitted_statistics_["stats"]["feature_standardization"]
+
+    assert torch.allclose(stats["mean"], torch.tensor([[1.0, 4.0]]))
+    assert torch.allclose(stats["std"], torch.tensor([[1.0, 2.0]]))
+    assert torch.allclose(
+        train_bundle.modalities[MultimodalModality.stats],
+        torch.tensor([[-1.0, -1.0], [1.0, 1.0]]),
+    )
+    expected_test = torch.tensor([[3.0, 3.0]])
+    assert torch.allclose(test_bundle.modalities[MultimodalModality.stats], expected_test)
+
+
+def test_multimodal_preprocessor_applies_stats_imputation_before_feature_standardization():
+    train_stats = torch.tensor(
+        [
+            [1.0, float("nan")],
+            [3.0, 5.0],
+            [5.0, 1.0],
+        ]
+    )
+    test_stats = torch.tensor([[float("inf"), 9.0]])
+    preprocessor = MultimodalPreprocessor(
+        normalization_config={
+            MultimodalModality.stats: [
+                NormalizationMethod.imputation,
+                NormalizationMethod.feature_standardization,
+            ],
+        }
+    )
+
+    train_bundle = preprocessor.fit_transform(make_bundle(stats=train_stats))
+    test_bundle = preprocessor.transform(make_bundle(stats=test_stats))
+
+    imputed_train = torch.tensor([[1.0, 3.0], [3.0, 5.0], [5.0, 1.0]])
+    mean = imputed_train.mean(dim=0, keepdim=True)
+    std = imputed_train.std(dim=0, unbiased=False, keepdim=True)
+    expected_train = (imputed_train - mean) / std
+    imputed_test = torch.tensor([[3.0, 9.0]])
+    expected_test = (imputed_test - mean) / std
+
+    assert torch.allclose(
+        train_bundle.modalities[MultimodalModality.stats],
+        expected_train,
+    )
+    assert torch.allclose(
+        test_bundle.modalities[MultimodalModality.stats],
+        expected_test,
+    )
+
+
+def test_multimodal_preprocessor_does_not_update_stats_statistics_on_transform():
+    train_stats = torch.tensor([[0.0, 2.0], [2.0, 6.0]])
+    test_stats = torch.tensor([[4.0, 10.0]])
+    preprocessor = MultimodalPreprocessor(
+        normalization_config={
+            MultimodalModality.stats: [NormalizationMethod.feature_standardization],
+        }
+    ).fit(make_bundle(stats=train_stats))
+    train_mean = preprocessor.fitted_statistics_["stats"]["feature_standardization"]["mean"].clone()
+    train_std = preprocessor.fitted_statistics_["stats"]["feature_standardization"]["std"].clone()
+
+    preprocessor.transform(make_bundle(stats=test_stats))
+
+    stats = preprocessor.fitted_statistics_["stats"]["feature_standardization"]
+    assert torch.equal(stats["mean"], train_mean)
+    assert torch.equal(stats["std"], train_std)
 
 
 def test_multimodal_preprocessor_rejects_unfitted_transform():

--- a/tests/unit/core/multimodal/test_preprocessor.py
+++ b/tests/unit/core/multimodal/test_preprocessor.py
@@ -44,7 +44,7 @@ def test_multimodal_preprocessor_keeps_raw_unchanged():
     assert bundle.target is target
     assert bundle.metadata["modalities"] == [MultimodalModality.raw]
     assert bundle.metadata["shapes"][MultimodalModality.raw] == (2, 1, 3)
-    assert bundle.metadata["normalization"][MultimodalModality.raw] == "per_sample_z_norm"
+    assert bundle.metadata["normalization"][MultimodalModality.raw] == "none"
     assert "fitted_statistics" not in bundle.metadata
     assert preprocessor.fitted_statistics_ == {}
     assert torch.equal(bundle.modalities[MultimodalModality.raw], raw)

--- a/tests/unit/core/operation/transformation/test_quantile_extractor.py
+++ b/tests/unit/core/operation/transformation/test_quantile_extractor.py
@@ -6,12 +6,41 @@ import itertools
 import logging
 from fedot_ind.core.operation.transformation.representation.statistical.quantile_extractor import QuantileExtractor
 from fedot_ind.core.operation.transformation.torch_backend.statistical.quantile_extractor import TorchQuantileExtractor
+from fedot_ind.core.operation.transformation.torch_backend.enums import StatisticalFeature
+from fedot_ind.core.operation.transformation.torch_backend.statistical.stat_features import (
+    q25_torch,
+    q75_torch,
+    n_peaks_torch,
+)
 from fedot.core.operations.operation_parameters import OperationParameters
 from tests.unit.api.fixtures import warm_up_cuda_computations
 from fedot_ind.tools.synthetic.ts_datasets_generator import TimeSeriesDatasetsGenerator
 
 
 logger = logging.getLogger(__name__)
+
+
+def test_torch_quantile_extractor_applies_stat_feature_config():
+    params = OperationParameters(
+        stat_feature_config={
+            StatisticalFeature.q25: {},
+            StatisticalFeature.q75: {},
+        },
+        stat_feature_global_config={
+            StatisticalFeature.n_peaks: {"normalized": True},
+        },
+    )
+    extractor = TorchQuantileExtractor(params)
+    ts = torch.tensor([[1.0, 2.0, 3.0, 4.0], [4.0, 3.0, 2.0, 1.0]])
+
+    local = extractor.get_statistical_features_torch(ts, add_global_features=False, axis=-1)
+    global_ = extractor.get_statistical_features_torch(ts, add_global_features=True, axis=-1)
+
+    assert len(local) == 2
+    assert torch.allclose(local[0], q25_torch(ts, axis=-1))
+    assert torch.allclose(local[1], q75_torch(ts, axis=-1))
+    assert len(global_) == 1
+    assert torch.allclose(global_[0], n_peaks_torch(ts, axis=-1, normalized=True))
 
 
 def test_stat_extractor(length=10000, window_size=10, stride=2, add_global_features=True):

--- a/tests/unit/core/operation/transformation/torch_backend/test_image_methods.py
+++ b/tests/unit/core/operation/transformation/torch_backend/test_image_methods.py
@@ -159,6 +159,25 @@ class TestGAF:
         out = gaf.transform(torch.randn(B, T))
         assert out.shape == (B, T // 2, T // 2)
 
+    def test_per_sample_minmax_handles_unnormalized_input_by_default(self):
+        gaf = GAF({"image_size": IMAGE_SIDE, "torch_device": "cpu"})
+        out = gaf.transform(torch.randn(B, T) * 10.0 + 100.0)
+        assert out.shape == (B, IMAGE_SIDE, IMAGE_SIDE)
+        assert_finite(out)
+
+    def test_can_disable_per_sample_minmax_for_pre_normalized_input(self):
+        gaf = GAF(
+            {
+                "image_size": IMAGE_SIDE,
+                "use_per_sample_minmax": False,
+                "torch_device": "cpu",
+            }
+        )
+
+        assert_finite(gaf.transform(torch.linspace(-1.0, 1.0, T).repeat(B, 1)))
+        with pytest.raises(ValueError, match="use_per_sample_minmax"):
+            gaf.transform(torch.randn(B, T) * 10.0)
+
     def test_config_not_mutated_on_repeated_transform(self):
         gaf = GAF({"image_size": 0.5, "torch_device": "cpu"})
         out_short = gaf.transform(torch.randn(2, 100))

--- a/tests/unit/models/test_benchmark_industrial_tasks.py
+++ b/tests/unit/models/test_benchmark_industrial_tasks.py
@@ -48,6 +48,31 @@ def _classification_record() -> dict:
     }
 
 
+def _classification_multichannel_record() -> dict:
+    train_features = np.array(
+        [
+            [[0.0, 0.1, 0.2], [1.0, 1.1, 1.2]],
+            [[0.2, 0.1, 0.0], [1.2, 1.1, 1.0]],
+            [[2.0, 2.1, 2.2], [3.0, 3.1, 3.2]],
+            [[2.2, 2.1, 2.0], [3.2, 3.1, 3.0]],
+        ],
+        dtype=float,
+    )
+    test_features = np.array(
+        [
+            [[0.05, 0.1, 0.15], [1.05, 1.1, 1.15]],
+            [[2.05, 2.1, 2.15], [3.05, 3.1, 3.15]],
+        ],
+        dtype=float,
+    )
+    return {
+        'train_features': train_features,
+        'train_target': np.array(['a', 'a', 'b', 'b']),
+        'test_features': test_features,
+        'test_target': np.array(['a', 'b']),
+    }
+
+
 def _regression_record() -> dict:
     train_features = np.array([[0.0], [1.0], [2.0], [3.0], [4.0]])
     train_target = np.array([1.0, 3.0, 5.0, 7.0, 9.0])
@@ -143,6 +168,32 @@ def test_local_tsc_adapter_reads_real_ts_dataset() -> None:
     assert record.metadata['source_train_file'] == 'BasicMotions_TRAIN.ts'
     assert record.metadata['dimensions'] == 6
     assert len(record.train_features[0]) == 600
+
+
+def test_in_memory_tsc_multichannel_record_keeps_matrix_path_compatible(tmp_path: Path) -> None:
+    spec = DatasetSpec(
+        benchmark='in_memory_tsc',
+        dataset_name='toy_multichannel_tsc',
+        adapter_options={'record': _classification_multichannel_record()},
+    )
+    adapter = build_classification_dataset_adapter(spec)
+    records = adapter.load_dataset(spec)
+    assert len(records) == 1
+    record = records[0]
+    # Matrix-based baseline path expects flattened 2D features.
+    assert len(record.train_features[0]) == 6
+    assert len(record.test_features[0]) == 6
+
+    config = BenchmarkSuiteConfig(
+        task_type=TaskType.TS_CLASSIFICATION,
+        datasets=(spec,),
+        models=(ModelSpec(adapter_name='nearest_centroid', display_name='NearestCentroid'),),
+        metrics=('accuracy',),
+        artifact_spec=ArtifactSpec(output_dir=str(tmp_path), persist_on_run=False),
+        run_spec=RunSpec(run_name='toy_multichannel_matrix_path', primary_metric='accuracy'),
+    )
+    result = run_tsc_benchmark_suite(config)
+    assert any(record.status is RunStatus.SUCCESS for record in result.run_records)
 
 
 def test_tser_suite_runs_and_writes_artifacts(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

This PR introduces an Industrial-native, train-aware multimodal data preparation pipeline for time-series classification/benchmark workflows.

- Adds `MultimodalDataBundle` as the core container for modality tensors, targets, and metadata.
- Adds `MultimodalPreprocessor` with a handler-based normalization architecture (`imputation`, `feature_standardization`, `image_standardization`, `log1p`) fitted on train only.
- Adds `PreparationConfig` and `MultimodalDatasetPreparer` to build multimodal representations (`raw`, `stats`, `gaf`, `stft`, `mtf`) from `DataLoader`, `ClassificationDatasetRecord`, or raw numpy/torch inputs.
- Supports optional per-sample z-normalization for `raw` before modality generation (separate from preprocessor normalization).
- Refactors statistical feature extraction around `TorchQuantileExtractor` with configurable `stat_feature_config` / `stat_feature_global_config`.
- Simplifies transformation dispatch via class mappings (`GAF`, `STFTSpectrogram`, `MTF`, `TorchQuantileExtractor`) and centralized default stat configs in `mapping.py`.
- Includes metadata for modality shapes, transform params, device/dtype, and normalization policy.
- Adds unit tests for preparation flow, no-leakage behavior, short/constant/multichannel series, and matrix-based baseline compatibility.

## Test plan

- [x] `pytest tests/unit/core/multimodal`
- [x] Matrix-based baseline path check (`test_in_memory_tsc_multichannel_record_keeps_matrix_path_compatible`)
- [x] Verified train-fit / test-transform statistics do not leak across splits
- [x] Verified default and custom stats transformation configs

Closes #251