### PR TITLE
refactor(detection): clean port anomaly detection runtime

### DIFF
--- a/fedot_ind/core/metrics/README.md
+++ b/fedot_ind/core/metrics/README.md
@@ -1,0 +1,198 @@
+# Модуль метрик Fedot Industrial
+
+Единый API для расчёта метрик по **одному** датасету (одна пара target / predicted). Результат — `dict` при наличии флага `return_dataframe=False`; для результата в pandas DataFrame (как раньше в `api/main.py`) используйте те же методы с флагом `return_dataframe=True` или без флага вовсе (дефолтное значение для этого флага `True`).
+
+<!-- [`metrics_implementation.py`](metrics_implementation.py) -->
+
+## Быстрый старт
+
+```python
+from fedot_ind.core.metrics.metrics import (
+    calculate_classification_metric,
+    calculate_detection_metric,
+    calculate_regression_metric,
+    calculate_forecasting_metric,
+)
+
+scores = calculate_classification_metric(
+    target=[0, 1, 1, 0],
+    predicted_labels=[0, 1, 0, 0],
+    metrics=('accuracy', 'f1'),
+)
+
+scores = calculate_detection_metric(
+    target=[0, 0, 1, 1, 0],
+    predicted_labels=[0, 0, 1, 0, 0],
+    metrics=('accuracy', 'f1'),
+)
+
+scores = calculate_regression_metric(
+    target=[1.0, 2.0, 3.0],
+    predicted=[1.1, 2.0, 2.9],
+    metrics=('r2', 'rmse'),
+)
+
+scores = calculate_forecasting_metric(
+    target=actual,
+    predicted=forecast,
+    metrics=[{'name': 'smape'}, {'name': 'mase'}],
+    train_data=history,
+    seasonality=12,
+)
+```
+
+## Структура
+
+```
+metrics/
+  metrics.py              # QualityMetric, публичные функции calculate_* (dict)
+  metric_library.py       # все реализации + METRIC_REGISTRY
+  metrics_implementation.py  # legacy-код
+  _exceptions.py
+  anomaly_detection/function.py  # легаси NAB / average_time (pandas) - аналогичная логика перенесена в metrics.py без использования pandas.
+  README.md # краткая информация по всему новому модулю метрик
+```
+
+## Формат `metric_names`
+
+- строка: `'accuracy'`;
+- словарь: `{'name': 'nab', 'params': {'scale_koef': 1.0}}`;
+- кортеж или список строк и/или словарей
+
+Повтор одного имени с разными `params` → ключи `nab`, `nab__1`, `nab__2`, …
+
+Метрики, возвращающие словарь с подметриками:
+- per_class_scores (списки поклассовых recall, precision, f1, support - число истинных объектов каждого класса), 
+- bin_confusion_matrix (int TP, TN, FP, FN), 
+- bin_metrics (TP, TN, FP, FN, precision, recall, f1, FAR (%), MAR (%) ), 
+- nab ({'Standard': float, 'LowFP': float, 'LowFN': float} – NAB скоры в процентах.), 
+- average_time ({average_delay : float, missing : int, FP : int, total_anomalies : int} ),
+**Распрямляются** в формате `'метрика'.'подметрика'`
+
+## Входные данные
+
+Только **последовательности** (списки / numpy), одна серия на вызов. Вложенный список серий `[[0,1], [1,0]]` → `MetricValidationError`.
+
+| Задача | target | predicted_labels | дополнительно |
+|--------|--------|------------------|---------------|
+| classification | метки классов | `predicted_labels` | `predicted_probs` для logloss / roc_auc |
+| detection | 0/1 метки | 0/1 метки | `predicted_probs` и params для NAB / average_time |
+| regression | float | float | — |
+| forecasting | float горизонт | float горизонт | `train_data`, `seasonality` в kwargs |
+
+`predicted_probs`: 1D (бинарный случай) или 2D `(n_samples, n_classes)`.
+
+## Метрики по задачам
+
+**shared_cls_det** (classification + detection): `accuracy`, `balanced_accuracy`, `f1`, `precision`, `recall`, `per_class_scores` (`dict` с ключами `recall`, `precision`, `f1` `support` и в качестве значений списки метрик по классам), `logloss`, `roc_auc`
+
+**detection**: все метрики из `shared_cls_det`, `bin_confusion_matrix`, `bin_precision`, `bin_recall`, `bin_f1`, `bin_far`, `bin_mar`, `bin_metrics` (`dict` с полями `precision`, `recall`, `f1`, `FAR`, `MAR`), `nab` (`dict` с полями `Standard`; `LowFP`; `LowFN`), `nab_standard`, `nab_low_fp`, `nab_low_fn`, `average_time` (`dict` с полями `average_delay`, `missing`, `FP`, `total_anomalies`)
+
+**shared_reg_forecast** (regression + forecasting): `mse`, `rmse`, `mae`, `r2`, `msle`, `mape`, `median_absolute_error`, `explained_variance_score`, `max_error`, `d2_absolute_error_score`
+
+**forecasting**: все метрики из `shared_reg_forecast`; Аггрегированные: `mae`, `rmse`, `smape`, `mase`, `owa` ; Pointwise → список по горизонту: `pw_mae`, `pw_rmse`, `pw_smape`, `pw_mase`, `pw_owa`
+
+## Добавить метрику
+
+1. Реализовать функцию в [`metric_library.py`](metric_library.py) в нужной секции или импортировать откуда-то.
+2. Зарегистрировать в `METRIC_REGISTRY` в начале или конце файла, присвоив новой метрике уникальное имя:
+3. Зарегистрировать в `METRICS_TO_MINIMIZE` или `METRICS_TO_MAXIMIZE` в начале или конце файла
+
+Заметка: приятнее регистрировать в начале файла, чтобы было видно, какие именно метрики добавлены, а какие были реализованы по умолчанию в модуле.
+
+## Обратная совместимость
+
+```python
+from fedot_ind.core.metrics.metrics_implementation import calculate_forecasting_metric
+
+df = calculate_forecasting_metric(
+    target=y_true, predicted_labels=y_pred, metric_names=('rmse',),
+    train_data=train, seasonality=12,
+)
+```
+
+## Исключения
+
+- `MetricValidationError` — неверные входы или отсутствуют probs;
+- `MetricNotFoundError` — неизвестное имя метрики.
+- `MetricError`
+
+## Тесты
+
+```bash
+pytest tests/unit/core/metrics/test_metrics.py -q
+```
+## Аргументы функций:
+
+### Публичные функции:
+- классификация:
+    - target
+    - predicted_labels
+    - predicted_probs = None
+    - metric_names = None (выбируться дефолтные 'f1','accuracy')
+    - rounding_order = 4
+    - return_dataframe = True
+    - **kwargs
+- детекция:
+    - target
+    - predicted_labels
+    - predicted_probs = None
+    - metric_names = None (выбируться дефолтные 'f1','accuracy')
+    - rounding_order = 4
+    - return_dataframe = True
+    - **kwargs
+- регрессия:
+    - target
+    - predicted_labels
+    - metric_names = None (выбируться дефолтные 'r2', 'rmse', 'mae')
+    - rounding_order = 4
+    - return_dataframe = True
+    - **kwargs
+- прогнозирование:
+    - target
+    - predicted_labels
+    - metric_names = None (выбируться дефолтные 'r2', 'rmse', 'mae')
+    - rounding_order = 4
+    - return_dataframe = True
+    - train_data = None
+    - seasonality = None
+    - **kwargs
+
+### Особые параметры метрик (помимо y_true и y_pred- первые два позиционных аргумента во всех метриках):
+- per_class_scores
+    - labels = None (именованный)
+- accuracy
+    - labels = None (именованный)
+- balanced_accuracy
+    - labels = None (именованный)
+    - pos_label = 'auto' (именованный и будет выбран класс с минимальной поддержкой)
+- binary_confusion_matrix / binary_precision / binary_recall / binary_f1 / binary_far / binary_mar / binary_metrics
+    - labels = None (именованный)
+    - pos_label = 1 (именованный)
+- precision / recall / f1_score
+    - labels = None (именованный)
+    - average = 'auto' (именованный и если классов > 2 → 'weighted', иначе 'binary')
+    - pos_label = 'auto' (именованный и для average='binary' – как определить положительный класс)
+- metric_logloss / metric_roc_auc
+    - predicted_probs = None (именованный и если None, то будет one-hot из predicted_labels)
+- NAB
+    - window_width: Optional[int] = None,
+    - portion: float = 0.1,
+    - anomaly_window_destination: str = "lefter",
+    - clear_anomalies_mode: bool = True,
+    - intersection_mode: str = "cut right window",
+    - scale_func: Union[str, Callable] = "my_scale",
+    - scale_koef: float = 1.0,
+    - table_of_coef: Optional[Dict] = None,
+- Average Time
+    - window_width: Optional[int] = None,
+    - portion: float = 0.1,
+    - anomaly_window_destination: str = "lefter",
+    - clear_anomalies_mode: bool = True,
+    - intersection_mode: str = "cut right window",
+- MAPE
+    - epsilon: float = 1e-8, - предотвращает деление на очень маленькое число, если модуль разности меньше epsilon
+- поэлементные mase_error и owa_error и аггрегированные mase и owa
+    - y_train: np.ndarray, 
+    - seasonal_period: int, - по умолчанию 1
+

--- a/fedot_ind/core/metrics/_exceptions.py
+++ b/fedot_ind/core/metrics/_exceptions.py
@@ -1,0 +1,17 @@
+"""Exceptions raised by the metrics package."""
+
+
+class MetricError(Exception):
+    """Base exception for all metric-related failures."""
+
+
+class MetricValidationError(MetricError):
+    """Raised when inputs or metric parameters are invalid.
+
+    Examples: length mismatch, missing ``predicted_probs`` for ``roc_auc``,
+    multi-series target in a single-dataset API call.
+    """
+
+
+class MetricNotFoundError(MetricError):
+    """Raised when a requested metric name is not registered for the task."""

--- a/fedot_ind/core/metrics/anomaly_detection/function.py
+++ b/fedot_ind/core/metrics/anomaly_detection/function.py
@@ -1,3 +1,8 @@
+"""Legacy pandas-based anomaly detection metrics.
+
+Prefer ``fedot_ind.core.metrics.metrics.calculate_detection_metric`` for new code.
+"""
+
 import numpy as np
 import pandas as pd
 
@@ -35,8 +40,17 @@ def single_detecting_boundaries(target_series,
         raise ValueError('Cannot perform boundaries extraction: should extract from series or list of timestamps')
 
     detecting_boundaries = []
-    td = pd.Timedelta(window_width) if window_width is not None else pd.Timedelta(
-        (predicted_labels.index[-1] - predicted_labels.index[0]) / (len(target_timestamps) + 1) * share)
+
+    # td = pd.Timedelta(window_width) if window_width is not None else pd.Timedelta(
+    # (predicted_labels.index[-1] - predicted_labels.index[0]) / (len(target_timestamps) + 1) * share)
+    if window_width is not None:
+        td = int(window_width) if isinstance(window_width, (int, float)) else pd.Timedelta(window_width)
+    else:
+        span = predicted_labels.index[-1] - predicted_labels.index[0]
+        if isinstance(span, pd.Timedelta):
+            td = pd.Timedelta(span / (len(target_timestamps) + 1) * share)
+        else:
+            td = max(1, int(span / (len(target_timestamps) + 1) * share))
     for val in target_timestamps:
         if anomaly_window_destination == 'lefter':
             detecting_boundaries.append([val - td, val])
@@ -283,11 +297,26 @@ def single_average_delay(
 #         return y
 
 
+def scale(fp_case_window, A_tp, A_fp, koef=1, clear_anomalies_mode=True, detalization=1000):
+    """Improved tanh scoring function used by NAB evaluation."""
+    window_start, cp, window_end = fp_case_window[0], fp_case_window[1], fp_case_window[2]
+    if hasattr(cp, '__iter__') and not isinstance(cp, (str, bytes)):
+        cp = cp[0] if len(cp) else window_start
+    x = np.linspace(-np.pi / 2, np.pi / 2, detalization)
+    x = x if clear_anomalies_mode else x[::-1]
+    denom = np.tanh(np.pi * koef / 2)
+    y = (A_tp - A_fp) / 2 * -1 * np.tanh(koef * x) / denom + (A_tp - A_fp) / 2 + A_fp
+    span = max(window_end - window_start, 1)
+    event = int((cp - window_start) / span * detalization)
+    event = min(max(event, 0), len(y) - 1)
+    return float(y[event])
+
+
 def single_evaluate_nab(detecting_boundaries,
                         predicted_labels,
                         table_of_val=None,
                         clear_anomalies_mode=True,
-                        scale="improved",
+                        nab_scale="improved",
                         scale_val=1  # TODO
                         ):
     """
@@ -368,3 +397,82 @@ def single_evaluate_nab(detecting_boundaries,
 
     return np.array([np.array(Scores), np.array(
         Scores_null), np.array(Scores_perfect)])
+
+
+# LEGACY FROM NAB/AVERAGE_TIME BLOCK FROM METRIC_LIB.PY
+
+# from fedot_ind.core.metrics.anomaly_detection.function import (
+#     single_average_delay,
+#     single_detecting_boundaries,
+#     single_evaluate_nab,
+# )
+
+
+# def _labels_to_series(values: np.ndarray) -> pd.Series:
+#     array = np.asarray(values, dtype=int).reshape(-1)
+#     return pd.Series(array, index=pd.RangeIndex(len(array)))
+
+
+# def _detecting_boundaries_from_binary(
+#         target: np.ndarray,
+#         predicted: np.ndarray,
+#         **params: Any,
+# ) -> list[list]:
+#     target_series = _labels_to_series(target)
+#     boundaries = single_detecting_boundaries(
+#         target_series=target_series,
+#         target_list_ts=None,
+#         predicted_labels=_labels_to_series(predicted),
+#         share=float(params.get('share', 0.1)),
+#         window_width=params.get('window_width', 1),
+#         anomaly_window_destination=str(params.get('anomaly_window_destination', 'lefter')),
+#         intersection_mode=str(params.get('intersection_mode', 'cut right window')),
+#     )
+#     return boundaries
+
+
+# def metric_nab(target: np.ndarray, predicted: np.ndarray, **params: Any) -> float | dict[str, float]:
+#     boundaries = _detecting_boundaries_from_binary(target, predicted, **params)
+#     matrix = single_evaluate_nab(
+#         boundaries,
+#         _labels_to_series(predicted),
+#         table_of_val=params.get('table_of_val'),
+#         clear_anomalies_mode=bool(params.get('clear_anomalies_mode', True)),
+#         scale_val=float(params.get('scale_val', 1.0)),
+#     )
+#     profile = str(params.get('profile', 'all'))
+#     names = ['Standard', 'LowFP', 'LowFN']
+#     results = {}
+#     for t, profile_name in enumerate(names):
+#         val = round(100 * (matrix[0, t] - matrix[1, t]) / (matrix[2, t] - matrix[1, t]), 2)
+#         results[profile_name] = val
+#     if profile != 'all':
+#         return results[profile]
+#     return results
+
+
+# def metric_average_time(target: np.ndarray, predicted: np.ndarray, **params: Any) -> float | dict[str, Any]:
+#     boundaries = _detecting_boundaries_from_binary(target, predicted, **params)
+#     missing, detect_history, fp, all_target = single_average_delay(
+#         boundaries,
+#         _labels_to_series(predicted),
+#         anomaly_window_destination=str(params.get('anomaly_window_destination', 'lefter')),
+#         clear_anomalies_mode=bool(params.get('clear_anomalies_mode', True)),
+#     )
+#     # mean_delay = float(np.mean(detect_history)) if detect_history else 0.0
+#     if detect_history:
+#         delays = [
+#             float(item.total_seconds()) if hasattr(item, 'total_seconds') else float(item)
+#             for item in detect_history
+#         ]
+#         mean_delay = float(np.mean(delays))
+#     else:
+#         mean_delay = 0.0
+#     if params.get('return_breakdown'):
+#         return {
+#             'false_positive': int(fp),
+#             'missed_anomaly': int(missing),
+#             'all_detection_hist': mean_delay,
+#             'all_anomaly_history': int(all_target),
+#         }
+#     return mean_delay

--- a/fedot_ind/core/metrics/metric_library.py
+++ b/fedot_ind/core/metrics/metric_library.py
@@ -1,0 +1,1443 @@
+"""Metric implementations and registry for all task types.
+
+Add new metrics to ``METRIC_REGISTRY`` below (or implement a function and register it).
+Each metric callable has the form ``(target, predicted, **params) -> float | list | dict``.
+It also can return ``np.ndarray`` ONLY for point-wise metrics for forcasting. The same was in benchmarkV2 in forcasting.py
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any, Optional, Tuple, Dict, Union, List
+
+import numpy as np
+from sklearn.metrics import (
+    log_loss,
+    roc_auc_score,
+)
+
+from fedot_ind.core.metrics._exceptions import MetricNotFoundError, MetricValidationError
+
+
+MetricFn = Callable[..., Union[float, list, dict]]
+
+# ---------------------------------------------------------------------------
+# Registry — register new metrics here
+# Dont forget to add it in METRICS_TO_MINIMIZE or METRICS_TO_MAXIMIZE !!!
+# ---------------------------------------------------------------------------
+METRIC_REGISTRY: dict[str, dict[str, MetricFn]] = {
+    'shared_cls_det': {},
+    'anomaly_detection': {},
+    'shared_reg_forecast': {},
+    'forecasting': {},
+}
+
+METRICS_TO_MINIMIZE = []
+METRICS_TO_MAXIMIZE = []
+
+
+def get_metric(task: str, name: str) -> MetricFn:
+    """Return metric function for *task*."""
+    # Подмена задач, ради обобщения метрик для разных задач
+    if task == 'classification':
+        taskk = 'shared_cls_det'
+    elif task == 'regression':
+        taskk = 'shared_reg_forecast'
+    else:
+        taskk = task
+    # Проверка наличия метрики для такой задачи
+    if name in METRIC_REGISTRY.get(taskk, {}):
+        return METRIC_REGISTRY[taskk][name]
+    raise MetricNotFoundError(f'Unknown metric "{name}" for task "{task}".')
+
+# ---------------------------------------------------------------------------
+# shared_cls_det
+#
+# A unified metrics module for classification and anomaly detection.
+# Supports multi-class and binary cases.
+# Easily migrates to PyTorch (see comments).
+# ---------------------------------------------------------------------------
+
+# CORE: confusion matrix
+
+
+def confusion_matrix(
+    y_true: np.ndarray,
+    y_pred: np.ndarray,
+    labels: Optional[Union[np.ndarray, list]] = None,
+    **_,
+) -> Tuple[np.ndarray, np.ndarray]:
+    """
+    Вычисляет матрицу ошибок NxN.
+
+    Args:
+        y_true: истинные метки (1D массив).
+        y_pred: предсказанные метки (1D массив).
+        labels: явный список меток (1D). Если None, определяются автоматически
+                как объединение уникальных значений y_true и y_pred.
+
+    Returns:
+        cm: матрица ошибок (N, N), где cm[i, j] – число объектов с истинным классом labels[i]
+            и предсказанным labels[j].
+
+        labels: отсортированный массив меток, соответствующих осям.
+    """
+    if labels is None:
+        labels = np.unique(np.concatenate([y_true, y_pred]))
+    else:
+        labels = np.asarray(labels)
+
+    if len(labels) == 1:
+        if labels[0] == 1:
+            labels = np.append(labels, 0)
+        elif labels[0] == 0:
+            labels = np.append(labels, 1)
+        else:
+            raise MetricValidationError(
+                f"Please add labels parameter for metric. In true and predicted labels there is only one unique value: {labels}. "
+                "Default labels for autocomplete is 0 and 1 - integer.")
+    labels = np.sort(labels)
+
+    # маппинг реальных меток в индексы матрицы
+    label_to_idx = {lab: i for i, lab in enumerate(labels)}
+    idx_true = np.vectorize(label_to_idx.get)(y_true)
+    idx_pred = np.vectorize(label_to_idx.get)(y_pred)
+
+    n = len(labels)
+    cm = np.zeros((n, n), dtype=np.int64)
+    # Для PyTorch:
+    # cm = torch.zeros(n, n, dtype=torch.int64)
+    # cm.index_put_((idx_true, idx_pred), torch.ones(..., dtype=torch.int64), accumulate=True)
+    np.add.at(cm, (idx_true, idx_pred), 1)
+    return cm, labels
+
+# Вспомогательные векторные операции над матрицей
+
+
+def _safe_divide(a: np.ndarray, b: np.ndarray) -> np.ndarray:
+    """Поэлементное a/b с заменой inf/nan на 0."""
+    with np.errstate(divide='ignore', invalid='ignore'):
+        res = np.divide(a, b)
+        res[~np.isfinite(res)] = 0.0
+    return res
+
+
+def _per_class_support(cm: np.ndarray) -> np.ndarray:
+    """Число истинных объектов каждого класса (сумма по строкам)."""
+    return cm.sum(axis=1)
+
+
+def _per_class_recall(cm: np.ndarray) -> np.ndarray:
+    """Recall для каждого класса."""
+    tp = cm.diagonal()
+    return _safe_divide(tp.astype(float), _per_class_support(cm).astype(float))
+
+
+def _per_class_precision(cm: np.ndarray) -> np.ndarray:
+    """Precision для каждого класса."""
+    tp = cm.diagonal()
+    predicted_as_class = cm.sum(axis=0)
+    return _safe_divide(tp.astype(float), predicted_as_class.astype(float))
+
+
+def _per_class_f1(cm: np.ndarray) -> np.ndarray:
+    """F1-score для каждого класса."""
+    prec = _per_class_precision(cm)
+    rec = _per_class_recall(cm)
+    return _safe_divide(2 * prec * rec, prec + rec)
+
+# Public per-class metrics
+
+
+def per_class_scores(y_true: np.ndarray, y_pred: np.ndarray, *
+    , labels: Union[np.ndarray, list, None] = None, **_) -> Dict[str, list]:
+    """
+    Возвращает словарь с массивами:
+        'recall', 'precision', 'f1', 'support'
+    по всем классам (порядок соответствует labels из confusion_matrix).
+    """
+    cm, _ = confusion_matrix(y_true, y_pred, labels)
+    return {
+        'recall': _per_class_recall(cm).tolist(),
+        'precision': _per_class_precision(cm).tolist(),
+        'f1': _per_class_f1(cm).tolist(),
+        'support': _per_class_support(cm).tolist()
+    }
+
+# Aggregations
+
+
+def accuracy(y_true: np.ndarray, y_pred: np.ndarray, *, labels: Union[np.ndarray, list, None] = None, **_) -> float:
+    """Общая доля правильных ответов."""
+    cm, _ = confusion_matrix(y_true, y_pred, labels)
+    return float(np.trace(cm) / cm.sum())
+
+
+def balanced_accuracy(y_true: np.ndarray, y_pred: np.ndarray,
+                      *, labels: Union[np.ndarray, list, None] = None,
+                      pos_label: Union[int, str] = 'auto',
+                      **_) -> float:
+    """Balanced accuracy – средний recall по классам."""
+    return recall(y_true, y_pred, labels=labels, average='macro', pos_label=pos_label)
+
+# Obtaining a Confusion Matrix for the binary case with a definition of what is the positive class
+
+
+def _binary_components(
+    cm: np.ndarray,
+    labels: np.ndarray,
+    pos_label: Union[int, str] = 'auto'
+) -> Tuple[int, int, int, int, int]:
+    """
+    Извлекает TP, TN, FP, FN и индекс положительного класса из матрицы 2×2.
+
+    Args:
+        cm: матрица 2×2.
+        labels: метки, соответствующие осям.
+        pos_label: значение положительного класса (число) или 'auto' –
+                   тогда выбирается класс с наименьшей поддержкой (меньшинство).
+
+    Returns:
+        tp, tn, fp, fn, pos_idx
+    """
+    if cm.shape != (2, 2):
+        raise MetricValidationError(
+            f"Confusion matrix должна быть 2x2 для бинарного случая. Текущая матрица имеет форму: {cm.shape}")
+    if pos_label == 'auto':
+        support = _per_class_support(cm)
+        pos_idx = int(np.argmin(support))  # класс с наименьшей поддержкой
+    else:
+        pos_idx_list = np.where(labels == pos_label)[0]
+        if len(pos_idx_list) == 0:
+            raise MetricValidationError(f"Метка {pos_label} не найдена среди {labels}")
+        pos_idx = pos_idx_list[0]
+    neg_idx = 1 - pos_idx
+
+    tp = cm[pos_idx, pos_idx]
+    tn = cm[neg_idx, neg_idx]
+    fp = cm[neg_idx, pos_idx]
+    fn = cm[pos_idx, neg_idx]
+    return int(tp), int(tn), int(fp), int(fn), pos_idx
+
+# Binary metrics (precision, recall, f1, FAR, MAR) + components
+
+
+def binary_confusion_matrix(
+    y_true: np.ndarray,
+    y_pred: np.ndarray,
+    *,
+    labels: Union[np.ndarray, list, None] = None,
+    pos_label: Union[int, str] = 1,
+    **_,
+) -> Dict[str, int]:
+    """Возвращает словарь {'TP': ..., 'TN': ..., 'FP': ..., 'FN': ...}."""
+    cm, labels = confusion_matrix(y_true, y_pred, labels)
+    tp, tn, fp, fn, _ = _binary_components(cm, labels, pos_label)
+    return {'TP': tp, 'TN': tn, 'FP': fp, 'FN': fn}
+
+
+def binary_precision(
+    y_true: np.ndarray,
+    y_pred: np.ndarray,
+    *,
+    labels: Union[np.ndarray, list, None] = None,
+    pos_label: Union[int, str] = 1,
+    **_,
+) -> float:
+    return precision(y_true, y_pred, average='binary', labels=labels, pos_label=pos_label)
+
+
+def binary_recall(
+    y_true: np.ndarray,
+    y_pred: np.ndarray,
+    *,
+    labels: Union[np.ndarray, list, None] = None,
+    pos_label: Union[int, str] = 1,
+    **_,
+) -> float:
+    return recall(y_true, y_pred, average='binary', labels=labels, pos_label=pos_label)
+
+
+def binary_f1(
+    y_true: np.ndarray,
+    y_pred: np.ndarray,
+    *,
+    labels: Union[np.ndarray, list, None] = None,
+    pos_label: Union[int, str] = 1,
+    **_,
+) -> float:
+    return f1_score(y_true, y_pred, average='binary', labels=labels, pos_label=pos_label)
+
+
+def binary_far(
+    y_true: np.ndarray,
+    y_pred: np.ndarray,
+    *,
+    labels: Union[np.ndarray, list, None] = None,
+    pos_label: Union[int, str] = 1,
+    **_,
+) -> float:
+    """False Alarm Rate (FAR) в процентах: FP / (FP + TN) * 100."""
+    cm, labels = confusion_matrix(y_true, y_pred, labels)
+    _, tn, fp, _, _ = _binary_components(cm, labels, pos_label)
+    return 100.0 * fp / (fp + tn) if (fp + tn) else 0.0
+
+
+def binary_mar(
+    y_true: np.ndarray,
+    y_pred: np.ndarray,
+    *,
+    labels: Union[np.ndarray, list, None] = None,
+    pos_label: Union[int, str] = 1,
+    **_,
+) -> float:
+    """Miss Alarm Rate (MAR) в процентах: FN / (FN + TP) * 100."""
+    cm, labels = confusion_matrix(y_true, y_pred, labels)
+    tp, _, _, fn, _ = _binary_components(cm, labels, pos_label)
+    return 100.0 * fn / (fn + tp) if (fn + tp) else 0.0
+
+
+def binary_metrics(
+    y_true: np.ndarray,
+    y_pred: np.ndarray,
+    *,
+    labels: Union[np.ndarray, list, None] = None,
+    pos_label: Union[int, str] = 1,
+    **_,
+) -> Dict[str, float]:
+    """
+    Возвращает словарь:
+        TP, TN, FP, FN, precision, recall, f1, FAR (%), MAR (%).
+
+            FAR = FP/(FP+TN)*100, MAR = FN/(FN+TP)*100.
+    """
+    cm_dict = binary_confusion_matrix(y_true, y_pred, labels=labels, pos_label=pos_label)
+    return {
+        **cm_dict,
+        'precision': binary_precision(y_true, y_pred, labels=labels, pos_label=pos_label),
+        'recall': binary_recall(y_true, y_pred, labels=labels, pos_label=pos_label),
+        'f1': binary_f1(y_true, y_pred, labels=labels, pos_label=pos_label),
+        'FAR': binary_far(y_true, y_pred, labels=labels, pos_label=pos_label),
+        'MAR': binary_mar(y_true, y_pred, labels=labels, pos_label=pos_label),
+    }
+
+# Universal precision/recall/f1 with average selection
+
+
+def precision(
+    y_true: np.ndarray,
+    y_pred: np.ndarray,
+    *,
+    labels: Union[np.ndarray, list, None] = None,
+    average: str = 'auto',
+    pos_label: Union[int, str] = 'auto',
+    **_,
+) -> float:
+    """
+    average: 'macro', 'weighted', 'micro', 'binary', 'auto'.
+
+    'auto' → macro для >2 классов, иначе binary.
+    """
+    cm, labels = confusion_matrix(y_true, y_pred, labels=labels)
+    n_classes = cm.shape[0]
+    if average == 'auto':
+        average = 'binary' if n_classes == 2 else 'macro'
+    if average == 'binary':
+        if n_classes != 2:
+            raise MetricValidationError("binary average для precision возможна только при 2 классах")
+        tp, _, fp, _, _ = _binary_components(cm, labels, pos_label)
+        return float(tp / (tp + fp) if (tp + fp) else 0.0)
+    elif average == 'micro':
+        # Для precision, recall, F1 в micro всё совпадает с accuracy
+        return float(np.trace(cm) / cm.sum())  # micro precision = accuracy
+    elif average == 'macro':
+        per_class = _per_class_precision(cm)
+        return float(np.mean(per_class))
+    elif average == 'weighted':
+        """Средневзвешенное по поддержке классов."""
+        per_class = _per_class_precision(cm)
+        support = _per_class_support(cm)
+        return float(np.average(per_class, weights=support))
+    else:
+        raise MetricValidationError(f"Неизвестный тип усреднения для precision: {average}")
+
+
+def recall(
+    y_true: np.ndarray,
+    y_pred: np.ndarray,
+    *,
+    labels: Union[np.ndarray, list, None] = None,
+    average: str = 'auto',
+    pos_label: Union[int, str] = 'auto',
+    **_,
+) -> float:
+    """
+    recall с выбором способа усреднения.
+
+    Args:
+        average: 'macro', 'weighted', 'micro', 'binary', 'auto'.
+
+                'auto' → macro для >2 классов, иначе binary.
+
+    pos_label: для average='binary' – как определить положительный класс.
+    """
+    cm, labels = confusion_matrix(y_true, y_pred, labels=labels)
+    n_classes = cm.shape[0]
+    if average == 'auto':
+        average = 'binary' if n_classes == 2 else 'macro'
+    if average == 'binary':
+        if n_classes != 2:
+            raise MetricValidationError("binary average для recall возможна только при 2 классах")
+        tp, _, _, fn, _ = _binary_components(cm, labels, pos_label)
+        return float(tp / (tp + fn) if (tp + fn) else 0.0)
+    elif average == 'micro':
+        # Для precision, recall, F1 в micro всё совпадает с accuracy
+        return float(np.trace(cm) / cm.sum())  # micro recall = accuracy
+    elif average == 'macro':
+        per_class = _per_class_recall(cm)
+        return float(np.mean(per_class))
+    elif average == 'weighted':
+        per_class = _per_class_recall(cm)
+        support = _per_class_support(cm)
+        return float(np.average(per_class, weights=support))
+    else:
+        raise MetricValidationError(f"Неизвестный тип усреднения для recall: {average}")
+
+
+def f1_score(
+    y_true: np.ndarray,
+    y_pred: np.ndarray,
+    *,
+    labels: Union[np.ndarray, list, None] = None,
+    average: str = 'auto',
+    pos_label: Union[int, str] = 'auto',
+    **_,
+) -> float:
+    """
+    F1-score с выбором способа усреднения.
+
+    Args:
+        average: 'macro', 'weighted', 'micro', 'binary', 'auto'.
+
+                 'auto': если классов > 2 → 'weighted', иначе 'binary'.
+
+        pos_label: для average='binary' – как определить положительный класс.
+    """
+    cm, labels = confusion_matrix(y_true, y_pred, labels=labels)
+    n_classes = cm.shape[0]
+
+    if average == 'auto':
+        average = 'binary' if n_classes == 2 else 'weighted'
+
+    if average == 'binary':
+        if n_classes != 2:
+            raise MetricValidationError("binary average для F1 возможна только при 2 классах")
+        tp, _, fp, fn, _ = _binary_components(cm, labels, pos_label)
+        prec = tp / (tp + fp) if (tp + fp) else 0.0
+        rec = tp / (tp + fn) if (tp + fn) else 0.0
+        return float(2 * prec * rec / (prec + rec) if (prec + rec) else 0.0)
+    elif average == 'micro':
+        # Для precision, recall, F1 в micro всё совпадает с accuracy
+        return float(np.trace(cm) / cm.sum())  # micro recall = accuracy
+    elif average == 'macro':
+        per_class = _per_class_f1(cm)
+        return float(np.mean(per_class))
+    elif average == 'weighted':
+        per_class = _per_class_f1(cm)
+        support = _per_class_support(cm)
+        return float(np.average(per_class, weights=support))
+    else:
+        raise MetricValidationError(f"Неизвестный тип усреднения для F1: {average}")
+
+# Остатки от классификации (может быть уже легаси)
+
+
+def metric_logloss(y_true: np.ndarray, y_pred: np.ndarray, *, predicted_probs=None, **_) -> float:
+    if predicted_probs is None and y_pred is None:
+        raise MetricValidationError(
+            'logloss requires predicted_probs. Or at least predicted (one-hot and get similar at probs)')
+    if predicted_probs is None and y_pred is not None:
+        # TODO Хорошо бы сделать логгирование, как описал в ROC-AUC
+        classes = sorted(set(int(v) for v in np.unique(y_true)) | set(int(v) for v in np.unique(y_pred)))
+        predicted_probs = np.zeros((len(y_pred), len(classes)))
+        for i, c in enumerate(classes):
+            predicted_probs[:, i] = (y_pred == c).astype(float)
+    return float(log_loss(y_true=y_true, y_pred=predicted_probs))
+
+
+def metric_roc_auc(y_true: np.ndarray, y_pred: np.ndarray, *, predicted_probs=None, **_) -> float:
+    # if predicted_probs is None:
+    #     raise MetricValidationError('roc_auc requires predicted_probs.')
+    # classes = np.unique(target)
+    classes = sorted(set(int(v) for v in np.unique(y_true)) | set(int(v) for v in np.unique(y_pred)))
+    if len(classes) > 2:
+        encoded_target = np.zeros((len(y_true), len(classes)))
+        for i, c in enumerate(classes):
+            encoded_target[:, i] = (y_true == c).astype(float)
+        if predicted_probs is None and y_pred is not None:
+            # TODO Тут бы логгировать, что типа нет данных вероятностей и будет
+            # делаться One-Hot для предсказаний и использоваться вместо вероятностей
+            y_score = np.zeros((len(y_pred), len(classes)))
+            for i, c in enumerate(classes):
+                y_score[:, i] = (y_pred == c).astype(float)
+        else:
+            y_score = predicted_probs  # if predicted_probs.ndim > 1 else encoded
+        return float(
+            roc_auc_score(
+                y_true=encoded_target,
+                y_score=y_score,
+                multi_class='ovr',
+                average='macro',
+                labels=classes))
+    y_score = predicted_probs.reshape(-1) if predicted_probs.ndim == 1 else predicted_probs[:, 1]
+    return float(roc_auc_score(y_true=y_true, y_score=y_score))
+
+# ---------------------------------------------------------------------------
+# Detection — NAB / average_time (binary labels only)
+# ---------------------------------------------------------------------------
+
+# Helper (private) functions
+
+
+def _filter_detecting_boundaries(
+    boundaries: List[List[int]]
+) -> List[List[int]]:
+    """
+    Удаляет пустые окна ([]) из списка границ.
+
+    Parameters
+    ----------
+    boundaries : list of lists
+        Список, где каждый элемент либо пустой [], либо пара [left, right].
+
+    Returns
+    -------
+    list of lists
+        Только непустые окна.
+    """
+    return [b for b in boundaries if len(b) == 2]
+
+
+def _compute_detecting_boundaries(
+    true_array: np.ndarray,
+    window_width: Optional[int] = None,
+    portion: float = 0.1,
+    anomaly_window_destination: str = "lefter",
+    intersection_mode: str = "cut right window",
+) -> List[List[int]]:
+    """
+    Строит окна обнаружения вокруг истинных аномалий.
+
+    Parameters
+    ----------
+    true_array : np.ndarray (1D, бинарный)
+        Маска истинных событий (1 = аномалия).
+    window_width : int, optional
+        Ширина окна в числе отсчётов (индексов). Если None, вычисляется как
+        int(len(true_array) / (кол-во аномалий + 1) * portion).
+    portion : float
+        Используется, если window_width не задан.
+    anomaly_window_destination : {'lefter', 'righter', 'center'}
+        Положение окна относительно истинной аномалии:
+        'lefter' : окно слева от аномалии [val - width, val]
+        'righter': окно справа от аномалии [val, val + width]
+        'center' : окно симметрично вокруг аномалии.
+    intersection_mode : {'cut left window', 'cut right window', 'cut both'}
+        Способ разрешения пересекающихся окон (см. документацию оригинального NAB).
+
+    Returns
+    -------
+    list of lists
+        Список окон; каждое окно – [left_index, right_index]. Может быть пустой список,
+        если аномалий нет.
+    """
+    # Индексы истинных аномалий
+    true_indices = np.flatnonzero(true_array)
+    if len(true_indices) == 0:
+        return [[]]
+
+    # TODO ХОРОШО БЫ СДЕЛАТЬ ЛОГГИРОВАНИЕ, ЧТО НЕТ НИ портион, НИ ширины И
+    # БУДУТ ИСПОЛЬЗОВАТЬСЯ ДЕФОЛТНЫЕ (ТАКОЕ БЫЛО У ПЕРВОНАЧАЛЬНЫХ АВТОРОВ)
+
+    # Расчёт ширины окна, если не задана явно
+    if window_width is None:
+        width = int(len(true_array) / (len(true_indices) + 1) * portion)
+    else:
+        width = window_width
+
+    # Построение начальных границ
+    boundaries = []
+    for val in true_indices:
+        if anomaly_window_destination == "lefter":
+            left = val - width
+            right = val
+        elif anomaly_window_destination == "righter":
+            left = val
+            right = val + width
+        elif anomaly_window_destination == "center":
+            half = width // 2
+            left = val - half
+            right = val + half
+        else:
+            raise MetricValidationError(
+                f"При вычислении detecting boundaries (для метрик NAB и/или average_time) обнаружен неизвестный параметр: anomaly_window_destination = {anomaly_window_destination}. "
+                "Параметр anomaly_window_destination должен быть 'lefter', 'righter' или 'center'.")
+        boundaries.append([left, right])
+
+    # Разрешение пересечений окон
+    if len(boundaries) <= 1:
+        # if len(boundaries) == 1:
+        return boundaries
+
+    new_boundaries = boundaries.copy()
+    for i in range(len(new_boundaries) - 1):
+        if new_boundaries[i][1] >= new_boundaries[i + 1][0]:
+            if intersection_mode == "cut left window":
+                new_boundaries[i][1] = new_boundaries[i + 1][0]
+            elif intersection_mode == "cut right window":
+                new_boundaries[i + 1][0] = new_boundaries[i][1]
+            elif intersection_mode == "cut both":
+                a = new_boundaries[i][1]
+                new_boundaries[i][1] = new_boundaries[i + 1][0]
+                new_boundaries[i + 1][0] = a
+            else:
+                raise MetricValidationError(
+                    f"При вычислении detecting boundaries (для метрик NAB и/или average_time) обнаружен неизвестный параметр: intersection_mode = {intersection_mode}. "
+                    "Параметр intersection_mode должен быть 'cut left window', 'cut right window' или 'cut both'.")
+    return new_boundaries
+
+
+def _extract_cp_confusion_matrix(
+    boundaries: List[List[int]],
+    prediction: np.ndarray,
+    point: int = 0,
+    binary: bool = False,
+) -> Dict:
+    """
+    Извлекает матрицу «окна обнаружения – предсказания».
+
+    Parameters
+    ----------
+    boundaries : list of lists
+        Отфильтрованный список окон [[left, right], ...].
+    prediction : np.ndarray (1D, бинарный)
+        Предсказания модели.
+    point : int
+        Индекс срабатывания внутри окна (0 – первое, -1 – последнее) для не-бинарного режима.
+    binary : bool
+        Если True, в TP сохраняются все предсказания внутри окна.
+
+    Returns
+    -------
+    dict
+        Словарь с ключами:
+        'TPs' : dict {номер_окна: [left, позиция_срабатывания, right]}
+        'FPs' : np.ndarray индексов ложных срабатываний.
+        'FNs' : список номеров окон без предсказаний (или все индексы окна для binary).
+    """
+    # Индексы всех предсказаний
+    times_pred = np.flatnonzero(prediction)
+    # Фильтруем границы – оставляем только реальные окна
+    boundaries = _filter_detecting_boundaries(boundaries)
+
+    TPs = {}
+    FPs = []
+    FNs = []
+
+    if len(boundaries) == 0:
+        # Все предсказания – ложные
+        return {"TPs": TPs, "FPs": times_pred, "FNs": FNs}
+
+    # Обрабатываем промежутки между окнами и внутри них
+    for i, (left, right) in enumerate(boundaries):
+        # Предсказания, попавшие в окно
+        mask = (times_pred >= left) & (times_pred <= right)
+        in_window = times_pred[mask]
+
+        if len(in_window) == 0:
+            if binary:
+                # В binary режиме FN – все индексы внутри окна
+                all_indices = np.arange(max(0, left), min(len(prediction), right + 1))
+                FNs.append(all_indices)
+            else:
+                FNs.append(i)
+        else:
+            if binary:
+                TPs[i] = [left, in_window, right]
+                # FN – те индексы окна, которые не попали в предсказания
+                all_in_window = np.arange(
+                    max(0, left), min(len(prediction), right + 1)
+                )
+                FNs.append(all_in_window[~np.isin(all_in_window, in_window)])
+            else:
+                idx = in_window[point]  # первое или последнее срабатывание
+                TPs[i] = [left, idx, right]
+
+        # Ложные срабатывания между текущим правым и следующим левым окном
+        if i < len(boundaries) - 1:
+            next_left = boundaries[i + 1][0]
+            inter_fp = times_pred[(times_pred > right) & (times_pred < next_left)]
+            FPs.append(inter_fp)
+
+    # FPs до первого окна
+    first_left = boundaries[0][0]
+    FPs.insert(0, times_pred[times_pred < first_left])
+    # FPs после последнего окна
+    last_right = boundaries[-1][1]
+    FPs.append(times_pred[times_pred > last_right])
+
+    # Склеиваем все FPs в один массив
+    if FPs:
+        FPs = np.concatenate([fp if len(fp) > 0 else np.array([], dtype=int) for fp in FPs])
+    else:
+        FPs = np.array([], dtype=int)
+
+    if binary:
+        if FNs:
+            FNs = np.concatenate(FNs) if all(isinstance(f, np.ndarray) for f in FNs) else FNs
+        else:
+            FNs = np.array([], dtype=int)
+
+    return {"TPs": TPs, "FPs": FPs, "FNs": FNs}
+
+
+def _my_scale(
+    fp_case_window: List[int],
+    A_tp: float = 1.0,
+    A_fp: float = 0.0,
+    koef: float = 1.0,
+    detalization: int = 1000,
+    clear_anomalies_mode: bool = True,
+) -> float:
+    """
+    Улучшенная оконная функция NAB (tanh-профиль).
+
+    Parameters
+    ----------
+    fp_case_window : list из трёх int [left, pred_pos, right]
+        Координаты окна и позиция предсказания.
+    A_tp, A_fp : float
+        Веса для истинно-положительного и ложно-положительного исходов.
+    koef : float
+        Коэффициент крутизны tanh.
+    detalization : int
+        Число точек дискретизации окна (влияет на точность вычисления скора).
+    clear_anomalies_mode : bool
+        True – левый край окна = A_tp, правый = A_fp; False – наоборот.
+
+    Returns
+    -------
+    float
+        Взвешенный скор для данного предсказания.
+    """
+    left, pred_pos, right = fp_case_window
+    if right == left:
+        return A_fp  # вырожденное окно
+
+    # Положение предсказания в окне в диапазоне [0, 1]
+    relative_pos = (pred_pos - left) / (right - left)
+    event = int(relative_pos * (detalization - 1))  # переводим в индекс массива x
+
+    x = np.linspace(-np.pi / 2, np.pi / 2, detalization)
+    if not clear_anomalies_mode:
+        x = x[::-1]
+
+    y = (
+        (A_tp - A_fp)
+        / 2
+        * (-np.tanh(koef * x) / np.tanh(np.pi * koef / 2))
+        + (A_tp - A_fp) / 2
+        + A_fp
+    )
+
+    # Защита от выхода за границы (маловероятно, но возможно при округлении)
+    event = min(event, detalization - 1)
+    return y[event]
+
+# Main computing functions (private)
+
+
+def _single_average_delay(
+    boundaries: List[List[int]],
+    prediction: np.ndarray,
+    anomaly_window_destination: str,
+    clear_anomalies_mode: bool,
+) -> Tuple[int, List[float], int, int]:
+    """
+    Вычисляет среднюю задержку обнаружения для одного набора границ.
+
+    Возвращает:
+        missing      : int – количество пропущенных аномалий
+        detectHistory: list[float] – задержки (в числе отсчётов) для обнаруженных аномалий
+        FP           : int – количество ложных срабатываний
+        all_true_anom: int – общее число истинных аномалий
+    """
+    boundaries = _filter_detecting_boundaries(boundaries)
+    point = 0 if clear_anomalies_mode else -1
+    confusion = _extract_cp_confusion_matrix(boundaries, prediction, point=point)
+
+    missing = len(confusion["FNs"])
+    FP = len(confusion["FPs"])
+    all_true_anom = len(confusion["TPs"]) + missing
+
+    # Выбор формулы задержки в зависимости от положения окна
+    if anomaly_window_destination == "lefter":
+        def delay(tp_entry): return tp_entry[2] - tp_entry[1]
+    elif anomaly_window_destination == "righter":
+        def delay(tp_entry): return tp_entry[1] - tp_entry[0]
+    elif anomaly_window_destination == "center":
+        def delay(tp_entry):
+            center = tp_entry[0] + (tp_entry[2] - tp_entry[0]) / 2.0
+            return tp_entry[1] - center
+    else:
+        raise MetricValidationError(
+            f"При вычислении average delay (для метрики average_time) обнаружен неизвестный параметр: anomaly_window_destination = {anomaly_window_destination}. "
+            "Параметр anomaly_window_destination должен быть 'lefter', 'righter' или 'center'.")
+    detectHistory = [delay(confusion["TPs"][i]) for i in confusion["TPs"]]
+    return missing, detectHistory, FP, all_true_anom
+
+
+def _single_evaluate_nab(
+    boundaries: List[List[int]],
+    prediction: np.ndarray,
+    table_of_coef: Optional[Dict] = None,
+    clear_anomalies_mode: bool = True,
+    scale_func: Callable = _my_scale,
+    scale_koef: float = 1.0,
+) -> np.ndarray:
+    """
+    Вычисляет NAB скор для одного набора границ.
+
+    Возвращает np.array формы (3,3):
+        [Scores, Scores_null, Scores_perfect] для профилей Standard, LowFP, LowFN.
+    """
+    boundaries = _filter_detecting_boundaries(boundaries)
+
+    # Таблица коэффициентов по умолчанию
+    if table_of_coef is None:
+        table_of_coef = {
+            "Standard": {"A_tp": 1.0, "A_fp": -0.11, "A_fn": -1.0},
+            "LowFP": {"A_tp": 1.0, "A_fp": -0.22, "A_fn": -1.0},
+            "LowFN": {"A_tp": 1.0, "A_fp": -0.11, "A_fn": -2.0},
+        }
+
+    point = 0 if clear_anomalies_mode else -1
+    confusion = _extract_cp_confusion_matrix(boundaries, prediction, point=point)
+
+    scores = []
+    scores_perfect = []
+    scores_null = []
+
+    for profile in ["Standard", "LowFP", "LowFN"]:
+        A_tp = table_of_coef[profile]["A_tp"]
+        A_fp = table_of_coef[profile]["A_fp"]
+        A_fn = table_of_coef[profile]["A_fn"]
+
+        score = 0.0
+        score += A_fp * len(confusion["FPs"])
+        score += A_fn * len(confusion["FNs"])
+        for win_id, tp_entry in confusion["TPs"].items():
+            score += scale_func(tp_entry, A_tp, A_fp, koef=scale_koef)
+
+        scores.append(score)
+        scores_perfect.append(len(boundaries) * A_tp)
+        scores_null.append(len(boundaries) * A_fn)
+
+    return np.array([scores, scores_null, scores_perfect])
+
+# Public API
+
+
+def compute_nab_score(
+    y_true: np.ndarray,
+    y_pred: np.ndarray,
+    *,
+    window_width: Optional[int] = None,
+    portion: float = 0.1,
+    anomaly_window_destination: str = "lefter",
+    clear_anomalies_mode: bool = True,
+    intersection_mode: str = "cut right window",
+    scale_func: Union[str, Callable] = "my_scale",
+    scale_koef: float = 1.0,
+    table_of_coef: Optional[Dict] = None,
+    **_
+) -> Dict[str, float]:
+    """
+    Вычисление NAB метрики для одной последовательности.
+
+    Parameters
+    ----------
+    true : np.ndarray (1D, int)
+        Бинарная маска истинных аномалий (1 – аномалия, 0 – норма).
+    prediction : np.ndarray (1D, int)
+        Бинарные предсказания модели.
+    window_width : int, optional
+        Ширина окна обнаружения в отсчётах. Если None, вычисляется автоматически
+        как int(len(prediction) / (число аномалий + 1) * portion).
+    portion : float
+        Доля длины последовательности, используемая при автоматическом расчёте окна.
+    anomaly_window_destination : {'lefter', 'righter', 'center'}
+        Положение окна относительно аномалии.
+    clear_anomalies_mode : bool
+        True – левый край окна соответствует A_tp, правый A_fp.
+    intersection_mode : {'cut left window', 'cut right window', 'cut both'}
+        Правило разрешения пересекающихся окон.
+    scale_func : {'my_scale'} или Callable
+        Оконная функция NAB.
+        Если 'my_scale' – используется встроенная :func:`_my_scale`.
+        Если передан Callable, он должен иметь сигнатуру
+        `func(fp_case_window, A_tp, A_fp, koef) -> float`.
+    scale_koef : float
+        Параметр крутизны для масштабирующей функции.
+    table_of_coef : dict, optional
+        Профили коэффициентов. По умолчанию – стандартные NAB.
+
+    Returns
+    -------
+    dict
+        {'Standard': float, 'LowFP': float, 'LowFN': float} – NAB скоры в процентах.
+
+    Raises
+    ------
+    MetricValidationError
+        Если истинных аномалий нет (нечего оценивать).
+    """
+    # Проверка и приведение типов
+    true = np.asarray(y_true, dtype=int).ravel()
+    prediction = np.asarray(y_pred, dtype=int).ravel()
+    if true.shape != prediction.shape:
+        raise MetricValidationError(
+            f"При вычислении NAB обнаружена ошибка длины true.shape = {true.shape} и prediction.shape = {prediction.shape}. "
+            "Они должны иметь одинаковую длину")
+
+    # Выбор оконной функции
+    if isinstance(scale_func, str):
+        if scale_func == "my_scale":
+            scale_func_callable = _my_scale
+        else:
+            raise MetricValidationError(
+                "При вычислении NAB обнаружена ошибка. Параметр scale_func как строка может быть только 'my_scale'. "
+                "Для кастомной функции передайте Callable. Подсказка: это можно сделать, создав новую оболочку в модуле метрик "
+                "с кастомной функцией и зарегистрировав новую метрику. В дальнейшем её можно будет вызвать по уникальному имени")
+    elif callable(scale_func):
+        scale_func_callable = scale_func
+    else:
+        raise TypeError(
+            "При вычислении NAB обнаружена ошибка. Параметр scale_func должен быть строкой 'my_scale' или Callable.")
+
+    boundaries = _compute_detecting_boundaries(
+        true,
+        window_width=window_width,
+        portion=portion,
+        anomaly_window_destination=anomaly_window_destination,
+        intersection_mode=intersection_mode,
+    )
+
+    # Фильтрованные границы (без пустых)
+    filtered = _filter_detecting_boundaries(boundaries)
+    if len(filtered) == 0:
+        raise MetricValidationError(
+            "Расчёт NAB невозможен. Не обнаружено ни одной истинной аномалии. "
+        )
+
+    matrix = _single_evaluate_nab(
+        filtered,
+        prediction,
+        table_of_coef=table_of_coef,
+        clear_anomalies_mode=clear_anomalies_mode,
+        scale_func=scale_func_callable,
+        scale_koef=scale_koef,
+    )
+
+    results = {}
+    for t, profile in enumerate(["Standard", "LowFP", "LowFN"]):
+        # Формула NAB: 100 * (Score - Score_null) / (Score_perfect - Score_null)
+        num = matrix[0, t] - matrix[1, t]
+        den = matrix[2, t] - matrix[1, t]
+        # Защита от деления на ноль (теоретически не должно случаться, но для безопасности)
+        if den == 0:
+            results[profile] = 0.0
+        else:
+            results[profile] = round(100.0 * num / den, 2)
+
+    return results
+
+
+def compute_average_time(
+    y_true: np.ndarray,
+    y_pred: np.ndarray,
+    *,
+    window_width: Optional[int] = None,
+    portion: float = 0.1,
+    anomaly_window_destination: str = "lefter",
+    clear_anomalies_mode: bool = True,
+    intersection_mode: str = "cut right window",
+    **_
+) -> Dict[str, (float | int)]:
+    """
+    Вычисление средней задержки обнаружения.
+
+    Parameters
+    ----------
+    true : np.ndarray (1D, int)
+        Бинарная маска истинных аномалий.
+    prediction : np.ndarray (1D, int)
+        Бинарные предсказания.
+    window_width : int, optional
+        Ширина окна обнаружения в отсчётах.
+    portion : float
+        Используется при автоматическом расчёте окна.
+    anomaly_window_destination : {'lefter', 'righter', 'center'}
+        Положение окна.
+    clear_anomalies_mode : bool
+        Определяет, какое срабатывание (первое или последнее) считается.
+    intersection_mode : str
+        Правило разрешения пересечений.
+
+    Returns
+    -------
+    dict
+        {average_delay : float,  # средняя задержка в отсчётах (0, если аномалий не найдено)
+         missing : int,          # количество пропущенных аномалий
+         FP : int,               # количество ложных срабатываний
+         total_anomalies : int}  # общее число истинных аномалий
+    """
+    true = np.asarray(y_true, dtype=int).ravel()
+    prediction = np.asarray(y_pred, dtype=int).ravel()
+    if true.shape != prediction.shape:
+        raise MetricValidationError(
+            f"При вычислении average_time обнаружена ошибка длины true.shape = {true.shape} и prediction.shape = {prediction.shape}. "
+            "Они должны иметь одинаковую длину")
+
+    boundaries = _compute_detecting_boundaries(
+        true,
+        window_width=window_width,
+        portion=portion,
+        anomaly_window_destination=anomaly_window_destination,
+        intersection_mode=intersection_mode,
+    )
+
+    missing, detect_history, fp, total = _single_average_delay(
+        boundaries,
+        prediction,
+        anomaly_window_destination,
+        clear_anomalies_mode,
+    )
+
+    avg_delay = float(np.mean(detect_history)) if detect_history else 0.0
+    return {
+        'average_delay': avg_delay,
+        'missing': missing,
+        'FP': fp,
+        'total_anomalies': total}
+
+
+def metric_nab_standard(y_true: np.ndarray, y_pred: np.ndarray, **params: Any) -> float:
+    return float(compute_nab_score(y_true, y_pred, **params)['Standard'])
+
+
+def metric_nab_low_fp(y_true: np.ndarray, y_pred: np.ndarray, **params: Any) -> float:
+    return float(compute_nab_score(y_true, y_pred, **params)['LowFP'])
+
+
+def metric_nab_low_fn(y_true: np.ndarray, y_pred: np.ndarray, **params: Any) -> float:
+    return float(compute_nab_score(y_true, y_pred, **params)['LowFN'])
+
+# ---------------------------------------------------------------------------
+# shared_reg_forecast
+
+# Unified metrics for time series regression and forecasting.
+# All implementations are in NumPy, ready for replacement with PyTorch (np -> torch, np.where -> torch.where, etc.).
+# ---------------------------------------------------------------------------
+
+# Regression metrics
+
+
+def mse(y_true: np.ndarray, y_pred: np.ndarray, **_) -> float:
+    """Mean Squared Error."""
+    return float(np.mean((y_true - y_pred) ** 2))
+
+
+def rmse(y_true: np.ndarray, y_pred: np.ndarray, **_) -> float:
+    """Root Mean Squared Error."""
+    return float(np.sqrt(mse(y_true, y_pred)))
+
+
+def mae(y_true: np.ndarray, y_pred: np.ndarray, **_) -> float:
+    """Mean Absolute Error."""
+    return float(np.mean(np.abs(y_true - y_pred)))
+
+
+def r2_score(y_true: np.ndarray, y_pred: np.ndarray, **_) -> float:
+    """R² (coefficient of determination)."""
+    residual = np.sum((y_true - y_pred) ** 2)
+    total = np.sum((y_true - np.mean(y_true)) ** 2)
+    return float(1.0 - residual / total) if total > 1e-12 else 0.0
+
+
+def msle(y_true: np.ndarray, y_pred: np.ndarray, **_) -> float:
+    """Mean Squared Logarithmic Error."""
+    if (y_true < 0).any() or (y_pred < 0).any():
+        raise MetricValidationError(
+            'There are negative values in GT or predicted sequence. MSLE does not support negative values')
+    return float(np.mean((np.log1p(y_true) - np.log1p(y_pred)) ** 2))
+
+
+def mape(y_true: np.ndarray, y_pred: np.ndarray, *, epsilon: float = 1e-8, **_) -> float:
+    """
+    Mean Absolute Percentage Error (возвращает долю, не проценты).
+    Совпадает с поведением sklearn.metrics.mean_absolute_percentage_error.
+    """
+    denom = np.maximum(epsilon, np.abs(y_true))
+    return float(np.mean(np.abs((y_true - y_pred) / denom)))
+
+
+def median_absolute_error(y_true: np.ndarray, y_pred: np.ndarray, **_) -> float:
+    """Median Absolute Error."""
+    return float(np.median(np.abs(y_true - y_pred)))
+
+
+def explained_variance_score(y_true: np.ndarray, y_pred: np.ndarray, **_) -> float:
+    """Explained variance regression score."""
+    diff_var = np.var(y_true - y_pred)
+    y_var = np.var(y_true)
+    return float(1.0 - diff_var / y_var) if y_var > 1e-12 else 0.0
+
+
+def max_error(y_true: np.ndarray, y_pred: np.ndarray, **_) -> float:
+    """Max residual error."""
+    return float(np.max(np.abs(y_true - y_pred)))
+
+
+def d2_absolute_error_score(y_true: np.ndarray, y_pred: np.ndarray, **_) -> float:
+    """
+    D² regression score for absolute error (аналог R² для MAE).
+    """
+    numerator = mae(y_true, y_pred)
+    denominator = mae(y_true, np.median(y_true))
+    return float(1.0 - numerator / denominator) if denominator > 1e-12 else 0.0
+
+# ---------------------------------------------------------------------------
+# Forecasting (from benchmark/v2/forecasting.py)
+# ---------------------------------------------------------------------------
+
+# Helper functions for forecasting
+
+
+def _mase_scale(train: np.ndarray, seasonal_period: int) -> float:
+    """
+    Масштаб для MASE: среднее абсолютное изменение ряда с лагом seasonal_period (или 1).
+    """
+    train = np.asarray(
+        train,
+        dtype=float).reshape(
+        -1)  # типа безопаснее было бы сделать .flatten() {не меняет область памяти, а создаёт копию}, но в исходном было reshape(-1), значит так и оставлю
+    lag = seasonal_period if seasonal_period > 1 and len(train) > seasonal_period else 1
+    if len(train) <= lag:
+        return 1.0
+    scale = float(np.mean(np.abs(train[lag:] - train[:-lag])))
+    return scale if scale > 1e-8 else 1.0
+
+
+def _seasonal_naive(train: np.ndarray, horizon: int, seasonal_period: int) -> np.ndarray:
+    """
+    Сезонный наивный прогноз: повтор последнего сезонного блока нужной длины (или 1).
+    """
+    train = np.asarray(train, dtype=float).reshape(-1)
+    lag = seasonal_period if seasonal_period > 1 and len(train) > seasonal_period else 1
+    base = train[-lag:]
+    repeats = int(np.ceil(horizon / lag))
+    return np.tile(base, repeats)[:horizon]
+
+# Pointwise errors for prediction
+
+
+def absolute_error(y_true: np.ndarray, y_pred: np.ndarray, **_) -> np.ndarray:
+    """Поэлементные абсолютные ошибки."""
+    return np.abs(y_true - y_pred)
+
+# Просто так, по сути, пока что не нужна нигде, да и вряд ли понадобится. Я ошибся сделав её, а стирать жалко
+
+
+def squared_error(y_true: np.ndarray, y_pred: np.ndarray, **_) -> np.ndarray:
+    """Поэлементные квадраты ошибок."""
+    return (absolute_error(y_true, y_pred) ** 2)
+#
+    # Pointwise RMSE is identical to absolute_error()
+
+
+def smape_error(y_true: np.ndarray, y_pred: np.ndarray, *, epsilon: float = 1e-8, **_) -> np.ndarray:
+    """
+    Поэлементные значения sMAPE (symmetric MAPE), умножаются на 200.
+    Возвращает массив той же длины, что и входы.
+    """
+    denom = np.abs(y_true) + np.abs(y_pred)
+    denom = np.where(denom < epsilon, epsilon, denom)
+    return 100.0 * 2.0 * np.abs(y_pred - y_true) / denom
+
+
+def mase_error(y_true: np.ndarray,
+               y_pred: np.ndarray,
+               *, y_train: np.ndarray,
+               seasonal_period: int, **_) -> np.ndarray:
+    """Поэлементные значения MASE."""
+    return absolute_error(y_true, y_pred) / _mase_scale(y_train, seasonal_period)
+
+
+def owa_error(y_true: np.ndarray,
+              y_pred: np.ndarray,
+              *, y_train: np.ndarray,
+              seasonal_period: int, **_) -> np.ndarray:
+    """
+    Поэлементные значения OWA (Overall Weighted Average).
+    Возвращает массив, каждый элемент которого вычислен по формуле
+    0.5 * (smape_i / smape_baseline_i + mase_i / mase_baseline_i).
+    """
+    y_train = np.asarray(y_train, dtype=float)
+    horizon = len(y_true)
+    baseline = _seasonal_naive(y_train, horizon, seasonal_period)
+
+    smape_actual = smape_error(y_true, y_pred)
+    mase_actual = mase_error(y_true, y_pred, y_train, seasonal_period)
+    smape_base = smape_error(y_true, baseline)
+    mase_base = mase_error(y_true, baseline, y_train, seasonal_period)
+
+    # защита от деления на 0
+    smape_base = np.where(smape_base < 1e-8, 1.0, smape_base)
+    mase_base = np.where(mase_base < 1e-8, 1.0, mase_base)
+
+    return 0.5 * ((smape_actual / smape_base) + (mase_actual / mase_base))
+
+# Aggregated forecast metrics
+
+    # aggregated mae is identical to mae()
+
+    # aggregated rmse is identical to rmse()
+
+
+def smape(y_true: np.ndarray, y_pred: np.ndarray, **params) -> float:
+    """sMAPE, усреднённый по всем точкам."""
+    if params is None:
+        params = {}
+    epsilon = params.get('epsilon', 1e-8)
+    return float(np.mean(smape_error(y_true, y_pred, epsilon=epsilon)))
+
+
+def mase(y_true: np.ndarray,
+         y_pred: np.ndarray,
+         *, y_train: np.ndarray,
+         seasonal_period: int, **_) -> float:
+    """MASE, усреднённый по всем точкам."""
+    return float(np.mean(mase_error(y_true, y_pred, y_train=y_train, seasonal_period=seasonal_period)))
+
+
+def owa(y_true: np.ndarray, y_pred: np.ndarray,
+        *, y_train: np.ndarray, seasonal_period: int, **params) -> float:
+    """
+    Агрегированный OWA по всему горизонту:
+    0.5 * (smape / smape_baseline + mase / mase_baseline).
+    В отличие от среднего от owa_error, здесь агрегация выполняется после усреднения.
+    """
+    y_train = np.asarray(y_train, dtype=float)
+    horizon = len(y_true)
+    baseline = _seasonal_naive(y_train, horizon, seasonal_period)
+
+    smape_val = smape(y_true, y_pred, **params)
+    mase_val = mase(y_true, y_pred, y_train=y_train, seasonal_period=seasonal_period)
+    smape_base = smape(y_true, baseline, **params)
+    mase_base = mase(y_true, baseline, y_train=y_train, seasonal_period=seasonal_period)
+
+    smape_base = smape_base if smape_base > 1e-8 else 1.0
+    mase_base = mase_base if mase_base > 1e-8 else 1.0
+
+    return float(0.5 * ((smape_val / smape_base) + (mase_val / mase_base)))
+
+# ---------------------------------------------------------------------------
+# Populate registry
+# ---------------------------------------------------------------------------
+
+
+def validate_metric_registry(metric_registry):
+    """
+    Проверяет, что все метрики, зарегистрированные в metric_registry,
+    присутствуют либо в METRICS_TO_MINIMIZE, либо в METRICS_TO_MAXIMIZE.
+
+    Args:
+        metric_registry: Словарь, где ключи — названия категорий (например, 'shared_cls_det'),
+                         значения — словари вида {имя_метрики: функция}.
+
+    Raises:
+        MetricNotFoundError: Если найдены метрики, не попавшие ни в один из кортежей,
+                    или если метрика попала одновременно в оба кортежа.
+    """
+    # Собираем все имена метрик из всех категорий реестра
+    all_registered = set()
+    for category_dict in metric_registry.values():
+        all_registered.update(category_dict.keys())
+
+    covered = set(METRICS_TO_MINIMIZE) | set(METRICS_TO_MAXIMIZE)
+    missing_in_minmax = all_registered - covered
+    if missing_in_minmax:
+        raise MetricNotFoundError(
+            f"Следующие метрики зарегистрированы в реестре, но отсутствуют в кортежах "
+            f"METRICS_TO_MINIMIZE или METRICS_TO_MAXIMIZE: {missing_in_minmax}"
+        )
+
+    missing_in_reg = covered - all_registered
+    if missing_in_reg:
+        raise MetricNotFoundError(
+            f"Следующие метрики присутствуют в кортеже METRICS_TO_MINIMIZE или "
+            f"METRICS_TO_MAXIMIZE, но отсутствуют в реестре : {missing_in_reg}"
+        )
+
+    duplicate = set(METRICS_TO_MINIMIZE) & set(METRICS_TO_MAXIMIZE)
+    if duplicate:
+        raise MetricNotFoundError(
+            f"Следующие метрики одновременно присутствуют в METRICS_TO_MINIMIZE "
+            f"и METRICS_TO_MAXIMIZE: {duplicate}"
+        )
+
+
+# def flatten_metric_value(name: str, value: Any) -> dict[str, float]:
+#     """Развернуть dict-результаты метрик в плоские числовые ключи.
+
+#       nab → {'nab.Standard': ..., 'nab.LowFP': ..., 'nab.LowFN': ..., 'nab': nab.Standard}
+#             (canonical alias под исходным именем для обратной совместимости с
+#              primary_metric='nab' в presets и FEDOT-обвязке).
+#       bin_metrics → {'bin_metrics.TP': ..., 'bin_metrics.f1': ..., ..., 'bin_metrics': <first numeric>}
+#       bin_f1 (float) → {'bin_f1': float}
+#       per_class_scores (dict со списками) → {} (списки не сводятся скаляром).
+
+#     Нечисловые элементы внутри dict пропускаются.
+#     """
+#     if isinstance(value, (int, float, np.floating)):
+#         return {name: float(value)}
+#     if isinstance(value, dict):
+#         flat: dict[str, float] = {}
+#         for sub_key, sub_value in value.items():
+#             if isinstance(sub_value, (int, float, np.floating)):
+#                 flat[f'{name}.{sub_key}'] = float(sub_value)
+#         if not flat:
+#             return {}
+#         # canonical alias под исходным именем: для nab берём 'Standard', иначе первое числовое
+#         if f'{name}.Standard' in flat:
+#             flat.setdefault(name, flat[f'{name}.Standard'])
+#         else:
+#             flat.setdefault(name, next(iter(flat.values())))
+#         return flat
+#     return {}
+
+
+def _register_all() -> None:
+    METRIC_REGISTRY['shared_cls_det'].update({
+        'accuracy': accuracy,
+        'balanced_accuracy': balanced_accuracy,
+        'f1': f1_score,
+        'precision': precision,
+        'recall': recall,
+        'per_class_scores': per_class_scores,
+        'logloss': metric_logloss,
+        'roc_auc': metric_roc_auc,
+    })
+    METRIC_REGISTRY['anomaly_detection'].update({
+        # Unpacking all classification metrics
+        **METRIC_REGISTRY['shared_cls_det'],
+        # Binary metrics for the case with classes 0 and 1, where 1 is the positive class.
+        # THERE IS AN ARGUMENT FOR SETTING pos_label, BUT IT'S HARDCODED FOR 1 NOW
+        'bin_confusion_matrix': binary_confusion_matrix,
+        'bin_precision': binary_precision,
+        'bin_recall': binary_recall,
+        'bin_f1': binary_f1,
+        'bin_far': binary_far,
+        'bin_mar': binary_mar,
+        'bin_metrics': binary_metrics,
+        # Anomaly Detection-Specific Metrics - NAB and average_time
+        'nab': compute_nab_score,
+        'nab_standard': metric_nab_standard,
+        'nab_low_fp': metric_nab_low_fp,
+        'nab_low_fn': metric_nab_low_fn,
+        'average_time': compute_average_time,
+    })
+    METRIC_REGISTRY['shared_reg_forecast'].update({
+        'mse': mse,
+        'rmse': rmse,
+        'mae': mae,
+        'r2': r2_score,
+        'msle': msle,
+        'mape': mape,
+        'median_absolute_error': median_absolute_error,
+        'explained_variance_score': explained_variance_score,
+        'max_error': max_error,
+        'd2_absolute_error_score': d2_absolute_error_score,
+    })
+    METRIC_REGISTRY['forecasting'].update({
+        # Unpacking all regression metrics
+        **METRIC_REGISTRY['shared_reg_forecast'],
+        # Aggregated, as was done in forecasting
+        # 'mae': mae, # есть в регрессии с таким же именем
+        # 'rmse': rmse, # есть в регрессии с таким же именем
+        'smape': smape,
+        'mase': mase,
+        'owa': owa,
+        # Pointwise, as was done in forecasting
+        'pw_mae': absolute_error,
+        'pw_rmse': absolute_error,
+        'pw_smape': smape_error,
+        'pw_mase': mase_error,
+        'pw_owa': owa_error,
+    })
+
+    # Constants for minimization (the smaller the better)
+    global METRICS_TO_MINIMIZE
+    METRICS_TO_MINIMIZE = (
+        *METRICS_TO_MINIMIZE,
+        'logloss',                # логистическая потеря
+        'bin_far',                # доля ложных срабатываний (False Acceptance Rate)
+        'bin_mar',                # доля пропущенных тревог (Missed Alarm Rate)
+        'average_time',           # среднее время обработки
+        'mse',                    # среднеквадратичная ошибка
+        'rmse',                   # корень из среднеквадратичной ошибки
+        'mae',                    # средняя абсолютная ошибка
+        'msle',                   # среднеквадратичная логарифмическая ошибка
+        'mape',                   # средняя абсолютная процентная ошибка
+        'median_absolute_error',  # медианная абсолютная ошибка
+        'max_error',              # максимальная ошибка
+        'smape',                  # симметричная MAPE
+        'mase',                   # масштабированная абсолютная ошибка
+        'owa',                    # общий взвешенный средний (Overall Weighted Average)
+        'pw_mae',                 # поточечная MAE
+        'pw_rmse',                # поточечная RMSE
+        'pw_smape',               # поточечная SMAPE
+        'pw_mase',                # поточечная MASE
+        'pw_owa',                 # поточечная OWA
+    )
+
+    # Constants for maximization (the bigger the better)
+    global METRICS_TO_MAXIMIZE
+    METRICS_TO_MAXIMIZE = (
+        *METRICS_TO_MAXIMIZE,
+        'accuracy',
+        'balanced_accuracy',
+        'f1',
+        'precision',
+        'recall',
+        'roc_auc',
+        'per_class_scores',        # сложная метрика (словарь), включается для полноты
+        'bin_precision',
+        'bin_recall',
+        'bin_f1',
+        'bin_confusion_matrix',    # матрица ошибок, не скаляр
+        'bin_metrics',             # агрегированный словарь метрик
+        'nab',                     # Numenta Anomaly Benchmark score (основной)
+        'nab_standard',            # NAB со стандартным профилем
+        'nab_low_fp',              # NAB с низкой частотой ложных срабатываний
+        'nab_low_fn',              # NAB с низкой частотой пропусков
+        'r2',                      # коэффициент детерминации R²
+        'explained_variance_score',
+        'd2_absolute_error_score',  # аналог R² для абсолютной ошибки
+    )
+
+    validate_metric_registry(METRIC_REGISTRY)
+
+
+_register_all()

--- a/fedot_ind/core/metrics/metrics.py
+++ b/fedot_ind/core/metrics/metrics.py
@@ -1,0 +1,403 @@
+"""Unified metrics API: one dataset per call, dict results, parameterized metric specs.
+
+See ``README.md`` in this package. Legacy pandas DataFrame output remains in
+``metrics_implementation.py``.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from typing import Any
+
+import pandas as pd
+import numpy as np
+
+from fedot_ind.core.metrics._exceptions import (
+    MetricError,
+    MetricNotFoundError,
+    MetricValidationError,
+)
+from fedot_ind.core.metrics.metric_library import get_metric
+
+__all__ = [
+    'MetricError',
+    'MetricNotFoundError',
+    'MetricValidationError',
+    'QualityMetric',
+    'ClassificationMetric',
+    'AnomalyMetric',
+    'RegressionMetric',
+    'ForecastingMetric',
+    'calculate_classification_metric',
+    'calculate_detection_metric',
+    'calculate_regression_metric',
+    'calculate_forecasting_metric',
+]
+
+
+# ---------------------------------------------------------------------------
+# Input helpers (no interval support)
+# ---------------------------------------------------------------------------
+
+def _as_array(values: Any, *, dtype=None) -> np.ndarray:
+    return np.asarray(values, dtype=dtype)
+
+
+def _reject_nested_series(values: Any) -> None:
+    """Reject batched multi-series input like ``[[0, 1], [1, 0]]``."""
+    if isinstance(values, np.ndarray):
+        return
+    if isinstance(values, (list, tuple)) and len(values) > 0 and isinstance(values[0], (list, tuple)):
+        inner = values[0]
+        if len(inner) > 0 and not isinstance(inner[0], (list, tuple)):
+            raise MetricValidationError(
+                'multiple series in one call are not supported; evaluate one dataset at a time.',
+            )
+
+
+def _labels(target_or_labels: Any) -> np.ndarray:
+    _reject_nested_series(target_or_labels)
+    array = _as_array(target_or_labels)
+    if array.ndim >= 2 and array.shape[-1] > 1:
+        array = np.argmax(array, axis=-1)
+    return array.reshape(-1)
+
+
+def _has_none_values(values: Any) -> bool:
+    if values is None:
+        return True
+    array = np.asarray(values, dtype=object).reshape(-1)
+    return any(item is None for item in array)
+
+
+def _float_pair(target: Any, predicted: Any) -> tuple[np.ndarray, np.ndarray]:
+    y_true = _as_array(target, dtype=float).reshape(-1)
+    y_pred = _as_array(predicted, dtype=float).reshape(-1)
+    if len(y_true) != len(y_pred):
+        raise MetricValidationError(
+            f'target and predicted must have the same length ({len(y_true)} != {len(y_pred)}).',
+        )
+    return y_true, y_pred
+
+
+def _probs(probs: Any | None, *, n_samples: int) -> np.ndarray | None:
+    if probs is None:
+        return None
+    array = _as_array(probs, dtype=float)
+    if array.ndim == 1:
+        return array.reshape(-1)
+    if array.ndim != 2 or array.shape[0] != n_samples:
+        raise MetricValidationError('predicted_probs must be 1D or 2D with shape (n_samples, n_classes).')
+    return array
+
+
+def _normalize_metrics(
+        metrics: Sequence[str | Mapping[str, Any]] | str | None,
+        default: tuple[str, ...],
+) -> tuple[str | Mapping[str, Any], ...]:
+    if metrics is None:
+        return default
+    if isinstance(metrics, str):
+        return (metrics,)
+    return tuple(metrics)
+
+
+def _parse_spec(spec: str | Mapping[str, Any]) -> tuple[str, dict[str, Any]]:
+    if isinstance(spec, str):
+        return spec, {}
+    if isinstance(spec, Mapping):
+        name = spec.get('name')
+        if not name:
+            raise MetricValidationError('Metric spec dict must include "name".')
+        params = spec.get('params') or {}
+        if not isinstance(params, Mapping):
+            raise MetricValidationError('Metric spec "params" must be a mapping.')
+        return str(name), dict(params)
+    raise MetricValidationError(f'Invalid metric spec: {type(spec).__name__}.')
+
+
+def _result_keys(names: list[str]) -> list[str]:
+    counts: dict[str, int] = {}
+    keys: list[str] = []
+    for name in names:
+        if name not in counts:
+            counts[name] = 0
+            keys.append(name)
+        else:
+            counts[name] += 1
+            keys.append(f'{name}__{counts[name]}')
+    return keys
+
+
+# ---------------------------------------------------------------------------
+# QualityMetric and task evaluators
+# ---------------------------------------------------------------------------
+
+class QualityMetric:
+    """Base evaluator: parses metric specs and dispatches to ``metric_library``."""
+
+    task: str = 'NONE'
+
+    def __init__(self, rounding_order: int = 4) -> None:
+        self.rounding_order = int(rounding_order)
+        self.target: np.ndarray = np.array([])
+        self.predicted: np.ndarray = np.array([])
+
+    def _extra_kwargs(self, _metric_name: str) -> dict[str, Any]:
+        return {}
+
+    def metric_evaluation(
+            self,
+            metrics_specs: Sequence[str | Mapping[str, Any]],
+    ) -> dict[str, float | list | dict]:
+        if not metrics_specs:
+            return {}
+        parsed = [_parse_spec(s) for s in metrics_specs]
+        names = [n for n, _ in parsed]
+        keys = _result_keys(names)
+        out: dict[str, float | list | dict] = {}
+        for key, (name, params) in zip(keys, parsed):
+            fn = get_metric(self.task, name)
+            value = fn(self.target, self.predicted, **{**self._extra_kwargs(name), **params})
+            if isinstance(value, (float, np.floating)):
+                out[key] = round(float(value), self.rounding_order)
+            elif isinstance(value, dict):
+                new_value = {}
+                for subkey, subvalue in value.items():
+                    if isinstance(subvalue, (float, np.floating)):
+                        new_value[subkey] = round(float(subvalue), self.rounding_order)
+                    elif isinstance(subvalue, (int,)):
+                        new_value[subkey] = int(subvalue)
+                    elif isinstance(subvalue, (list, np.ndarray)):
+                        np_value = np.array(subvalue, dtype=float)
+                        # При необходимости можно переделать на чистый list или убрать это
+                        new_value[subkey] = np.round(np_value, self.rounding_order).tolist()
+                    else:
+                        raise MetricValidationError(
+                            f'Undefined data type of the metric output in dict values: {type(subvalue).__name__}')
+                out[key] = new_value
+            # Тут я забыл, что единственное место, вроде бы, где я возвращаю список - это словарь спиское.
+            # Поэтмоу этот код не испоьзуется, но пусть будет, если кто-то захочет в добавленной метрике
+            # выводить список. И он тоже будет округлённым.
+            elif isinstance(value, (list, np.ndarray)):
+                np_value = np.array(value, dtype=float)
+                # При необходимости можно переделать на чистый list
+                out[key] = np.round(np_value, self.rounding_order).tolist()
+            else:
+                # out[key] = value
+                raise MetricValidationError(f'Undefined data type of the metric output: {type(value).__name__}')
+        return out
+
+
+class ClassificationMetric(QualityMetric):
+    """Classification metrics on label sequences (optional probabilities)."""
+
+    task = 'classification'
+
+    def __init__(
+            self,
+            target: Any,
+            predicted_labels: Any,
+            predicted_probs: Any | None = None,
+            rounding_order: int = 4,
+    ) -> None:
+        super().__init__(rounding_order=rounding_order)
+        self.target = _labels(target)
+        self.predicted = _labels(predicted_labels)
+        if _has_none_values(self.predicted):
+            raise MetricValidationError('Predicted labels is None.')
+        if len(self.target) != len(self.predicted):
+            raise MetricValidationError('target and predicted_labels length mismatch.')
+        self._probs = _probs(predicted_probs, n_samples=len(self.target))
+
+    def _extra_kwargs(self, _metric_name: str) -> dict[str, Any]:
+        return {'predicted_probs': self._probs, }
+
+
+class RegressionMetric(QualityMetric):
+    """Regression metrics on float vectors."""
+
+    task = 'regression'
+
+    def __init__(self, target: Any, predicted: Any, rounding_order: int = 4) -> None:
+        super().__init__(rounding_order=rounding_order)
+        self.target, self.predicted = _float_pair(target, predicted)
+
+
+class ForecastingMetric(QualityMetric):
+    """Forecasting horizon metrics (aggregate or pointwise via metric params)."""
+
+    task = 'forecasting'
+
+    def __init__(
+            self,
+            target: Any,
+            predicted: Any,
+            rounding_order: int = 4,
+            train_data: Any | None = None,
+            seasonality: int = 1,
+    ) -> None:
+        super().__init__(rounding_order=rounding_order)
+        self.target, self.predicted = _float_pair(target, predicted)
+        self._train = _as_array(train_data if train_data is not None else target, dtype=float).reshape(-1)
+        self._seasonality = int(seasonality)
+
+    def _extra_kwargs(self, _metric_name: str) -> dict[str, Any]:
+        return {'y_train': self._train, 'seasonal_period': self._seasonality}
+
+
+class AnomalyMetric(QualityMetric):
+    """Anomaly detection on binary label sequences (0/1)."""
+
+    task = 'anomaly_detection'
+
+    def __init__(
+            self,
+            target: Any,
+            predicted_labels: Any,
+            predicted_probs: Any | None = None,
+            rounding_order: int = 4,
+            **detection_params: Any,
+    ) -> None:
+        super().__init__(rounding_order=rounding_order)
+        self.target = _labels(target)
+        self.predicted = _labels(predicted_labels)
+        if _has_none_values(self.predicted):
+            raise MetricValidationError('Predicted labels is None.')
+        if len(self.target) != len(self.predicted):
+            raise MetricValidationError('target and predicted_labels length mismatch.')
+        self._probs = _probs(predicted_probs, n_samples=len(self.target))
+        self._detection_params = detection_params
+
+    def _extra_kwargs(self, _metric_name: str) -> dict[str, Any]:
+        return {**self._detection_params, 'predicted_probs': self._probs, }
+
+# PANDAS return adapter for legacy code in FedotIndustrial class
+
+
+def _flatten_metric_result(result: dict) -> dict:
+    flat = {}
+    for key, value in result.items():
+        if isinstance(value, dict):
+            for sub_key, sub_value in value.items():
+                flat[f'{key}.{sub_key}'] = sub_value
+                # flat[f'{sub_key}'] = sub_value
+        elif isinstance(value, list):
+            flat[key] = value
+        else:
+            flat[key] = value
+    return flat
+
+
+def _result_to_dataframe(result: dict, rounding_order: int) -> pd.DataFrame:
+    # return pd.DataFrame([_flatten_metric_result(result)], index=[0]).round(rounding_order)
+    return pd.DataFrame([result], index=[0]).round(rounding_order)
+
+# ---------------------------------------------------------------------------
+# Public calculate_* API
+# ---------------------------------------------------------------------------
+
+
+def calculate_classification_metric(
+        target: Any,
+        predicted_labels: Any,
+        predicted_probs: Any | None = None,
+        metric_names: Sequence[str | Mapping[str, Any]] | str | None = None,
+        rounding_order: int = 4,
+        return_dataframe: bool = True,
+        return_raw_dict: bool = False,
+        **kwargs: Any,
+) -> dict[str, float | list | dict]:
+    """Compute classification metrics for one dataset."""
+    specs = _normalize_metrics(metric_names, ('f1', 'accuracy'))
+    result = ClassificationMetric(target,
+                                  predicted_labels,
+                                  predicted_probs,
+                                  rounding_order=rounding_order,
+                                  ).metric_evaluation(specs)
+    if not return_raw_dict:
+        res = _flatten_metric_result(result)
+        if return_dataframe:  # kwargs.get('return_dataframe', True):
+            return _result_to_dataframe(res, rounding_order)
+        return res
+    return result
+
+
+def calculate_detection_metric(
+        target: Any,
+        predicted_labels: Any,
+        predicted_probs=None,
+        metric_names: Sequence[str | Mapping[str, Any]] | str | None = None,
+        rounding_order: int = 4,
+        return_dataframe: bool = True,
+        return_raw_dict: bool = False,
+        **kwargs: Any,
+) -> dict[str, float | list | dict]:
+    """Compute anomaly detection metrics on binary label sequences."""
+    specs = _normalize_metrics(metric_names, ('f1', 'accuracy'))
+    result = AnomalyMetric(
+        target,
+        predicted_labels,
+        predicted_probs,
+        rounding_order=rounding_order,
+        **kwargs,
+    ).metric_evaluation(specs)
+    if not return_raw_dict:
+        res = _flatten_metric_result(result)
+        if return_dataframe:  # kwargs.get('return_dataframe', True):
+            return _result_to_dataframe(res, rounding_order)
+        return res
+    return result
+
+
+def calculate_regression_metric(
+        target: Any,
+        predicted_labels: Any,
+        metric_names: Sequence[str | Mapping[str, Any]] | str | None = None,
+        rounding_order: int = 4,
+        return_dataframe: bool = True,
+        return_raw_dict: bool = False,
+        **kwargs: Any,
+) -> dict[str, float | list | dict]:
+    """Compute regression metrics for one dataset."""
+    del kwargs
+    specs = _normalize_metrics(metric_names, ('r2', 'rmse', 'mae'))
+    result = RegressionMetric(target,
+                              predicted_labels,
+                              rounding_order=rounding_order
+                              ).metric_evaluation(specs)
+    if not return_raw_dict:
+        res = _flatten_metric_result(result)
+        if return_dataframe:  # kwargs.get('return_dataframe', True):
+            return _result_to_dataframe(res, rounding_order)
+        return res
+    return result
+
+
+def calculate_forecasting_metric(
+        target: Any,
+        predicted_labels: Any,
+        metric_names: Sequence[str | Mapping[str, Any]] | str | None = None,
+        rounding_order: int = 4,
+        return_dataframe: bool = True,
+        return_raw_dict: bool = False,
+        train_data=None,
+        seasonality=None,
+        **kwargs: Any,
+) -> dict[str, float | list | dict]:
+    """Compute forecasting metrics for one horizon."""
+    specs = _normalize_metrics(metric_names, ('smape', 'rmse', 'mape'))
+    result = ForecastingMetric(
+        target,
+        predicted_labels,
+        rounding_order=rounding_order,
+        train_data=train_data,  # kwargs.get('train_data'),
+        # int(kwargs.get('seasonality', kwargs.get('seasonal_period', 1))),
+        seasonality=(int(seasonality) if seasonality is not None else 1)
+    ).metric_evaluation(specs)
+    if not return_raw_dict:
+        res = _flatten_metric_result(result)
+        if return_dataframe:  # kwargs.get('return_dataframe', True):
+            return _result_to_dataframe(res, rounding_order)
+        return res
+    return result

--- a/fedot_ind/core/metrics/metrics_implementation.py
+++ b/fedot_ind/core/metrics/metrics_implementation.py
@@ -23,8 +23,6 @@ from sklearn.metrics import (
     r2_score,
     roc_auc_score,
 )
-from sktime.performance_metrics.forecasting import mean_absolute_scaled_error, median_absolute_scaled_error, \
-    mean_absolute_error as tsf_mae, median_absolute_error as tsf_mdae, mean_absolute_percentage_error as tsf_mape
 
 from fedot_ind.core.architecture.settings.computational import backend_methods as np
 

--- a/fedot_ind/core/metrics/metrics_implementation.py
+++ b/fedot_ind/core/metrics/metrics_implementation.py
@@ -7,6 +7,7 @@ from fedot.core.operations.operation_parameters import OperationParameters
 from golem.core.dag.graph import Graph
 from sklearn.metrics import (
     accuracy_score,
+    balanced_accuracy_score,
     d2_absolute_error_score,
     explained_variance_score,
     f1_score,
@@ -18,6 +19,7 @@ from sklearn.metrics import (
     mean_squared_log_error,
     median_absolute_error,
     precision_score,
+    recall_score,
     r2_score,
     roc_auc_score,
 )
@@ -238,110 +240,97 @@ class Accuracy(QualityMetric):
         return accuracy_score(y_true=self.target, y_pred=self.predicted_labels)
 
 
+def _flatten_metric_result(result: dict) -> dict:
+    flat = {}
+    for key, value in result.items():
+        if isinstance(value, dict):
+            for sub_key, sub_value in value.items():
+                # flat[f'{key}_{sub_key}'] = sub_value
+                flat[f'{sub_key}'] = sub_value
+        elif isinstance(value, list):
+            flat[key] = value
+        else:
+            flat[key] = value
+    return flat
+
+
+def _result_to_dataframe(result: dict, rounding_order: int) -> pd.DataFrame:
+    return pd.DataFrame([_flatten_metric_result(result)], index=[0]).round(rounding_order)
+
+
+def _resolve_legacy_predictions(predicted_labels, predicted_probs, kwargs):
+    """Accept old ``labels``/``probs`` kwargs used by FedotIndustrial API."""
+    if predicted_labels is None and 'labels' in kwargs:
+        predicted_labels = kwargs.pop('labels')
+    if predicted_probs is None and 'probs' in kwargs:
+        predicted_probs = kwargs.pop('probs')
+    return predicted_labels, predicted_probs
+
+
 def calculate_regression_metric(target,
-                                labels,
-                                rounding_order=3,
+                                predicted_labels=None,
                                 metric_names=None,
+                                rounding_order=3,
                                 **kwargs):
+    from fedot_ind.core.metrics.metrics import calculate_regression_metric as _calculate
 
-    # Set default metrics
-    if metric_names is None:
-        metric_names = ('r2', 'rmse', 'mae')
-
-    target = target.astype(float)
-
-    # def mean_squared_error(y_true, y_pred):
-    #     return root_mean_squared_error(y_true, y_pred) ** 2
-
-    metric_dict = {'r2': r2_score,
-                   'mse': mean_squared_error,
-                   'rmse': root_mean_squared_error,
-                   'mae': mean_absolute_error,
-                   'msle': mean_squared_log_error,
-                   'mape': mean_absolute_percentage_error,
-                   'median_absolute_error': median_absolute_error,
-                   'explained_variance_score': explained_variance_score,
-                   'max_error': max_error,
-                   'd2_absolute_error_score': d2_absolute_error_score}
-
-    df = pd.DataFrame({name: func(target,
-                                  labels) for name,
-                       func in metric_dict.items() if name in metric_names},
-                      index=[0])
-    return df.round(rounding_order)
+    predicted_labels, _ = _resolve_legacy_predictions(predicted_labels, None, kwargs)
+    result = _calculate(
+        target=target,
+        predicted_labels=predicted_labels,
+        metric_names=metric_names,
+        rounding_order=rounding_order,
+        **kwargs,
+    )
+    if kwargs.get('return_dataframe', True):
+        return _result_to_dataframe(result, rounding_order)
+    return result
 
 
 def calculate_forecasting_metric(target,
-                                 labels,
-                                 rounding_order=3,
+                                 predicted_labels=None,
                                  metric_names=None,
+                                 rounding_order=3,
                                  train_data=None,
                                  seasonality=None,
                                  **kwargs):
-    target = target.astype(float)
+    from fedot_ind.core.metrics.metrics import calculate_forecasting_metric as _calculate
 
-    # Set default metrics
-    if metric_names is None:
-        metric_names = ('smape', 'rmse', 'mape')
-
-    def rmse(y_true, y_pred, T, _=None):
-        return root_mean_squared_error(y_true, y_pred)
-
-    def mae(A, F, T, _=None):
-        return tsf_mae(A, F)
-
-    def mdae(A, F, T, _=None):
-        return tsf_mdae(A, F)
-
-    def mase(A, F, y_train, sp):
-        return mean_absolute_scaled_error(A, F, sp=sp, y_train=y_train)
-
-    def mdase(A, F, y_train, sp):
-        return median_absolute_scaled_error(A, F, sp=sp, y_train=y_train)
-
-    def mape(A, F, T, _=None):
-        return tsf_mape(A, F) * 100
-
-    def smape(A, F, T, _=None):
-        return tsf_mape(A, F, symmetric=True) * 100
-
-    metric_dict = {
-        'rmse': rmse,
-        'mae': mae,
-        'mdae': mdae,
-        'mase': mase,
-        'mdase': mdase,
-        'mape': mape,
-        'smape': smape,
-    }
-
-    df = pd.DataFrame({name: func(target,
-                                  labels, train_data, seasonality) for name,
-                       func in metric_dict.items() if name in metric_names},
-                      index=[0])
-    return df.round(rounding_order)
+    predicted_labels, _ = _resolve_legacy_predictions(predicted_labels, None, kwargs)
+    result = _calculate(
+        target=target,
+        predicted_labels=predicted_labels,
+        metrics=metric_names,
+        rounding_order=rounding_order,
+        train_data=train_data,
+        seasonality=seasonality,
+        **kwargs,
+    )
+    if kwargs.get('return_dataframe', True):
+        return _result_to_dataframe(result, rounding_order)
+    return result
 
 
 def calculate_classification_metric(target,
-                                    labels,
-                                    probs,
+                                    predicted_labels=None,
+                                    predicted_probs=None,
+                                    metric_names=None,
                                     rounding_order=3,
-                                    metric_names=('f1', 'accuracy'),
                                     **kwargs):
+    from fedot_ind.core.metrics.metrics import calculate_classification_metric as _calculate
 
-    # Set default metrics
-    if metric_names is None:
-        metric_names = ('f1', 'accuracy')
-
-    metric_dict = {'accuracy': Accuracy,
-                   'f1': F1,
-                   # 'roc_auc': ROCAUC,
-                   'precision': Precision,
-                   'logloss': Logloss}
-
-    df = pd.DataFrame({name: func(target, labels, probs).metric()
-                      for name, func in metric_dict.items() if name in metric_names}, index=[0])
-    return df.round(rounding_order)
+    predicted_labels, predicted_probs = _resolve_legacy_predictions(predicted_labels, predicted_probs, kwargs)
+    result = _calculate(
+        target=target,
+        predicted_labels=predicted_labels,
+        predicted_probs=predicted_probs,
+        metric_names=metric_names,
+        rounding_order=rounding_order,
+        **kwargs,
+    )
+    if kwargs.get('return_dataframe', True):
+        return _result_to_dataframe(result, rounding_order)
+    return result
 
 
 def kl_divergence(solution: pd.DataFrame,
@@ -391,7 +380,139 @@ def kl_divergence(solution: pd.DataFrame,
         return np.average(solution.mean())
 
 
+class DetectionQualityMetric:
+    """Бзовый класс для pure detection метрик.
+    источник правдя для любого запуска:
+    benchmark, CLI, example, AutoML, тесты API shells.
+    """
+    default_value = 0.0
+    need_to_minimize = False  # метрику нужно максимизировать (f1, precision, recall, balanced_accuracy)
+    output_mode = 'labels'
+
+    @classmethod
+    def _to_1d_int_array(cls, values):
+        """приводение входных значений к единому формату:
+        одномерный numpy-массив целых чисел."""
+        if hasattr(values, 'detach'):
+            values = values.detach().cpu().numpy()
+        return np.asarray(values, dtype=int).reshape(-1)
+
+    @classmethod
+    def metric(cls, target, predict) -> float:
+        """каждый класс-метрика обязан реализовать свой metric,
+        иначе код упадёт явно"""
+        raise NotImplementedError
+
+
+class DetectionAccuracy(DetectionQualityMetric):
+    """Point-level accuracy."""
+    @classmethod
+    def metric(cls, target, predict) -> float:
+        target = cls._to_1d_int_array(target)
+        predict = cls._to_1d_int_array(predict)
+        return float(accuracy_score(target, predict))
+
+
+class DetectionBalancedAccuracy(DetectionQualityMetric):
+    """Point-level balanced accuracy."""
+    @classmethod
+    def metric(cls, target, predict) -> float:
+        target = cls._to_1d_int_array(target)
+        predict = cls._to_1d_int_array(predict)
+        return float(balanced_accuracy_score(target, predict))
+
+
+class DetectionPrecision(DetectionQualityMetric):
+    """Point-level anomaly precision."""
+    @classmethod
+    def metric(cls, target, predict) -> float:
+        target = cls._to_1d_int_array(target)
+        predict = cls._to_1d_int_array(predict)
+        return float(precision_score(target, predict, zero_division=0))
+
+
+class DetectionRecall(DetectionQualityMetric):
+    """Point-level anomaly recall."""
+    @classmethod
+    def metric(cls, target, predict) -> float:
+        target = cls._to_1d_int_array(target)
+        predict = cls._to_1d_int_array(predict)
+        return float(recall_score(target, predict, zero_division=0))
+
+
+class DetectionF1(DetectionQualityMetric):
+    """Binary point-level F1 для label = 1."""
+    @classmethod
+    def metric(cls, target, predict) -> float:
+        target = cls._to_1d_int_array(target)
+        predict = cls._to_1d_int_array(predict)
+        return float(f1_score(target, predict, zero_division=0))
+
+
+class DetectionF1Macro(DetectionQualityMetric):
+    """Macro F1 отдельно для класса 0 и для класса 1
+    с последующим усреднением.
+    """
+    @classmethod
+    def metric(cls, target, predict) -> float:
+        target = cls._to_1d_int_array(target)
+        predict = cls._to_1d_int_array(predict)
+        return float(f1_score(target, predict, average='macro', zero_division=0))
+
+
+# DETECTION_METRICS = {
+#     'accuracy': DetectionAccuracy,
+#     'balanced_accuracy': DetectionBalancedAccuracy,
+#     'precision': DetectionPrecision,
+#     'recall': DetectionRecall,
+#     'f1': DetectionF1,
+#     'f1_macro': DetectionF1Macro,
+
+#     # TODO: реализовать event-level Delay-Aware detection метрики
+#     # 'event_precision': DetectionEventPrecision,
+#     # 'event_recall': DetectionEventRecall,
+#     # 'event_f1': DetectionEventF1,
+#     # 'detection_delay': DetectionDelay,
+#     # 'fp_per_series': DetectionFalsePositivePerSeries,
+#     # 'nab': DetectionNAB,
+# }
+
+# SUPPORTED_DETECTION_METRICS = tuple(DETECTION_METRICS)
+
+
+# def calculate_detection_metric(
+#         target,
+#         labels,
+#         rounding_order=6,
+#         metric_names=None,
+#         **kwargs):
+#     """Единая функция-фасад для расчёта detection-метрик."""
+#     if metric_names is None:
+#         metric_names = ('f1_macro', 'balanced_accuracy')
+
+#     unsupported_metrics = set(metric_names) - set(DETECTION_METRICS)
+#     if unsupported_metrics:
+#         raise ValueError(f'Unsupported detection metrics: {sorted(unsupported_metrics)}')
+
+#     return {
+#         name: round(float(DETECTION_METRICS[name].metric(target, labels)), rounding_order)
+#         for name in metric_names
+#     }
+
+
+# DETECTION_METRICS_TO_MINIMIZE = tuple(
+#     name for name, metric in DETECTION_METRICS.items()
+#     if metric.need_to_minimize
+# )
+
+# DETECTION_METRICS_TO_MAXIMIZE = tuple(
+#     name for name, metric in DETECTION_METRICS.items()
+#     if not metric.need_to_minimize
+# )
+
+
 class AnomalyMetric(QualityMetric):
+    """Legacy NAB/window-based anomaly metric"""
 
     def __init__(self,
                  target,
@@ -650,7 +771,29 @@ class AnomalyMetric(QualityMetric):
         metric_dict = _metric_dict[self.metric](detecting_boundaries)
         return metric_dict
 
+# Legacy public function
+# def calculate_detection_metric(target, labels, **kwargs):
+#     metric_dict = AnomalyMetric(target=target, predicted_labels=labels).metric()
+#     return metric_dict
 
-def calculate_detection_metric(target, labels, **kwargs):
-    metric_dict = AnomalyMetric(target=target, predicted_labels=labels).metric()
-    return metric_dict
+
+def calculate_detection_metric(target,
+                               predicted_labels=None,
+                               predicted_probs=None,
+                               metric_names=None,
+                               rounding_order=3,
+                               **kwargs):
+    from fedot_ind.core.metrics.metrics import calculate_detection_metric as _calculate
+
+    predicted_labels, predicted_probs = _resolve_legacy_predictions(predicted_labels, predicted_probs, kwargs)
+    result = _calculate(
+        target=target,
+        predicted_labels=predicted_labels,
+        predicted_probs=predicted_probs,
+        metric_names=metric_names,
+        rounding_order=rounding_order,
+        **kwargs,
+    )
+    if kwargs.get('return_dataframe', True):
+        return _result_to_dataframe(result, rounding_order)
+    return result

--- a/fedot_ind/core/models/detection/__init__.py
+++ b/fedot_ind/core/models/detection/__init__.py
@@ -37,14 +37,7 @@ __all__ = [
 ]
 
 try:  # pragma: no cover - optional FEDOT runtime dependency
-    from fedot_ind.core.models.detection.modern_detectors import (
-        BaseRuntimeAnomalyDetector,
-        ConvAutoencoderDetector,
-        FeatureIsolationForestDetector,
-        FeatureOneClassDetector,
-        TCNAutoencoderDetector,
-        build_detection_input_data,
-    )
+    pass
 
     __all__.extend(
         [

--- a/fedot_ind/core/models/detection/__init__.py
+++ b/fedot_ind/core/models/detection/__init__.py
@@ -1,0 +1,60 @@
+from fedot_ind.core.models.detection.runtime import (
+    AnomalyScoreSeries,
+    DetectionBoundaryAdapter,
+    DetectionEvent,
+    DetectionSeriesEvaluation,
+    DetectionSplitKind,
+    DetectionSplitSpec,
+    DetectionWindowBatch,
+    RegimeSegment,
+    RiskFeatureFrame,
+    TransferAlignmentReport,
+    DetectionRuntimeResult,
+)
+from fedot_ind.core.models.detection.stage_tuning import (
+    DetectionStageName,
+    DetectionStageTuningPlan,
+    StageTuningGroup,
+    build_detection_stage_tuning_plan,
+)
+
+__all__ = [
+    'AnomalyScoreSeries',
+    'DetectionBoundaryAdapter',
+    'DetectionEvent',
+    'DetectionSeriesEvaluation',
+    'DetectionSplitKind',
+    'DetectionSplitSpec',
+    'DetectionStageName',
+    'DetectionStageTuningPlan',
+    'DetectionWindowBatch',
+    'RegimeSegment',
+    'RiskFeatureFrame',
+    'DetectionRuntimeResult',
+    'StageTuningGroup',
+    'TransferAlignmentReport',
+    'build_detection_stage_tuning_plan',
+]
+
+try:  # pragma: no cover - optional FEDOT runtime dependency
+    from fedot_ind.core.models.detection.modern_detectors import (
+        BaseRuntimeAnomalyDetector,
+        ConvAutoencoderDetector,
+        FeatureIsolationForestDetector,
+        FeatureOneClassDetector,
+        TCNAutoencoderDetector,
+        build_detection_input_data,
+    )
+
+    __all__.extend(
+        [
+            'BaseRuntimeAnomalyDetector',
+            'ConvAutoencoderDetector',
+            'FeatureIsolationForestDetector',
+            'FeatureOneClassDetector',
+            'TCNAutoencoderDetector',
+            'build_detection_input_data',
+        ]
+    )
+except Exception:  # pragma: no cover
+    pass

--- a/fedot_ind/core/models/detection/data_quality.py
+++ b/fedot_ind/core/models/detection/data_quality.py
@@ -1,0 +1,431 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Sequence
+
+import numpy as np
+import pandas as pd
+
+from fedot_ind.core.models.detection.runtime import ensure_detection_array
+
+
+# Timestamp alignment
+
+def align_timestamps(
+        values: np.ndarray,
+        timestamps: Sequence[str | float] | None,
+        *,
+        target_sample_rate_hz: float | None = None,
+        duplicate_policy: str = 'keep_last',   # 'keep_last' | 'mean' | 'drop'
+        gap_policy: str = 'mark_only',          # 'mark_only' | 'forward_fill' | 'interpolate_linear'
+) -> tuple[np.ndarray, np.ndarray, np.ndarray, dict[str, Any]]:
+    """Выравнивает ряд по временной оси (равномерные интервалы между отсчётами): сортировка,
+    дедупликация, диагностика/заполнение пропусков.
+
+    Возвращает кортеж (aligned_values, aligned_timestamps, gap_mask, alignment_report):
+        aligned_values     : np.ndarray (n_aligned, n_channels)
+        aligned_timestamps : np.ndarray (n_aligned,) в секундах
+        gap_mask           : np.ndarray (n_aligned,) bool, True = точка недостоверна
+                             (синтетически заполнена либо NaN)
+        alignment_report   : dict с n_duplicates, n_gaps, gap_total_seconds,
+                             resampling_method, original_n, aligned_n, ...
+
+    Ресемплинг на регулярную сетку выполняется если задан target_sample_rate_hz.
+    Иначе ряд лишь сортируется и дедуплицируется, а gap-статистика считается для отчёта.
+    """
+    # вход стал (n_samples, n_channels)
+    series = ensure_detection_array(values)
+    original_n = int(series.shape[0])  # фиктивная регулярная ось
+
+    if timestamps is None:
+        # временных меток нет -> регулярный целочисленный индекс; маскируем только NaN
+        gap_mask = np.isnan(series).any(axis=1)
+        report = {
+            'n_duplicates': 0,
+            'n_gaps': 0,
+            'gap_total_seconds': 0.0,
+            'resampling_method': 'none',
+            'original_n': original_n,
+            'aligned_n': original_n,
+            'has_timestamps': False,
+            'nominal_dt_seconds': 0.0,
+        }
+        return series, np.arange(original_n, dtype=float), gap_mask, report
+
+    seconds = _timestamps_to_seconds(timestamps)
+    if seconds.shape[0] != original_n:
+        raise ValueError('timestamps length must match the number of samples in values.')
+
+    order = np.argsort(seconds, kind='stable')
+    seconds = seconds[order]
+    series = series[order]
+    # дедупликация
+    series, seconds, n_duplicates = _resolve_duplicates(series, seconds, duplicate_policy)
+
+    diffs = np.diff(seconds)
+    positive = diffs[diffs > 0]
+    if target_sample_rate_hz is not None and float(target_sample_rate_hz) > 0:
+        nominal_dt = 1.0 / float(target_sample_rate_hz)
+    elif positive.size:
+        nominal_dt = float(np.median(positive))
+    else:
+        nominal_dt = 0.0
+
+    if nominal_dt > 0 and diffs.size:
+        gap_factor = diffs / nominal_dt
+        gap_positions = gap_factor > 1.5
+        n_gaps = int(np.count_nonzero(gap_positions))
+        gap_total_seconds = float(np.sum(diffs[gap_positions] - nominal_dt)) if n_gaps else 0.0
+    else:
+        n_gaps = 0
+        gap_total_seconds = 0.0
+
+    if target_sample_rate_hz is not None and nominal_dt > 0 and seconds.size >= 2:
+        aligned_values, aligned_seconds, gap_mask, method = _resample_to_grid(
+            series, seconds, nominal_dt, gap_policy,
+        )
+    else:
+        aligned_values, aligned_seconds = series, seconds
+        gap_mask = np.isnan(series).any(axis=1)
+        method = 'none'
+
+    report = {
+        'n_duplicates': int(n_duplicates),
+        'n_gaps': int(n_gaps),
+        'gap_total_seconds': float(gap_total_seconds),
+        'resampling_method': method,
+        'original_n': original_n,
+        'aligned_n': int(aligned_values.shape[0]),
+        'has_timestamps': True,
+        'nominal_dt_seconds': float(nominal_dt),
+    }
+    return aligned_values, aligned_seconds, gap_mask, report
+
+
+def _timestamps_to_seconds(timestamps: Sequence[str | float]) -> np.ndarray:
+    """Приводит метки времени к секундам"""
+    array = np.asarray(list(timestamps))
+    if array.dtype.kind in {'i', 'u', 'f'}:
+        return array.astype(float)
+    try:
+        return array.astype(float)  # числовые строки '0.0', '1.0', ...
+    except (ValueError, TypeError):
+        # TODO: pandas используется только ради парсинга ISO-строк в pd.to_datetime
+        parsed = pd.DatetimeIndex(pd.to_datetime(array, errors='coerce'))
+        if parsed.isna().any():
+            raise ValueError(
+                'Could not parse some timestamps; pass numeric seconds or ISO datetime strings.'
+            )
+        return parsed.astype('int64').to_numpy(dtype=float) / 1e9
+
+
+def _resolve_duplicates(
+        series: np.ndarray,
+        seconds: np.ndarray,
+        policy: str,
+) -> tuple[np.ndarray, np.ndarray, int]:
+    """Снимает дубликаты по одинаковым timestamp согласно policy."""
+    if seconds.size == 0:
+        return series, seconds, 0
+    unique_t, inverse, counts = np.unique(seconds, return_inverse=True, return_counts=True)
+    n_duplicates = int(seconds.size - unique_t.size)
+    if n_duplicates == 0:
+        return series, seconds, 0
+    normalized = str(policy).lower()
+    if normalized == 'mean':
+        aggregated = np.zeros((unique_t.size, series.shape[1]), dtype=float)
+        np.add.at(aggregated, inverse, series)
+        aggregated /= counts[:, None]
+        return aggregated, unique_t, n_duplicates
+    if normalized == 'drop':
+        keep = counts[inverse] == 1
+        return series[keep], seconds[keep], int(np.count_nonzero(~keep))
+    # keep_last для каждого уникального времени берём последнее вхождение
+    last_index = np.empty(unique_t.size, dtype=int)
+    last_index[inverse] = np.arange(inverse.size)
+    return series[last_index], unique_t, n_duplicates
+
+
+def _resample_to_grid(
+        series: np.ndarray,
+        seconds: np.ndarray,
+        nominal_dt: float,
+        gap_policy: str,
+) -> tuple[np.ndarray, np.ndarray, np.ndarray, str]:
+    """Перенос наблюдения на регулярную сетку и заполняет пропуски по gap_policy."""
+    grid = np.arange(seconds[0], seconds[-1] + 0.5 * nominal_dt, nominal_dt)
+    if grid.size == 0:
+        grid = seconds.copy()
+    aligned = np.full((grid.size, series.shape[1]), np.nan, dtype=float)
+    position = np.clip(np.round((seconds - seconds[0]) / nominal_dt).astype(int), 0, grid.size - 1)
+    aligned[position] = series
+    observed = np.zeros(grid.size, dtype=bool)
+    observed[position] = True
+    gap_mask = ~observed
+
+    normalized = str(gap_policy).lower()
+    if normalized == 'forward_fill':
+        aligned = _forward_fill(aligned)
+        method = 'forward_fill'
+    elif normalized == 'interpolate_linear':
+        aligned = _interpolate_linear(aligned)
+        method = 'interpolate_linear'
+    else:
+        method = 'mark_only'
+
+    gap_mask = gap_mask | np.isnan(aligned).any(axis=1)
+    return aligned, grid, gap_mask, method
+
+
+def _forward_fill(values: np.ndarray) -> np.ndarray:
+    filled = values.copy()
+    for channel in range(filled.shape[1]):
+        column = filled[:, channel]
+        valid = ~np.isnan(column)
+        if not valid.any():
+            continue
+        carry = np.where(valid, np.arange(column.size), 0)
+        np.maximum.accumulate(carry, out=carry)
+        column = column[carry]
+        first_valid = int(np.argmax(valid))
+        column[:first_valid] = column[first_valid]  # backfill ведущих NaN
+        filled[:, channel] = column
+    return filled
+
+
+def _interpolate_linear(values: np.ndarray) -> np.ndarray:
+    filled = values.copy()
+    for channel in range(filled.shape[1]):
+        column = filled[:, channel]
+        valid_idx = np.where(~np.isnan(column))[0]
+        if valid_idx.size == 0:
+            continue
+        filled[:, channel] = np.interp(np.arange(column.size), valid_idx, column[valid_idx])
+    return filled
+
+
+# Channel-quality diagnostics
+@dataclass(frozen=True)
+class ChannelQualityReport:
+    channel_name: str
+    n_missing: int
+    n_duplicates: int
+    is_dead: bool
+    saturation_segments: tuple[tuple[int, int], ...]
+    dropout_segments: tuple[tuple[int, int], ...]
+    noise_floor: float
+    dynamic_range: float
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            'channel_name': self.channel_name,
+            'n_missing': int(self.n_missing),
+            'n_duplicates': int(self.n_duplicates),
+            'is_dead': bool(self.is_dead),
+            'saturation_segments': [list(segment) for segment in self.saturation_segments],
+            'dropout_segments': [list(segment) for segment in self.dropout_segments],
+            'noise_floor': float(self.noise_floor),
+            'dynamic_range': float(self.dynamic_range),
+            **dict(self.metadata),
+        }
+
+
+@dataclass(frozen=True)
+class DataQualityReport:
+    n_channels: int
+    n_samples: int
+    channel_reports: tuple[ChannelQualityReport, ...]
+    overall_pct_missing: float
+    has_dead_channels: bool
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+    @property
+    def dead_channel_names(self) -> tuple[str, ...]:
+        return tuple(report.channel_name for report in self.channel_reports if report.is_dead)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            'n_channels': int(self.n_channels),
+            'n_samples': int(self.n_samples),
+            'channel_reports': [report.to_dict() for report in self.channel_reports],
+            'overall_pct_missing': float(self.overall_pct_missing),
+            'has_dead_channels': bool(self.has_dead_channels),
+            'dead_channel_names': list(self.dead_channel_names),
+            **dict(self.metadata),
+        }
+
+
+def diagnose_channel_quality(
+        values: np.ndarray,
+        channel_names: Sequence[str] | None = None,
+        *,
+        dead_var_eps: float = 1e-10,
+        saturation_quantile: float = 0.99,
+        min_saturation_length: int = 10,
+) -> DataQualityReport:
+    """
+    поканальный (per-channel) анализ качества сигналов
+    диагностика: dead channels, насыщение, дропауты, noise floor, динамический диапазон"""
+    series = ensure_detection_array(values)
+    n_samples, n_channels = series.shape
+    names = tuple(channel_names) if channel_names else tuple(f'channel_{i}' for i in range(n_channels))
+    if len(names) != n_channels:
+        raise ValueError('channel_names length must match the number of channels.')
+
+    reports = [
+        _diagnose_single_channel(
+            series[:, channel], names[channel],
+            dead_var_eps=dead_var_eps,
+            saturation_quantile=saturation_quantile,
+            min_saturation_length=min_saturation_length,
+        )
+        for channel in range(n_channels)
+    ]
+    total_missing = sum(report.n_missing for report in reports)
+    overall_pct_missing = 100.0 * float(total_missing) / float(max(1, n_samples * n_channels))
+    return DataQualityReport(
+        n_channels=int(n_channels),
+        n_samples=int(n_samples),
+        channel_reports=tuple(reports),
+        overall_pct_missing=overall_pct_missing,
+        has_dead_channels=any(report.is_dead for report in reports),
+    )
+
+
+def _diagnose_single_channel(
+        column: np.ndarray,
+        name: str,
+        *,
+        dead_var_eps: float,
+        saturation_quantile: float,
+        min_saturation_length: int,
+) -> ChannelQualityReport:
+    column = np.asarray(column, dtype=float)
+    n_missing = int(np.count_nonzero(np.isnan(column)))
+    finite = column[~np.isnan(column)]
+    if finite.size == 0:
+        return ChannelQualityReport(
+            channel_name=name, n_missing=n_missing, n_duplicates=0, is_dead=True,
+            saturation_segments=(), dropout_segments=(), noise_floor=0.0, dynamic_range=0.0,
+            metadata={'all_missing': True},
+        )
+
+    is_dead = float(np.var(finite)) < float(dead_var_eps)
+
+    same_as_prev = np.zeros(column.size, dtype=bool)
+    same_as_prev[1:] = (
+        (column[1:] == column[:-1]) & ~np.isnan(column[1:]) & ~np.isnan(column[:-1])
+    )
+    n_duplicates = int(np.count_nonzero(same_as_prev))
+
+    high = float(np.quantile(finite, saturation_quantile))
+    low = float(np.quantile(finite, 1.0 - saturation_quantile))
+    saturation_flags = np.where(np.isnan(column), False, (column >= high) | (column <= low))
+    saturation_segments = _contiguous_segments(saturation_flags, min_saturation_length)
+
+    dropout_flags = same_as_prev | np.isnan(column)
+    dropout_segments = _contiguous_segments(dropout_flags, min_saturation_length)
+
+    diffs = np.abs(np.diff(finite))
+    noise_floor = float(np.median(diffs)) if diffs.size else 0.0
+    dynamic_range = float(np.max(finite) - np.min(finite))
+
+    return ChannelQualityReport(
+        channel_name=name,
+        n_missing=n_missing,
+        n_duplicates=n_duplicates,
+        is_dead=bool(is_dead),
+        saturation_segments=saturation_segments,
+        dropout_segments=dropout_segments,
+        noise_floor=noise_floor,
+        dynamic_range=dynamic_range,
+    )
+
+
+def _contiguous_segments(flags: np.ndarray, min_length: int) -> tuple[tuple[int, int], ...]:
+    """Склеивает True-флаги в непрерывные сегменты [start, end] длиной >= min_length."""
+    segments: list[tuple[int, int]] = []
+    start = None
+    size = int(flags.size)
+    minimum = max(1, int(min_length))
+    for index in range(size):
+        if flags[index] and start is None:
+            start = index
+        elif not flags[index] and start is not None:
+            if index - start >= minimum:
+                segments.append((int(start), int(index - 1)))
+            start = None
+    if start is not None and size - start >= minimum:
+        segments.append((int(start), int(size - 1)))
+    return tuple(segments)
+
+
+def prepare_detection_series(
+        values: Sequence[float] | np.ndarray,
+        timestamps: Sequence[str | float] | None = None,
+        *,
+        duplicate_policy: str = 'keep_last',
+        gap_policy: str = 'mark_only',
+        target_sample_rate_hz: float | None = None,
+        channel_names: Sequence[str] | None = None,
+        run_channel_quality: bool = True,
+        dead_var_eps: float = 1e-10,
+        saturation_quantile: float = 0.99,
+        min_saturation_length: int = 10,
+) -> tuple[np.ndarray, np.ndarray, DataQualityReport]:
+    """alignment + gap_mask + (опц.) channel-quality.
+    Raw data
+    ↓
+    align_timestamps
+    ↓
+    Get an aligned row
+    ↓
+    diagnose_channel_quality
+    ↓
+    Get a quality report
+    ↓
+    Return everything together
+"""
+    aligned_values, _aligned_ts, gap_mask, alignment_report = align_timestamps(
+        values,
+        timestamps,
+        target_sample_rate_hz=target_sample_rate_hz,
+        duplicate_policy=duplicate_policy,
+        gap_policy=gap_policy,
+    )
+    gap_mask = np.asarray(gap_mask, dtype=bool).reshape(-1)
+
+    if run_channel_quality:
+        quality_report = diagnose_channel_quality(
+            aligned_values,
+            channel_names=channel_names,
+            dead_var_eps=dead_var_eps,
+            saturation_quantile=saturation_quantile,
+            min_saturation_length=min_saturation_length,
+        )
+    else:
+        n_samples, n_channels = ensure_detection_array(aligned_values).shape
+        quality_report = DataQualityReport(
+            n_channels=int(n_channels),
+            n_samples=int(n_samples),
+            channel_reports=(),
+            overall_pct_missing=0.0,
+            has_dead_channels=False,
+        )
+
+    quality_report = DataQualityReport(
+        n_channels=quality_report.n_channels,
+        n_samples=quality_report.n_samples,
+        channel_reports=quality_report.channel_reports,
+        overall_pct_missing=quality_report.overall_pct_missing,
+        has_dead_channels=quality_report.has_dead_channels,
+        metadata={
+            **dict(quality_report.metadata),
+            'alignment_report': alignment_report,
+            'duplicate_policy': str(duplicate_policy),
+            'gap_policy': str(gap_policy),
+            'target_sample_rate_hz': target_sample_rate_hz,
+        },
+    )
+    return aligned_values, gap_mask, quality_report

--- a/fedot_ind/core/models/detection/modern_detectors.py
+++ b/fedot_ind/core/models/detection/modern_detectors.py
@@ -15,6 +15,7 @@ from fedot_ind.core.models.detection.runtime import (
     AnomalyScoreSeries,
     DetectionEvent,
     RiskFeatureFrame,
+    DetectionRuntimeResult,
     align_window_scores_to_points,
     build_anomaly_score_series,
     build_detection_window_batch,
@@ -27,9 +28,16 @@ from fedot_ind.core.models.detection.runtime import (
     infer_regime_segments,
     resolve_detection_stride,
     resolve_detection_window_size,
+    coral_feature_align,
 )
 from fedot_ind.core.models.detection.stage_tuning import build_detection_stage_tuning_plan
 from fedot_ind.core.repository.detection_registry import detection_family_for
+
+from fedot_ind.core.models.detection.data_quality import (
+    DataQualityReport,
+    diagnose_channel_quality,
+    prepare_detection_series,
+)
 
 try:  # pragma: no cover - optional in lightweight environments
     import torch
@@ -61,6 +69,13 @@ def _operation_params_to_dict(params) -> dict[str, Any]:
     return dict(params)
 
 
+def _extract_detection_values_and_timestamps(values) -> tuple[Any, Any]:
+    """Return raw series and optional timestamps from FEDOT InputData or arrays."""
+    if hasattr(values, 'features'):
+        return values.features, getattr(values, 'idx', None)
+    return values, None
+
+
 class BaseRuntimeAnomalyDetector(ModelImplementation, ABC):
     canonical_name: str = 'runtime_detection_model'
     default_representation_mode: str = 'statistical'
@@ -77,26 +92,60 @@ class BaseRuntimeAnomalyDetector(ModelImplementation, ABC):
         self.transfer_strategy = self.params.get('transfer_strategy', 'domain_invariant_scaling')
         self.representation_mode = self.params.get('representation_mode', self.default_representation_mode)
         self.enable_regime_segmentation = bool(self.params.get('enable_regime_segmentation', True))
+        # data_quality policies
+        self.duplicate_policy = str(self.params.get('duplicate_policy', 'keep_last'))
+        self.gap_policy = str(self.params.get('gap_policy', 'mark_only'))
+        self.target_sample_rate_hz = self.params.get('target_sample_rate_hz')  # None ok
+        self.max_gap_fraction = float(self.params.get('max_gap_fraction', 0.5))
+        self.volatility_window = int(self.params.get('volatility_window', 16))
+        self.transition_quantile = float(self.params.get('transition_quantile', 0.85))
+        seed = self.params.get('random_state', None)
+        self.random_state = int(seed) if isinstance(seed, (int, float)) else None
 
     @property
     def family(self) -> str:
         return detection_family_for(self.canonical_name)
 
-    def fit(self, input_data: InputData) -> None:
-        series = self._prepare_series(input_data.features, fit_stage=True)
-        batch = self._build_batch(series, metadata={'fit_stage': True})
+    def fit(self, input_data: np.ndarray) -> None:
+        # series = self._prepare_series(input_data, fit_stage=True)
+        series, gap_mask, quality_report = self._prepare_series(input_data, fit_stage=True)
+        # Quality diagnostics + per-sample gap mask считаются ОДИН РАЗ:
+        # один источник правды для diagnostics, batch.mask и фильтра калибровки.
+        # quality_report = self._diagnose_data_quality(series)
+        # gap_mask = self._point_gap_mask(series)
+        batch = self._build_batch(series, metadata={'fit_stage': True}, gap_mask=gap_mask)
         self.training_batch_ = batch
-        self.regime_segments_ = infer_regime_segments(series) if self.enable_regime_segmentation else ()
+        # self.regime_segments_ = infer_regime_segments(series) if self.enable_regime_segmentation else ()
+        regime_reference = self._regime_reference_window(series.shape[0])
+        self.regime_segments_ = (
+            infer_regime_segments(
+                series,
+                volatility_window=self.volatility_window,
+                transition_quantile=self.transition_quantile,
+                reference_window=regime_reference,
+            )
+            if self.enable_regime_segmentation else ()
+        )
         features, representation_diagnostics = self._build_representation(batch, fit_stage=True)
+        features = self._apply_transfer_to_features(features, fit_stage=True)
         self._fit_scoring_model(features, batch=batch)
         window_scores = self._score_windows(features, batch=batch)
         point_scores = align_window_scores_to_points(window_scores, batch)
         regime_labels = _regime_labels_from_segments(self.regime_segments_, len(point_scores))
+        # Калибровка порога: gap-точки не должны влиять на распределение score.
+        # Если gap_mask пустой
+        valid_point_mask = ~gap_mask
+        if valid_point_mask.any():
+            calibration_scores = point_scores[valid_point_mask]
+            calibration_regime_labels = regime_labels[valid_point_mask]
+        else:
+            calibration_scores = point_scores
+            calibration_regime_labels = regime_labels
         self.threshold_ = estimate_detection_threshold(
-            point_scores,
+            calibration_scores,
             strategy=self.calibration_strategy,
             quantile=float(self.threshold_quantile),
-            regime_labels=regime_labels,
+            regime_labels=calibration_regime_labels,
         )
         self.training_score_series_ = build_anomaly_score_series(
             point_scores,
@@ -125,10 +174,13 @@ class BaseRuntimeAnomalyDetector(ModelImplementation, ABC):
         )
         self.stage_diagnostics_ = {
             'data_quality': {
-                'n_samples': int(series.shape[0]),
-                'n_channels': int(series.shape[1]),
+                **quality_report.to_dict(),
                 'window_size': int(batch.window_size),
                 'stride': int(batch.stride),
+                'n_gap_points': int(gap_mask.sum()),
+                'gap_fraction': float(gap_mask.mean()) if gap_mask.size else 0.0,
+                'n_valid_windows': int(batch.valid_window_mask().sum()),
+                'n_total_windows': int(batch.n_windows),
             },
             'regime_segmentation': {
                 'n_segments': len(self.regime_segments_),
@@ -140,6 +192,7 @@ class BaseRuntimeAnomalyDetector(ModelImplementation, ABC):
                 'strategy': self.calibration_strategy,
                 'threshold': float(self.threshold_),
                 'threshold_quantile': float(self.threshold_quantile),
+                'n_calibration_points': int(valid_point_mask.sum()),
             },
             'event_aggregation': {
                 'n_events': len(self.training_events_),
@@ -152,28 +205,29 @@ class BaseRuntimeAnomalyDetector(ModelImplementation, ABC):
             },
         }
 
-    def predict(self, input_data: InputData) -> np.ndarray:
-        score_series = self.score_series_on_values(input_data.features)
+    def predict(self, values: np.ndarray | list[float]) -> np.ndarray:
+        score_series = self.score_series_on_values(values)
         labels = np.asarray(score_series.labels, dtype=int).reshape(-1, 1)
         return labels
 
-    def predict_for_fit(self, input_data: InputData):
-        return self.score_samples(input_data)
+    def predict_for_fit(self, values: np.ndarray | list[float]):
+        return self.score_samples(values)
 
-    def predict_proba(self, input_data: InputData) -> np.ndarray:
-        return self.score_samples(input_data)
+    def predict_proba(self, values: np.ndarray | list[float]) -> np.ndarray:
+        return self.score_samples(values)
 
-    def score_samples(self, input_data: InputData) -> np.ndarray:
-        score_series = self.score_series_on_values(input_data.features)
+    def score_samples(self, values: np.ndarray | list[float]) -> np.ndarray:
+        score_series = self.score_series_on_values(values)
         scores = np.asarray(score_series.scores, dtype=float)
         reference_scale = np.std(scores) if np.std(scores) > 1e-8 else max(float(score_series.threshold), 1.0)
         anomaly_probability = _sigmoid((scores - float(score_series.threshold)) / reference_scale)
         return np.column_stack((1.0 - anomaly_probability, anomaly_probability))
 
     def score_series_on_values(self, values: np.ndarray | list[float]) -> AnomalyScoreSeries:
-        series = self._prepare_series(values, fit_stage=False)
-        batch = self._build_batch(series, metadata={'fit_stage': False})
+        series, gap_mask, _ = self._prepare_series(values, fit_stage=False)
+        batch = self._build_batch(series, metadata={'fit_stage': False}, gap_mask=gap_mask)
         features, _ = self._build_representation(batch, fit_stage=False)
+        features = self._apply_transfer_to_features(features, fit_stage=False)
         window_scores = self._score_windows(features, batch=batch)
         point_scores = align_window_scores_to_points(window_scores, batch)
         return build_anomaly_score_series(
@@ -184,12 +238,79 @@ class BaseRuntimeAnomalyDetector(ModelImplementation, ABC):
         )
 
     def detect_events_on_values(self, values: np.ndarray | list[float]) -> tuple[DetectionEvent, ...]:
+        series, _gap_mask, _ = self._prepare_series(values, fit_stage=False)
         score_series = self.score_series_on_values(values)
-        segments = infer_regime_segments(values) if self.enable_regime_segmentation else ()
+        if self.enable_regime_segmentation:
+            regime_reference = self._regime_reference_window(series.shape[0])
+            segments = infer_regime_segments(
+                series,
+                volatility_window=self.volatility_window,
+                transition_quantile=self.transition_quantile,
+                reference_window=regime_reference,
+            )
+        else:
+            segments = ()
         return detect_events_from_score_series(
             score_series,
             min_event_length=self.min_event_length,
             regime_segments=segments,
+        )
+
+    def evaluate_values(self, values: np.ndarray | list[float]) -> DetectionRuntimeResult:
+        # _prepare_series даёт чистую серию (forward-fill NaN) и gap_mask
+        # без этого build_transfer_alignment_report упадёт
+        series, gap_mask, _ = self._prepare_series(values, fit_stage=False)
+        score_series = self.score_series_on_values(values)
+        if self.enable_regime_segmentation:
+            regime_reference = self._regime_reference_window(series.shape[0])
+            segments = infer_regime_segments(
+                series,
+                volatility_window=self.volatility_window,
+                transition_quantile=self.transition_quantile,
+                reference_window=regime_reference,
+            )
+        else:
+            segments = ()
+        events = detect_events_from_score_series(
+            score_series,
+            min_event_length=self.min_event_length,
+            regime_segments=segments,
+        )
+        risk_feature_frame = build_risk_feature_frame(
+            events=events,
+            regime_segments=segments,
+            score_series=score_series,
+            node_name=self.params.get('node_name'),
+            domain_name=self.params.get('domain_name'),
+        )
+        # между каким fit/eval распределением была разница
+        transfer_report = build_transfer_alignment_report(
+            self.scaling_reference_,
+            series,
+            strategy=self.transfer_strategy,
+            source_domain=self.params.get('source_domain', 'fit'),
+            target_domain=self.params.get('target_domain', 'eval'),
+        )
+        # fit diagnostics и добавляет evaluation
+        stage_diagnostics = {
+            **self.get_stage_diagnostics(),
+            'evaluation': {
+                'n_samples': int(series.shape[0]),
+                'n_channels': int(series.shape[1]),
+                'n_events': int(len(events)),
+                'n_gap_points': int(gap_mask.sum()),
+            },
+        }
+        return DetectionRuntimeResult(
+            score_series=score_series,
+            events=events,
+            stage_diagnostics=stage_diagnostics,
+            risk_feature_frame=risk_feature_frame,
+            transfer_report=transfer_report,
+            metadata={
+                'canonical_name': self.canonical_name,
+                'family': self.family,
+            },
         )
 
     def get_stage_tuning_plan(self) -> dict[str, Any]:
@@ -201,22 +322,138 @@ class BaseRuntimeAnomalyDetector(ModelImplementation, ABC):
     def get_stage_diagnostics(self) -> dict[str, Any]:
         return dict(self.stage_diagnostics_)
 
-    def _build_batch(self, values: np.ndarray, metadata: dict[str, Any]) -> Any:
+    def _build_batch(
+            self,
+            values: np.ndarray,
+            metadata: dict[str, Any],
+            *,
+            gap_mask: np.ndarray | None = None,
+    ) -> Any:
         window_size = resolve_detection_window_size(
             values.shape[0],
             window_size=self.window_size,
             window_size_percent=self.window_size_percent,
         )
         stride = resolve_detection_stride(window_size, self.stride)
-        return build_detection_window_batch(values, window_size=window_size, stride=stride, metadata=metadata)
+        return build_detection_window_batch(
+            values,
+            window_size=window_size,
+            stride=stride,
+            gap_mask=gap_mask,
+            metadata=metadata
+        )
 
-    def _prepare_series(self, values: np.ndarray | list[float], *, fit_stage: bool) -> np.ndarray:
-        series = ensure_detection_array(values)
+    @staticmethod
+    def _point_gap_mask(series: np.ndarray) -> np.ndarray:
+        """Per-sample bool-маска: True = точка содержит NaN хотя бы в одном канале.
+        Это минимальный gap_mask, доступный без timestamps. После подключения
+        align_timestamps реальный gap_mask будет приходить снаружи этот
+        метод останется fallback'ом для случаев без временной оси.
+        """
+        return np.isnan(np.asarray(series, dtype=float)).any(axis=1)
+
+    def _regime_reference_window(self, length: int) -> tuple[int, int] | None:
+        """Slice для оценки regime-порогов внутри fit().
+
+        первая calibration_reference_fraction-доля ряда. параметр
+        regime_reference_window='full' (legacy global поведение).
+        """
+        override = self.params.get('regime_reference_window')
+        if override == 'full':
+            return None
+        if isinstance(override, (tuple, list)) and len(override) == 2:
+            return (int(override[0]), int(override[1]))
+        fraction = float(self.params.get('regime_reference_fraction', 0.5))
+        fraction = max(0.05, min(0.95, fraction))
+        stop = max(2, int(round(length * fraction)))
+        return (0, stop)
+
+    def _diagnose_data_quality(self, series: np.ndarray) -> DataQualityReport:
+        """Per-channel quality diagnostics поверх подготовленной серии.
+
+        Channel names берутся из params, если заданы (для согласованности с
+        DetectionSeriesRecord.metadata['channel_names'] на уровне benchmark);
+        иначе — дефолтные channel_0..N-1 из diagnose_channel_quality.
+        """
+        names = self.params.get('channel_names')
+        if names is not None:
+            names = tuple(names)
+            if len(names) != series.shape[1]:
+                names = None
+        return diagnose_channel_quality(series, channel_names=names)
+
+    def _prepare_series(
+            self,
+            values: np.ndarray | list[float],
+            *,
+            fit_stage: bool,
+    ) -> tuple[np.ndarray, np.ndarray]:
+        """чистит NaN, применяет масштабирование.
+
+        Возвращает (clean_series, gap_mask):
+            clean_series — без NaN, готов к domain_invariant_scale и score моделям;
+            gap_mask     — per-sample bool длины N, True = точка пришла как NaN
+                           (синтез из align_timestamps в адаптере либо raw missing).
+
+        gap_mask считается ПЕРЕД forward fill
+        чтобы пропуски не терялись в заполненных значениях.
+        """
+        values, timestamps = _extract_detection_values_and_timestamps(values)
+        names = self.params.get('channel_names')
+        if names is not None:
+            names = tuple(names)
+            n_channels = ensure_detection_array(values).shape[1]
+            if len(names) != n_channels:
+                names = None
+        aligned, gap_mask, quality_report = prepare_detection_series(
+            values,
+            timestamps=timestamps,
+            duplicate_policy=self.duplicate_policy,
+            gap_policy=self.gap_policy,
+            target_sample_rate_hz=self.target_sample_rate_hz,
+            channel_names=names,
+            run_channel_quality=fit_stage,
+        )
+        series = np.asarray(aligned, dtype=float)
+        # gap_mask из prepare — до fill; при mark_only в aligned ещё могут быть NaN
+        if gap_mask.any():
+            series = self._forward_fill_nans(series)
         if fit_stage or not hasattr(self, 'scaling_reference_'):
             self.scaling_reference_ = np.asarray(series, dtype=float)
         if self.transfer_strategy == 'domain_invariant_scaling':
-            return domain_invariant_scale(series, reference_values=self.scaling_reference_)
-        return np.asarray(series, dtype=float)
+            clean = domain_invariant_scale(series, reference_values=self.scaling_reference_)
+        elif str(self.transfer_strategy).lower() in {'feature_alignment', 'coral'}:
+            clean = np.asarray(series, dtype=float)
+        else:
+            raise ValueError(
+                f'Unsupported transfer_strategy: {self.transfer_strategy!r}. '
+                f'Supported: domain_invariant_scaling, feature_alignment, coral.'
+            )
+        return clean, gap_mask, quality_report
+
+    @staticmethod
+    def _forward_fill_nans(series: np.ndarray) -> np.ndarray:
+        """Заполняет NaN по каждому каналу last-observation-carried-forward.
+
+        Ведущие NaN заполняются первым валидным значением (backfill), чтобы
+        scaling не получил NaN на старте. Цикл по каналам идентичен
+        data_quality._forward_fill
+        """
+        filled = series.copy()
+        for channel in range(filled.shape[1]):
+            column = filled[:, channel]
+            valid = ~np.isnan(column)
+            if not valid.any():
+                column[:] = 0.0
+                filled[:, channel] = column
+                continue
+            carry = np.where(valid, np.arange(column.size), 0)
+            np.maximum.accumulate(carry, out=carry)
+            column = column[carry]
+            first_valid = int(np.argmax(valid))
+            column[:first_valid] = column[first_valid]
+            filled[:, channel] = column
+        return filled
 
     def _build_representation(self, batch, *, fit_stage: bool) -> tuple[np.ndarray, dict[str, Any]]:
         del fit_stage
@@ -230,6 +467,35 @@ class BaseRuntimeAnomalyDetector(ModelImplementation, ABC):
             'representation_mode': self.representation_mode,
             'feature_shape': tuple(int(value) for value in np.asarray(features).shape),
         }
+
+    def _apply_transfer_to_features(
+            self,
+            features: np.ndarray,
+            *,
+            fit_stage: bool,
+    ) -> np.ndarray:
+        strategy = str(self.transfer_strategy).lower()
+        if strategy == 'domain_invariant_scaling':
+            return np.asarray(features, dtype=float)
+        if strategy in {'feature_alignment', 'coral'}:
+            if fit_stage:
+                self._transfer_source_features_ = np.asarray(features, dtype=float)
+                return self._transfer_source_features_
+            reference = getattr(self, '_transfer_source_features_', None)
+            if reference is None or reference.shape[0] < 2 or features.shape[0] < 1:
+                return np.asarray(features, dtype=float)
+            if features.shape[1] != reference.shape[1]:
+                raise ValueError(
+                    f'Feature dim {features.shape[1]} != reference dim {reference.shape[1]} for transfer alignment.'
+                )
+            return coral_feature_align(
+                np.asarray(features, dtype=float),
+                reference,
+            )
+        raise ValueError(
+            f'Unsupported transfer_strategy: {self.transfer_strategy!r}. '
+            f'Supported: domain_invariant_scaling, feature_alignment, coral.'
+        )
 
     @abstractmethod
     def _fit_scoring_model(self, features: np.ndarray, *, batch) -> None:
@@ -252,8 +518,7 @@ class FeatureIsolationForestDetector(BaseRuntimeAnomalyDetector):
         super().__init__(params)
         self.n_estimators = int(self.params.get('n_estimators', 200))
         self.contamination = self.params.get('contamination', 'auto')
-        self.random_state = int(self.params.get('random_state', 42))
-        self.n_jobs = 1
+        self.n_jobs = int(self.params.get('n_jobs', 1))
 
     def _fit_scoring_model(self, features: np.ndarray, *, batch) -> None:
         del batch
@@ -275,6 +540,7 @@ class FeatureIsolationForestDetector(BaseRuntimeAnomalyDetector):
             'model_name': self.canonical_name,
             'n_estimators': int(self.n_estimators),
             'contamination': self.contamination,
+            'n_jobs': int(self.n_jobs),
         }
 
 
@@ -328,6 +594,7 @@ class _TorchAutoencoderDetector(BaseRuntimeAnomalyDetector, ABC):
         self.learning_rate = float(self.params.get('learning_rate', 1e-3))
         self.latent_dim = int(self.params.get('latent_dim', 16))
         self.device = str(self.params.get('device', 'cpu'))
+        self.random_state = int(self.params.get('random_state', 42))
 
     def _build_representation(self, batch, *, fit_stage: bool) -> tuple[np.ndarray, dict[str, Any]]:
         del fit_stage
@@ -342,7 +609,12 @@ class _TorchAutoencoderDetector(BaseRuntimeAnomalyDetector, ABC):
             raise ValueError('torch is required for neural anomaly detectors.')
         training_data = torch.from_numpy(np.asarray(features, dtype=np.float32).transpose(0, 2, 1))
         dataset = TensorDataset(training_data)
-        loader = DataLoader(dataset, batch_size=min(len(dataset), self.batch_size), shuffle=True)
+        # TODO: branch with seed = None
+        seed = self.random_state
+        torch.manual_seed(seed)
+        generator = torch.Generator()
+        generator.manual_seed(seed)
+        loader = DataLoader(dataset, batch_size=min(len(dataset), self.batch_size), shuffle=True, generator=generator,)
         self.model_impl = self._build_torch_model(training_data.shape[1]).to(self.device)
         optimizer = torch.optim.Adam(self.model_impl.parameters(), lr=self.learning_rate)
         loss_fn = nn.MSELoss()
@@ -373,6 +645,7 @@ class _TorchAutoencoderDetector(BaseRuntimeAnomalyDetector, ABC):
             'batch_size': int(self.batch_size),
             'learning_rate': float(self.learning_rate),
             'latent_dim': int(self.latent_dim),
+            'random_state': int(self.random_state),
         }
 
     @abstractmethod

--- a/fedot_ind/core/models/detection/progress_policy.py
+++ b/fedot_ind/core/models/detection/progress_policy.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+from typing import Any
+
+
+@dataclass(frozen=True)
+class DetectionProgressPolicy:
+    """Detection-specific progress policy.
+
+    The policy mirrors forecasting progress semantics without coupling detection
+    runtime to forecasting internals.
+    """
+
+    enabled: bool = False
+    leave: bool = False
+    show_postfix: bool = True
+    stage_tuning_enabled: bool | None = None
+    head_training_enabled: bool | None = None
+
+    def _resolve_scope_enabled(self, scoped_flag: bool | None) -> bool:
+        if scoped_flag is None:
+            return bool(self.enabled)
+        return bool(scoped_flag)
+
+    def is_stage_tuning_enabled(self) -> bool:
+        """Return whether stage tuning progress bars should be shown."""
+        return self._resolve_scope_enabled(self.stage_tuning_enabled)
+
+    def is_head_training_enabled(self) -> bool:
+        """Return whether model-head training progress bars should be shown."""
+        return self._resolve_scope_enabled(self.head_training_enabled)
+
+    def tqdm_kwargs(self, *, scope: str, desc: str, unit: str) -> dict[str, Any]:
+        """Build tqdm keyword arguments for a named progress scope."""
+        if scope == 'stage_tuning':
+            enabled = self.is_stage_tuning_enabled()
+        elif scope == 'head_training':
+            enabled = self.is_head_training_enabled()
+        else:
+            enabled = bool(self.enabled)
+        return {
+            'desc': desc,
+            'unit': unit,
+            'leave': bool(self.leave),
+            'disable': not enabled,
+        }
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize progress settings for diagnostics and benchmark artifacts."""
+        return asdict(self)
+
+
+def resolve_detection_progress_policy(
+        policy: DetectionProgressPolicy | dict[str, Any] | bool | None = None,
+        *,
+        show_progress: bool | None = True,
+) -> DetectionProgressPolicy:
+    """Normalize user config into :class:`DetectionProgressPolicy`.
+
+    Parameters
+    ----------
+    policy:
+        Policy in one of supported forms:
+        - ready dataclass instance,
+        - plain dict from config/JSON,
+        - bool shortcut (on/off),
+        - None (use defaults).
+    show_progress:
+        Optional hard override for the global ``enabled`` flag.
+    """
+    if isinstance(policy, DetectionProgressPolicy):
+        resolved = policy
+    elif isinstance(policy, dict):
+        resolved = DetectionProgressPolicy(
+            enabled=bool(policy.get('enabled', False if show_progress is None else show_progress)),
+            leave=bool(policy.get('leave', False)),
+            show_postfix=bool(policy.get('show_postfix', True)),
+            stage_tuning_enabled=policy.get('stage_tuning_enabled'),
+            head_training_enabled=policy.get('head_training_enabled'),
+        )
+    elif isinstance(policy, bool):
+        resolved = DetectionProgressPolicy(enabled=bool(policy))
+    else:
+        resolved = DetectionProgressPolicy(enabled=False if show_progress is None else bool(show_progress))
+
+    if show_progress is None:
+        return resolved
+    return DetectionProgressPolicy(
+        enabled=bool(show_progress),
+        leave=resolved.leave,
+        show_postfix=resolved.show_postfix,
+        stage_tuning_enabled=resolved.stage_tuning_enabled,
+        head_training_enabled=resolved.head_training_enabled,
+    )

--- a/fedot_ind/core/models/detection/runtime.py
+++ b/fedot_ind/core/models/detection/runtime.py
@@ -7,10 +7,13 @@ from typing import Any, Sequence
 import numpy as np
 import pandas as pd
 
-try:  # pragma: no cover - lightweight environments may not have FEDOT
-    from fedot.core.data.data import InputData
+try:  # pragma: no cover
+    from fedot.core.data.data import InputData, OutputData
+    from fedot.core.repository.dataset_types import DataTypesEnum
 except Exception:  # pragma: no cover
     InputData = None
+    OutputData = None
+    DataTypesEnum = None
 
 
 class DetectionSplitKind(str, Enum):
@@ -56,6 +59,20 @@ class DetectionWindowBatch:
     def statistical_features(self) -> np.ndarray:
         return build_window_statistical_features(self.windows)
 
+    @property
+    def window_gap_fraction(self) -> np.ndarray:
+        """Доля недостоверных точек в каждом окне, shape (n_windows,).
+        Если mask нет — все окна считаются чистыми (нули)."""
+        if self.mask is None:
+            return np.zeros(self.n_windows, dtype=float)
+        return self.mask.astype(float).mean(axis=1)  # насколько окно дырявое
+
+    def valid_window_mask(self, *, max_gap_fraction: float = 0.5) -> np.ndarray:
+        """bool-маска валидных окон: True = доля gap <= порога.
+        Используется представлением и calibration для исключения
+        окон, в которых данных нет или они синтетически достроены."""
+        return self.window_gap_fraction <= float(max_gap_fraction)
+
     def to_dict(self) -> dict[str, Any]:
         return {
             'windows_shape': tuple(int(value) for value in self.windows.shape),
@@ -64,6 +81,7 @@ class DetectionWindowBatch:
             'window_size': int(self.window_size),
             'stride': int(self.stride),
             'channel_names': list(self.channel_names),
+            'mask_shape': None if self.mask is None else tuple(int(v) for v in self.mask.shape),
             **dict(self.metadata),
         }
 
@@ -112,7 +130,16 @@ class DetectionEvent:
     metadata: dict[str, Any] = field(default_factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
-        return asdict(self)
+        return {
+            'start_index': int(self.start_index),
+            'end_index': int(self.end_index),
+            'peak_index': int(self.peak_index),
+            'peak_score': float(self.peak_score),
+            'mean_score': float(self.mean_score),
+            'label': self.label,
+            'regime_label': self.regime_label,
+            **dict(self.metadata),
+        }
 
 
 @dataclass(frozen=True)
@@ -168,6 +195,43 @@ class DetectionSeriesEvaluation:
 
 
 @dataclass(frozen=True)
+class DetectionRuntimeResult:
+    score_series: AnomalyScoreSeries  # typed scores + labels + threshold + calibration strategy
+    events: tuple[DetectionEvent, ...]  # typed события аномалий
+    stage_diagnostics: dict[str, Any]  # structured diagnostics payload
+    risk_feature_frame: RiskFeatureFrame | None = None
+    transfer_report: TransferAlignmentReport | None = None  # отчёт о transfer alignment
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+    @property
+    def labels(self) -> tuple[int, ...]:
+        return self.score_series.labels
+
+    @property
+    def scores(self) -> tuple[float, ...]:
+        return self.score_series.scores
+
+    @property
+    def threshold(self) -> float:
+        """score_series.threshold.
+        Симметрично с labels/scores: и labels, и scores, и threshold
+        три «характеристики предсказания» для компактности доставания
+        """
+        return float(self.score_series.threshold)
+
+    def to_dict(self) -> dict[str, Any]:
+        # сериализация для benchmark/artifacts
+        return {
+            'score_series': self.score_series.to_dict(),
+            'events': [event.to_dict() for event in self.events],
+            'stage_diagnostics': dict(self.stage_diagnostics),
+            'risk_feature_frame': None if self.risk_feature_frame is None else self.risk_feature_frame.to_dict(),
+            'transfer_report': None if self.transfer_report is None else self.transfer_report.to_dict(),
+            **dict(self.metadata),
+        }
+
+
+@dataclass(frozen=True)
 class RiskFeatureFrame:
     columns: tuple[str, ...]
     rows: tuple[dict[str, Any], ...]
@@ -192,27 +256,96 @@ class DetectionBoundaryAdapter:
             window_size: int | None = None,
             window_size_percent: float | None = None,
             stride: int | None = None,
+            gap_mask: Sequence[bool] | np.ndarray | None = None,
             metadata: dict[str, Any] | None = None,
     ) -> DetectionWindowBatch:
         if InputData is None:  # pragma: no cover
-            raise ValueError(
-                'FEDOT InputData is unavailable in the current environment.')
+            raise ValueError('FEDOT InputData is unavailable in the current environment.')
         values = ensure_detection_array(input_data.features)
         resolved_window_size = resolve_detection_window_size(
             values.shape[0],
             window_size=window_size,
             window_size_percent=window_size_percent,
         )
+        resolved_gap_mask = gap_mask
+        if resolved_gap_mask is None:
+            supplementary = getattr(input_data, 'supplementary_data', None)
+            if supplementary is not None:
+                resolved_gap_mask = getattr(supplementary, 'gap_mask', None)
         return build_detection_window_batch(
             values,
             window_size=resolved_window_size,
             stride=resolve_detection_stride(resolved_window_size, stride),
-            metadata={'idx': getattr(
-                input_data, 'idx', None), **dict(metadata or {})},
+            gap_mask=resolved_gap_mask,
+            metadata={'idx': getattr(input_data, 'idx', None), **dict(metadata or {})},
+        )
+
+    @staticmethod
+    def to_output_data(
+            input_data: InputData,
+            *,
+            score_series: AnomalyScoreSeries | None = None,
+            events: Sequence[DetectionEvent] | None = None,
+            predict_mode: str = 'labels',  # 'labels' | 'scores' | 'probs'
+    ) -> OutputData:
+        """Заворачивает результат детекции обратно в FEDOT OutputData.
+        Симметрична from_input_data: концентрирует boundary-логику в адаптере,
+        вместо того чтобы собирать OutputData вручную в strategy.
+        predict_mode:
+            'labels' — бинарные метки (n, 1);
+            'scores' — поточечные anomaly scores (n, 1);
+            'probs'  — двухколоночная вероятность [P(norm), P(anomaly)] (n, 2).
+        """
+        if OutputData is None:  # pragma: no cover
+            raise ValueError('FEDOT OutputData is unavailable in the current environment.')
+        if score_series is None:
+            raise ValueError('to_output_data requires a score_series to build predictions.')
+        mode = str(predict_mode).lower()
+        # режимs повторяют логику, которая сейчас в _predict_by_mode (detection_runtime_strategy.py)
+        # и score_samples (modern_detectors.py)
+        if mode == 'labels':
+            predict = np.asarray(score_series.labels, dtype=int).reshape(-1, 1)
+        elif mode in {'scores', 'score'}:
+            predict = np.asarray(score_series.scores, dtype=float).reshape(-1, 1)
+        elif mode in {'probs', 'probabilities'}:
+            scores = np.asarray(score_series.scores, dtype=float)
+            scale = np.std(scores) if np.std(scores) > 1e-8 else max(float(score_series.threshold), 1.0)
+            anomaly = 1.0 / (1.0 + np.exp(-(scores - float(score_series.threshold)) / scale))
+            predict = np.column_stack((1.0 - anomaly, anomaly))
+        else:
+            raise ValueError(f'Unsupported detection predict_mode: {predict_mode}')
+
+        return OutputData(
+            idx=input_data.idx,
+            features=input_data.features,
+            predict=predict,
+            target=getattr(input_data, 'target', None),
+            task=input_data.task,
+            data_type=DataTypesEnum.table,
+            supplementary_data=getattr(input_data, 'supplementary_data', None),
         )
 
 
 def ensure_detection_array(values: Sequence[float] | np.ndarray) -> np.ndarray:
+    """
+    Преобразует входные данные в двумерный массив numpy с плавающей точкой, пригодный для детектирования.
+
+    - Если входной массив одномерный, преобразует в столбец (n, 1).
+    - Если двумерный — оставляет без изменений.
+    - Если размерность больше 2 — сворачивает все оси, кроме первой, в одну.
+
+    Параметры:
+        values : Sequence[float] или np.ndarray
+            Входные данные (список, кортеж, массив).
+
+    Возвращает:
+        np.ndarray
+            Двумерный массив с shape (n_samples, n_features).
+
+    Исключения:
+        ValueError
+            Если передан 0-мерный массив (скаляр).
+    """
     array = np.asarray(values, dtype=float)
     if array.ndim == 1:
         return array.reshape(-1, 1)
@@ -231,19 +364,63 @@ def resolve_detection_window_size(
         window_size_percent: float | None = None,
         minimum_window_size: int = 8,
 ) -> int:
+    """
+    Определяет размер окна для скользящего анализа временного ряда.
+
+    Правила:
+    1. Если длина ряда меньше 4 — возвращает длину ряда (минимум 1).
+    2. Если задан window_size — возвращает max(2, min(window_size, series_length)).
+    3. Если задан window_size_percent — вычисляет размер как процент от series_length,
+       затем ограничивает max(2, min(..., series_length)).
+    4. Иначе — default = max(minimum_window_size, round(series_length * 0.1)), затем
+       ограничивает series_length.
+
+    Параметры:
+        series_length : int
+            Общее количество точек ряда.
+        window_size : int или None
+            Явный размер окна.
+        window_size_percent : float или None
+            Размер окна в процентах от длины ряда.
+        minimum_window_size : int, default=8
+            Минимальный размер окна по умолчанию.
+
+    Возвращает:
+        int
+            Итоговый размер окна (всегда >=2 для рядов длиной >=4).
+
+    Важно:
+    --
+    Используется round() - надо узнать, насколько это важно для контекста
+    """
     if series_length < 4:
         return max(1, int(series_length))
     if window_size is not None:
         return max(2, min(int(window_size), int(series_length)))
     if window_size_percent is not None:
-        resolved = int(
-            round(series_length * float(window_size_percent) / 100.0))
+        resolved = int(round(series_length * float(window_size_percent) / 100.0))
         return max(2, min(resolved, int(series_length)))
     default_window = max(minimum_window_size, int(round(series_length * 0.1)))
     return min(default_window, int(series_length))
 
 
 def resolve_detection_stride(window_size: int, stride: int | None = None) -> int:
+    """
+    Определяет шаг сдвига окна (stride) для детектирования.
+
+    - Если stride задан явно — возвращает max(1, int(stride)).
+    - Иначе — возвращает max(1, window_size // 4).
+
+    Параметры:
+        window_size : int
+            Размер окна.
+        stride : int или None
+            Шаг сдвига (если None — выбирается автоматически).
+
+    Возвращает:
+        int
+            Шаг сдвига (всегда >= 1).
+    """
     if stride is not None:
         return max(1, int(stride))
     return max(1, int(window_size // 4))
@@ -255,30 +432,139 @@ def build_detection_window_batch(
         window_size: int,
         stride: int = 1,
         channel_names: Sequence[str] | None = None,
+        gap_mask: Sequence[bool] | np.ndarray | None = None,
         metadata: dict[str, Any] | None = None,
 ) -> DetectionWindowBatch:
+    """
+    Нарезает временной ряд на окна заданного размера с заданным шагом.
+
+    Создаёт объект (DetectionWindowBatch), содержащий:
+    - трёхмерный массив окон (n_windows, window_size, n_channels),
+    - индексы начала и конца каждого окна (n_windows, 2),
+    - метаданные (длина ряда, размер окна, шаг, имена каналов и пользовательские метаданные).
+
+    Параметры:
+        values : Sequence[float] или np.ndarray
+            Входной ряд (1D или 2D, где второй размер — каналы).
+        window_size : int
+            Размер окна.
+        stride : int, default=1
+            Шаг сдвига.
+        channel_names : Sequence[str] или None
+            Имена каналов. Если None — генерируются как 'channel_0', 'channel_1', ...
+        metadata : dict или None
+            Дополнительные метаданные.
+
+    Возвращает:
+        DetectionWindowBatch
+            Сформированный пакет окон.
+
+    Исключения:
+        ValueError
+            Если длина ряда меньше window_size.
+    """
     series = ensure_detection_array(values)
     if series.shape[0] < window_size:
         raise ValueError(
             f'Series length {series.shape[0]} is shorter than the requested detection window {window_size}.'
         )
-    windows = []
-    indices = []
+    if gap_mask is not None:
+        gap_array = np.asarray(gap_mask, dtype=bool).reshape(-1)
+        if gap_array.shape[0] != series.shape[0]:
+            raise ValueError(
+                f'gap_mask length {gap_array.shape[0]} must match series length {series.shape[0]}.'
+            )
+    else:
+        gap_array = None
+
+    windows: list[np.ndarray] = []
+    indices: list[tuple[int, int]] = []
+    window_masks: list[np.ndarray] | None = [] if gap_array is not None else None
     for start in range(0, series.shape[0] - window_size + 1, stride):
         end = start + window_size
         windows.append(series[start:end])
         indices.append((start, end))
+        if window_masks is not None:
+            window_masks.append(gap_array[start:end])
+
     window_tensor = np.asarray(windows, dtype=float)
     window_index = np.asarray(indices, dtype=int)
+    mask_tensor = np.asarray(window_masks, dtype=bool) if window_masks is not None else None
+
     return DetectionWindowBatch(
         windows=window_tensor,
         window_indices=window_index,
         original_length=int(series.shape[0]),
         window_size=int(window_size),
         stride=int(stride),
-        channel_names=tuple(channel_names or tuple(
-            f'channel_{index}' for index in range(series.shape[1]))),
+        channel_names=tuple(channel_names or tuple(f'channel_{index}' for index in range(series.shape[1]))),
+        mask=mask_tensor,
         metadata=dict(metadata or {}),
+    )
+
+
+def _calibration_count_from_remaining(
+    remaining: int,
+    split_spec: DetectionSplitSpec,
+) -> int:
+    """replacement of functionality for selecting a calibration sample
+    calibration_batch = _slice(n_train, n_train + n_calibration)"""
+    if remaining <= 0:
+        return 0
+    raw = remaining * float(split_spec.calibration_fraction) / max(1e-8, 1.0 - float(split_spec.train_fraction))
+    return min(remaining, max(0, int(round(raw))))
+
+
+def _train_count_from_pool(pool_size: int, split_spec: DetectionSplitSpec) -> int:
+    """replacement of functionality for selecting a train sample"""
+    if pool_size <= 0:
+        return 0
+    return max(1, int(round(pool_size * float(split_spec.train_fraction))))
+
+
+def _batch_by_window_ids(
+        batch: DetectionWindowBatch,
+        window_ids: Sequence[int] | np.ndarray,
+        *,
+        split_spec: DetectionSplitSpec,
+        split_name: str,
+) -> DetectionWindowBatch | None:
+    """replacing the functionality for selecting using continuous slices with an arbitrary set of windows
+    _split_temporal_window_ids
+
+        ↓
+    calculates safe indexes
+        ↓
+    _batch_by_window_ids
+        ↓
+    just compiles a batch
+    """
+    ids = np.asarray(window_ids, dtype=int).reshape(-1)
+    if ids.size == 0:
+        return None
+    base_meta = dict(batch.metadata)
+    slice_meta: dict[str, Any] = {
+        **base_meta,
+        'selected_window_ids': [int(i) for i in ids.tolist()],
+        'split_kind': split_spec.kind.value,
+        'split_name': str(split_name),
+    }
+    if 'window_domains' in base_meta:
+        domains = np.asarray(base_meta['window_domains'], dtype=object).reshape(-1)
+        if domains.shape[0] != batch.n_windows:
+            raise ValueError(
+                f'window_domains length {domains.shape[0]} must match batch.n_windows {batch.n_windows}.'
+            )
+        slice_meta['window_domains'] = [str(domains[i]) for i in ids.tolist()]
+    return DetectionWindowBatch(
+        windows=batch.windows[ids],
+        window_indices=batch.window_indices[ids],
+        original_length=batch.original_length,
+        window_size=batch.window_size,
+        stride=batch.stride,
+        channel_names=batch.channel_names,
+        mask=batch.mask[ids] if batch.mask is not None else None,
+        metadata=slice_meta,
     )
 
 
@@ -286,116 +572,210 @@ def split_detection_batch(
         batch: DetectionWindowBatch,
         split_spec: DetectionSplitSpec,
 ) -> tuple[DetectionWindowBatch, DetectionWindowBatch, DetectionWindowBatch | None]:
-    n_windows = batch.n_windows
-    if n_windows <= 0:
+    """
+    Splits the detection packet into training, calibration, and test samples according to the specification.
+
+    THREE partitioning types are supported:
+    - DOMAIN_HOLDOUT: Allocates one domain value as the target (target_domain),
+    the remaining domains are used for training. Within the target domain, windows are divided into calibration and test windows
+    within the temporal order.
+    - HOLDOUT: Random or temporal partitioning of all windows with specified proportions.
+    - TEMPORAL: No domains. Train separately, and divide calibration and test windows according to the temporal order
+    using the _split_temporal_window_ids() method.
+
+    To prevent future leakage (prevent_future_leakage=True), it is guaranteed that the calibration windows precede the test windows in time.
+
+    Parameters:
+    batch : DetectionWindowBatch
+    A batch of windows obtained from build_detection_window_batch.
+    split_spec : DetectionSplitSpec
+    Split specification object.
+
+    Returns:
+    tuple[DetectionWindowBatch, DetectionWindowBatch, DetectionWindowBatch | None]
+    (train_batch, calibration_batch, test_batch). The calibration batch may be the same as the training batch if there are no calibration windows.
+
+    Exceptions:
+    ValueError
+    If the batch does not contain windows, the required metadata for the domain split is missing,
+    or the split resulted in an empty training set.
+    """
+    n_windows = int(batch.n_windows)
+    if n_windows < 1:
         raise ValueError('Detection split requires at least one window.')
 
-    def _metadata_for_indices(indices: np.ndarray, split_name: str) -> dict[str, Any]:
-        metadata = dict(batch.metadata)
-        for key, value in list(metadata.items()):
-            if isinstance(value, np.ndarray) and value.shape[:1] == (n_windows,):
-                metadata[key] = value[indices].tolist()
-            elif isinstance(value, (list, tuple)) and len(value) == n_windows:
-                metadata[key] = [value[int(index)] for index in indices]
-        metadata.update({
-            'split_kind': split_spec.kind.value,
-            'split_name': split_name,
-            'selected_window_ids': [int(index) for index in indices.tolist()],
-        })
-        return metadata
-
-    def _take(indices: Sequence[int], split_name: str) -> DetectionWindowBatch | None:
-        selected = np.asarray(list(indices), dtype=int)
-        if selected.size == 0:
-            return None
-        selected_mask = batch.mask
-        if isinstance(batch.mask, np.ndarray) and batch.mask.shape[:1] == (n_windows,):
-            selected_mask = batch.mask[selected]
-        return DetectionWindowBatch(
-            windows=batch.windows[selected],
-            window_indices=batch.window_indices[selected],
-            original_length=batch.original_length,
-            window_size=batch.window_size,
-            stride=batch.stride,
-            channel_names=batch.channel_names,
-            mask=selected_mask,
-            metadata=_metadata_for_indices(selected, split_name),
+    if split_spec.kind == DetectionSplitKind.DOMAIN_HOLDOUT:
+        # train   = source
+        # holdout = target
+        if 'window_domains' not in batch.metadata:
+            raise ValueError(
+                'DOMAIN_HOLDOUT requires batch.metadata["window_domains"] with one label per window.'
+            )
+        domains = np.asarray(batch.metadata['window_domains'], dtype=object).reshape(-1)
+        if domains.shape[0] != n_windows:
+            raise ValueError(
+                f'window_domains length {domains.shape[0]} must match batch.n_windows {n_windows}.'
+            )
+        target = split_spec.target_domain
+        if target is None:
+            raise ValueError('DOMAIN_HOLDOUT requires split_spec.target_domain to be set.')
+        train_ids = np.flatnonzero(domains != target)
+        holdout_ids = np.flatnonzero(domains == target)
+        if holdout_ids.size == 0:
+            raise ValueError(f'target_domain {target!r} is not present in window_domains.')
+        if train_ids.size == 0:
+            raise ValueError('Detection split produced an empty train batch.')
+        n_calibration = int(round(holdout_ids.size * float(split_spec.calibration_fraction)))
+        calib_ids, test_ids = _split_temporal_window_ids(
+            batch.window_indices,
+            holdout_ids,
+            calibration_size=n_calibration,
+            prevent_future_leakage=split_spec.prevent_future_leakage,
         )
-
-    if split_spec.kind is DetectionSplitKind.DOMAIN_HOLDOUT:
-        domains = batch.metadata.get('window_domains')
-        if domains is None:
-            raise ValueError(
-                'Domain holdout split requires window_domains metadata.')
-        if len(domains) != n_windows:
-            raise ValueError(
-                'window_domains metadata must match the number of detection windows.')
-        target_domain = split_spec.target_domain or str(domains[-1])
-        train_ids = [index for index, domain in enumerate(
-            domains) if str(domain) != str(target_domain)]
-        target_ids = [index for index, domain in enumerate(
-            domains) if str(domain) == str(target_domain)]
-        n_calibration = max(1, int(
-            round(len(target_ids) * split_spec.calibration_fraction))) if target_ids else 0
-        n_calibration = min(len(target_ids), n_calibration)
-        train_batch = _take(train_ids, 'train')
-        calibration_batch = _take(target_ids[:n_calibration], 'calibration')
-        test_batch = _take(target_ids[n_calibration:], 'test')
-        if train_batch is None:
-            raise ValueError(
-                'Detection domain holdout produced an empty train batch.')
+        train_batch = _batch_by_window_ids(
+            batch, train_ids, split_spec=split_spec, split_name='train',
+        )
+        calibration_batch = _batch_by_window_ids(
+            batch, calib_ids, split_spec=split_spec, split_name='calibration',
+        )
+        test_batch = _batch_by_window_ids(
+            batch, test_ids, split_spec=split_spec, split_name='test',
+        )
         return train_batch, calibration_batch or train_batch, test_batch
 
-    if split_spec.kind is DetectionSplitKind.TEMPORAL and split_spec.prevent_future_leakage:
-        train_boundary = int(
-            round(batch.original_length * split_spec.train_fraction))
-        calibration_boundary = int(round(
-            batch.original_length *
-            min(1.0, split_spec.train_fraction +
-                split_spec.calibration_fraction)
-        ))
-        train_ids = np.flatnonzero(
-            batch.window_indices[:, 1] <= train_boundary)
-        calibration_ids = np.flatnonzero(
-            (batch.window_indices[:, 0] >= train_boundary)
-            & (batch.window_indices[:, 1] <= calibration_boundary)
-        )
-        test_ids = np.flatnonzero(
-            batch.window_indices[:, 0] >= calibration_boundary)
-        train_batch = _take(train_ids, 'train')
-        calibration_batch = _take(calibration_ids, 'calibration')
-        test_batch = _take(test_ids, 'test')
-        if train_batch is None:
-            raise ValueError(
-                'Detection temporal split produced an empty train batch.')
-        return train_batch, calibration_batch or train_batch, test_batch
-
-    n_train = max(1, int(round(n_windows * split_spec.train_fraction)))
-    remaining = max(0, n_windows - n_train)
-    n_calibration = int(round(remaining * split_spec.calibration_fraction /
-                        max(1e-8, 1.0 - split_spec.train_fraction)))
-    n_calibration = min(remaining, max(0, n_calibration))
-    if split_spec.kind is DetectionSplitKind.HOLDOUT:
-        ordered_ids = np.random.default_rng(
-            split_spec.random_seed).permutation(n_windows)
-    else:
+    if split_spec.kind == DetectionSplitKind.TEMPORAL:
         ordered_ids = np.arange(n_windows, dtype=int)
+        n_train = _train_count_from_pool(n_windows, split_spec)
+        remaining_ids = ordered_ids[n_train:]
+        n_calibration = _calibration_count_from_remaining(int(remaining_ids.size), split_spec)
+        calib_ids, test_ids = _split_temporal_window_ids(
+            batch.window_indices,
+            remaining_ids,
+            calibration_size=n_calibration,
+            prevent_future_leakage=split_spec.prevent_future_leakage,
+        )
+        train_batch = _batch_by_window_ids(
+            batch, ordered_ids[:n_train], split_spec=split_spec, split_name='train',
+        )
+        calibration_batch = _batch_by_window_ids(
+            batch, calib_ids, split_spec=split_spec, split_name='calibration',
+        )
+        test_batch = _batch_by_window_ids(
+            batch, test_ids, split_spec=split_spec, split_name='test',
+        )
+        return train_batch, calibration_batch or train_batch, test_batch
 
-    train_batch = _take(sorted(ordered_ids[:n_train].tolist()), 'train')
-    calibration_batch = _take(
-        sorted(ordered_ids[n_train:n_train + n_calibration].tolist()), 'calibration')
-    test_batch = _take(
-        sorted(ordered_ids[n_train + n_calibration:].tolist()), 'test')
-    if train_batch is None:
-        raise ValueError('Detection split produced an empty train batch.')
-    return train_batch, calibration_batch or train_batch, test_batch
+    if split_spec.kind == DetectionSplitKind.HOLDOUT:
+        n_train = _train_count_from_pool(n_windows, split_spec)
+        remaining = max(0, n_windows - n_train)
+        n_calibration = _calibration_count_from_remaining(remaining, split_spec)
+        if split_spec.prevent_future_leakage:
+            ordered_ids = np.arange(n_windows, dtype=int)
+            train_ids = ordered_ids[:n_train]
+            tail_ids = ordered_ids[n_train:]
+            calib_ids, test_ids = _split_temporal_window_ids(
+                batch.window_indices,
+                tail_ids,
+                calibration_size=n_calibration,
+                prevent_future_leakage=True,
+            )
+        else:
+            perm = np.random.default_rng(int(split_spec.random_seed)).permutation(n_windows)
+            train_ids = perm[:n_train]
+            calib_ids = perm[n_train:n_train + n_calibration]
+            test_ids = perm[n_train + n_calibration:]
+        train_batch = _batch_by_window_ids(
+            batch, train_ids, split_spec=split_spec, split_name='train',
+        )
+        calibration_batch = _batch_by_window_ids(
+            batch, calib_ids, split_spec=split_spec, split_name='calibration',
+        )
+        test_batch = _batch_by_window_ids(
+            batch, test_ids, split_spec=split_spec, split_name='test',
+        )
+        if train_batch is None:
+            raise ValueError('Detection split produced an empty train batch.')
+        return train_batch, calibration_batch or train_batch, test_batch
+    raise ValueError(f'Unsupported detection split kind: {split_spec.kind}')
+
+
+def _split_temporal_window_ids(
+        window_indices: np.ndarray,
+        candidate_ids: np.ndarray,
+        *,
+        calibration_size: int,
+        prevent_future_leakage: bool,
+        minimum_start: int | None = None,
+) -> tuple[np.ndarray, np.ndarray]:
+    """
+    Вспомогательная функция: разбивает идентификаторы окон на калибровочные и тестовые,
+    соблюдая временной порядок (если prevent_future_leakage=True).
+
+    Параметры:
+        window_indices : np.ndarray
+            Массив формы (n_windows, 2) с началом и концом каждого окна.
+        candidate_ids : np.ndarray
+            Массив идентификаторов окон, которые нужно разделить.
+        calibration_size : int
+            Сколько окон выделить в калибровку (берутся первые по времени).
+        prevent_future_leakage : bool
+            Если True, тестовые окна не могут начинаться раньше, чем заканчивается последнее калибровочное.
+        minimum_start : int или None
+            Минимальное значение start индекса для включения окна (фильтр).
+
+    Возвращает:
+        tuple[np.ndarray, np.ndarray]
+            (calibration_ids, test_ids) – отсортированные массивы идентификаторов.
+    """
+    candidates = np.asarray(candidate_ids, dtype=int).reshape(-1)
+    if candidates.size == 0:
+        return np.asarray([], dtype=int), np.asarray([], dtype=int)
+    ordered = np.sort(candidates)
+    if minimum_start is not None:
+        ordered = ordered[window_indices[ordered, 0] >= int(minimum_start)]
+    if ordered.size == 0:
+        return np.asarray([], dtype=int), np.asarray([], dtype=int)
+
+    calibration_size = max(0, int(calibration_size))
+    calibration_ids = ordered[:calibration_size]
+    if not prevent_future_leakage or calibration_ids.size == 0:
+        return calibration_ids, ordered[calibration_size:]
+
+    calibration_end = int(window_indices[calibration_ids[-1], 1])
+    test_ids = ordered[window_indices[ordered, 0] >= calibration_end]
+    test_ids = test_ids[~np.isin(test_ids, calibration_ids)]
+    return calibration_ids, test_ids
 
 
 def build_window_statistical_features(windows: np.ndarray) -> np.ndarray:
+    """
+    Вычисляет статистические признаки для каждого окна многоканального временного ряда.
+
+    Для каждого окна (n_windows, window_size, n_channels) вычисляет по каждому каналу:
+    - среднее,
+    - стандартное отклонение,
+    - минимум,
+    - максимум,
+    - разность между последним и первым отсчётами (наклон/размах).
+
+    Результат конкатенируется по оси каналов, т.е. для каждого окна возвращается вектор
+    размерности 5 * n_channels.
+
+    Параметры:
+        windows : np.ndarray
+            Массив формы (n_windows, window_size, n_channels).
+
+    Возвращает:
+        np.ndarray
+            Массив формы (n_windows, 5 * n_channels).
+
+    Исключения:
+        ValueError
+            Если входной массив не трёхмерный.
+    """
     array = np.asarray(windows, dtype=float)
     if array.ndim != 3:
-        raise ValueError(
-            'Detection windows must have shape [n_windows, window_size, n_channels].')
+        raise ValueError('Detection windows must have shape [n_windows, window_size, n_channels].')
     mean = np.mean(array, axis=1)
     std = np.std(array, axis=1)
     minimum = np.min(array, axis=1)
@@ -404,12 +784,67 @@ def build_window_statistical_features(windows: np.ndarray) -> np.ndarray:
     return np.concatenate((mean, std, minimum, maximum, slope), axis=1)
 
 
+def _resolve_reference_slice(
+        length: int,
+        reference_window: slice | tuple[int, int] | None,
+) -> slice:
+    """Нормализует reference_window в slice внутри [0, length].
+
+    Принимает:
+      slice — используется как есть (с клипом в границы);
+      tuple (start, stop) — оба индекса клипуются в [0, length];
+      None — slice(0, length), т.е. legacy global behaviour.
+
+    Возвращает slice, у которого 0 <= start < stop <= length, либо
+    slice(0, length) если запрошенное окно вырождено или выходит за пределы.
+    """
+    if reference_window is None:
+        return slice(0, length)
+    if isinstance(reference_window, slice):
+        start = 0 if reference_window.start is None else int(reference_window.start)
+        stop = length if reference_window.stop is None else int(reference_window.stop)
+    else:
+        start, stop = int(reference_window[0]), int(reference_window[1])
+    start = max(0, min(start, length))
+    stop = max(0, min(stop, length))
+    if stop - start < 2:
+        return slice(0, length)
+    return slice(start, stop)
+
+
 def infer_regime_segments(
         values: Sequence[float] | np.ndarray,
         *,
         volatility_window: int = 16,
         transition_quantile: float = 0.85,
+        reference_window: slice | tuple[int, int] | None = None,
 ) -> tuple[RegimeSegment, ...]:
+    """
+    Выделяет сегменты временного ряда, характеризующие режимы: высокий уровень (high_load),
+    низкий уровень (low_load), переходный (transition) или стабильный (stable).
+
+    Алгоритм:
+    1. Берёт среднее по каналам (если многоканальный).
+    2. Вычисляет скользящую волатильность (rolling std) с окном volatility_window.
+    3. Вычисляет абсолютный наклон ряда abs(diff()).
+    4. Порог перехода — quantile абсолютного наклона (transition_quantile).
+    5. Квантили 75% и 25% среднего по каналам сигнала задают границы high/low.
+    6. Размечает точки: transition, иначе stable, потом stable с высоким/низким уровнем.
+    7. Склеивает соседние точки с одинаковой меткой в сегменты.
+
+    Параметры:
+        values : Sequence[float] или np.ndarray
+            Входной ряд (1D или 2D или ND) - ensure_detection_array сожмёт до 2D.
+        volatility_window : int, default=16
+            Размер окна для расчёта волатильности. Не меньше 3.
+        transition_quantile : float, default=0.85
+            Квантиль абсолютного наклона для определения переходов (0..1).
+
+    Возвращает:
+        tuple[RegimeSegment, ...]
+            Кортеж объектов RegimeSegment с индексами, меткой, средним уровнем,
+            волатильностью и наклоном внутри сегмента.
+    """
     series = ensure_detection_array(values)
     regime_signal = np.mean(series, axis=1)
     slope = np.diff(regime_signal, prepend=regime_signal[0])
@@ -421,10 +856,15 @@ def infer_regime_segments(
         .to_numpy(dtype=float)
     )
     abs_slope = np.abs(slope)
-    transition_threshold = float(np.quantile(
-        abs_slope, transition_quantile)) if len(abs_slope) else 0.0
-    high_level = float(np.quantile(regime_signal, 0.75))
-    low_level = float(np.quantile(regime_signal, 0.25))
+    ref = _resolve_reference_slice(series.shape[0], reference_window)
+    reference_signal = regime_signal[ref]
+    reference_abs_slope = abs_slope[ref]
+    transition_threshold = (
+        float(np.quantile(reference_abs_slope, transition_quantile))
+        if reference_abs_slope.size else 0.0
+    )
+    high_level = float(np.quantile(reference_signal, 0.75)) if reference_signal.size else 0.0
+    low_level = float(np.quantile(reference_signal, 0.25)) if reference_signal.size else 0.0
 
     labels = np.full(series.shape[0], 'stable', dtype=object)
     labels[abs_slope >= transition_threshold] = 'transition'
@@ -457,10 +897,29 @@ def align_window_scores_to_points(
         window_scores: Sequence[float] | np.ndarray,
         batch: DetectionWindowBatch,
 ) -> np.ndarray:
+    """
+    Преобразует оценки (аномалий), вычисленные для каждого окна, в поточечный ряд.
+
+    Для каждой точки временного ряда усредняет оценки всех окон, которые покрывают эту точку.
+    Точки без покрытия получают значение 0 (деление на 1 предотвращает разрыв).
+
+    Параметры:
+        window_scores : Sequence[float] или np.ndarray
+            Оценки для каждого окна (длина равна batch.n_windows).
+        batch : DetectionWindowBatch
+            Пакет окон, содержащий window_indices и original_length.
+
+    Возвращает:
+        np.ndarray
+            Массив длины original_length, где каждому индексу сопоставлена средняя оценка.
+
+    Исключения:
+        ValueError
+            Если длина window_scores не совпадает с batch.n_windows.
+    """
     scores = np.asarray(window_scores, dtype=float).reshape(-1)
     if scores.shape[0] != batch.n_windows:
-        raise ValueError(
-            'The number of window scores must match the number of detection windows.')
+        raise ValueError('The number of window scores must match the number of detection windows.')
     point_scores = np.zeros(batch.original_length, dtype=float)
     point_counts = np.zeros(batch.original_length, dtype=float)
     for score, (start, end) in zip(scores, batch.window_indices):
@@ -477,6 +936,35 @@ def estimate_detection_threshold(
         quantile: float = 0.99,
         regime_labels: Sequence[str] | None = None,
 ) -> float:
+    """
+    Вычисляет порог для бинаризации аномалий на основе оценок.
+
+    Поддерживаемые стратегии:
+    - 'mad' : медиана + 3 * MAD (медианное абсолютное отклонение); если MAD близок к нулю,
+               использует стандартное отклонение.
+    - 'quantile' : заданный квантиль распределения оценок.
+    - 'regime_conditional' : применяет стратегию 'mad' только к точкам, не отмеченным как 'transition'
+                             (если переданы regime_labels).
+    - 'domain_calibrated' : среднее + 2.5 * стандартное отклонение.
+
+    Параметры:
+        scores : Sequence[float] или np.ndarray
+            Вектор оценок (поточечных) длины original_length.
+        strategy : str, default='mad'
+            Название стратегии.
+        quantile : float, default=0.99
+            Квантиль (используется для strategy='quantile').
+        regime_labels : Sequence[str] или None
+            Метки режимов для каждой точки (требуется для 'regime_conditional').
+
+    Возвращает:
+        float
+            Вычисленный порог.
+
+    Исключения:
+        ValueError
+            Если стратегия не поддерживается.
+    """
     values = np.asarray(scores, dtype=float).reshape(-1)
     if values.size == 0:
         return 0.0
@@ -509,6 +997,25 @@ def build_anomaly_score_series(
         calibration_strategy: str,
         metadata: dict[str, Any] | None = None,
 ) -> AnomalyScoreSeries:
+    """
+    Формирует объект AnomalyScoreSeries из поточечных оценок и порога.
+
+    Сравнивает каждую оценку с порогом и создаёт бинарную метку (1 если score >= threshold, иначе 0).
+
+    Параметры:
+        point_scores : Sequence[float] или np.ndarray
+            Оценки для каждой точки временного ряда.
+        threshold : float
+            Порог детекции.
+        calibration_strategy : str
+            Название стратегии, использованной для получения порога (сохраняется в метаданных).
+        metadata : dict или None
+            Дополнительные метаданные.
+
+    Возвращает:
+        AnomalyScoreSeries
+            Объект, содержащий кортежи оценок и меток, порог, стратегию и метаданные.
+    """
     scores = np.asarray(point_scores, dtype=float).reshape(-1)
     labels = (scores >= float(threshold)).astype(int)
     return AnomalyScoreSeries(
@@ -526,6 +1033,28 @@ def detect_events_from_score_series(
         min_event_length: int = 1,
         regime_segments: Sequence[RegimeSegment] = (),
 ) -> tuple[DetectionEvent, ...]:
+    """
+    Обнаруживает непрерывные аномальные участки (события) на основе бинарной метки.
+
+    Событием считается последовательность точек с меткой 1, длина которой не меньше min_event_length.
+    Для каждого события определяются:
+    - начальный и конечный индексы,
+    - пиковый индекс (максимальная оценка внутри события),
+    - пиковое и среднее значение оценки,
+    - метка режима, соответствующая позиции пика (если переданы regime_segments).
+
+    Параметры:
+        score_series : AnomalyScoreSeries
+            Серия с оценками и метками.
+        min_event_length : int, default=1
+            Минимальная длина события (количество последовательных аномальных точек).
+        regime_segments : Sequence[RegimeSegment], default=()
+            Сегменты режимов для определения regime_label события.
+
+    Возвращает:
+        tuple[DetectionEvent, ...]
+            Кортеж обнаруженных событий, отсортированных по времени.
+    """
     labels = np.asarray(score_series.labels, dtype=int).reshape(-1)
     scores = np.asarray(score_series.scores, dtype=float).reshape(-1)
     events: list[DetectionEvent] = []
@@ -535,12 +1064,10 @@ def detect_events_from_score_series(
             start = index
         elif label == 0 and start is not None:
             if index - start >= int(min_event_length):
-                events.append(_build_detection_event(
-                    start, index - 1, scores, regime_segments))
+                events.append(_build_detection_event(start, index - 1, scores, regime_segments))
             start = None
     if start is not None and len(labels) - start >= int(min_event_length):
-        events.append(_build_detection_event(
-            start, len(labels) - 1, scores, regime_segments))
+        events.append(_build_detection_event(start, len(labels) - 1, scores, regime_segments))
     return tuple(events)
 
 
@@ -550,6 +1077,26 @@ def _build_detection_event(
         scores: np.ndarray,
         regime_segments: Sequence[RegimeSegment],
 ) -> DetectionEvent:
+    """
+    Вспомогательная функция: создаёт один объект DetectionEvent для заданного интервала.
+
+    Вычисляет пик (максимум scores), среднее значение и определяет метку режима
+    по пересечению с regime_segments.
+
+    Параметры:
+        start : int
+            Начальный индекс события.
+        end : int
+            Конечный индекс события (включительно).
+        scores : np.ndarray
+            Массив оценок для всего ряда.
+        regime_segments : Sequence[RegimeSegment]
+            Сегменты режимов.
+
+    Возвращает:
+        DetectionEvent
+            Сформированный объект события.
+    """
     segment_scores = scores[start:end + 1]
     peak_offset = int(np.argmax(segment_scores))
     peak_index = int(start + peak_offset)
@@ -573,9 +1120,25 @@ def domain_invariant_scale(
         *,
         reference_values: Sequence[float] | np.ndarray | None = None,
 ) -> np.ndarray:
+    """
+    Масштабирует данные, делая их инвариантными к сдвигу и масштабу относительно опорного распределения.
+
+    Используется преобразование: (x - median) / MAD, где MAD — медианное абсолютное отклонение.
+    Если reference_values не задан, используется сама серия.
+    MAD, близкие к нулю, заменяются на 1.0.
+
+    Параметры:
+        values : Sequence[float] или np.ndarray
+            Данные для масштабирования (1D или 2D).
+        reference_values : Sequence[float] или np.ndarray или None
+            Опорные данные для оценки медианы и MAD. Если None — используются values.
+
+    Возвращает:
+        np.ndarray
+            Масштабированные данные той же формы, что и values.
+    """
     series = ensure_detection_array(values)
-    reference = ensure_detection_array(
-        reference_values) if reference_values is not None else series
+    reference = ensure_detection_array(reference_values) if reference_values is not None else series
     median = np.median(reference, axis=0)
     mad = np.median(np.abs(reference - median), axis=0)
     mad = np.where(mad < 1e-8, 1.0, mad)
@@ -588,25 +1151,45 @@ def coral_feature_align(
         *,
         epsilon: float = 1e-6,
 ) -> np.ndarray:
+    """
+    Выполняет выравнивание признаков методом CORAL (CORrelation ALignment).
+
+    Приводит ковариацию и среднее исходных признаков к ковариации и среднему целевых,
+    используя линейное преобразование:
+    1. Центрирует source и target.
+    2. Вычисляет ковариационные матрицы с регуляризацией epsilon.
+    3. Строит отбеливающее преобразование для source и окрашивающее для target.
+    4. Применяет преобразование к центрированному source и добавляет среднее target.
+
+    Параметры:
+        source_features : Sequence[float] или np.ndarray
+            Признаки исходного домена (shape n_source x d).
+        target_features : Sequence[float] или np.ndarray
+            Признаки целевого домена (shape n_target x d).
+        epsilon : float, default=1e-6
+            Регуляризация для ковариационных матриц (добавляется к диагонали).
+
+    Возвращает:
+        np.ndarray
+            Выровненные признаки исходного домена (n_source x d).
+
+    Исключения:
+        ValueError
+            Если входные массивы не двумерные.
+    """
     source = np.asarray(source_features, dtype=float)
     target = np.asarray(target_features, dtype=float)
     if source.ndim != 2 or target.ndim != 2:
-        raise ValueError(
-            'CORAL feature alignment expects 2D feature matrices.')
+        raise ValueError('CORAL feature alignment expects 2D feature matrices.')
     source_centered = source - np.mean(source, axis=0, keepdims=True)
     target_centered = target - np.mean(target, axis=0, keepdims=True)
-    source_cov = np.cov(source_centered, rowvar=False) + \
-        epsilon * np.eye(source.shape[1])
-    target_cov = np.cov(target_centered, rowvar=False) + \
-        epsilon * np.eye(target.shape[1])
+    source_cov = np.cov(source_centered, rowvar=False) + epsilon * np.eye(source.shape[1])
+    target_cov = np.cov(target_centered, rowvar=False) + epsilon * np.eye(target.shape[1])
     source_values, source_vectors = np.linalg.eigh(source_cov)
     target_values, target_vectors = np.linalg.eigh(target_cov)
-    source_whitener = source_vectors @ np.diag(1.0 / np.sqrt(
-        np.clip(source_values, epsilon, None))) @ source_vectors.T
-    target_colorer = target_vectors @ np.diag(
-        np.sqrt(np.clip(target_values, epsilon, None))) @ target_vectors.T
-    aligned = source_centered @ source_whitener @ target_colorer + \
-        np.mean(target, axis=0, keepdims=True)
+    source_whitener = source_vectors @ np.diag(1.0 / np.sqrt(np.clip(source_values, epsilon, None))) @ source_vectors.T
+    target_colorer = target_vectors @ np.diag(np.sqrt(np.clip(target_values, epsilon, None))) @ target_vectors.T
+    aligned = source_centered @ source_whitener @ target_colorer + np.mean(target, axis=0, keepdims=True)
     return np.asarray(aligned, dtype=float)
 
 
@@ -618,6 +1201,30 @@ def build_transfer_alignment_report(
         source_domain: str = 'source',
         target_domain: str = 'target',
 ) -> TransferAlignmentReport:
+    """
+    Создаёт отчёт о различиях между исходным и целевым доменом для диагностики переноса.
+
+    Вычисляет средние значения по каналам, количество наблюдений, сдвиг средних,
+    а также включает в метаданные стандартные отклонения.
+
+    Параметры:
+        source_values : Sequence[float] или np.ndarray
+            Данные исходного домена.
+        target_values : Sequence[float] или np.ndarray
+            Данные целевого домена.
+        strategy : str, default='domain_invariant_scaling'
+            Название стратегии выравнивания (сохраняется в отчёте).
+        source_domain : str, default='source'
+            Метка для исходного домена.
+        target_domain : str, default='target'
+            Метка для целевого домена.
+
+    Возвращает:
+        TransferAlignmentReport
+            Объект отчёта с полями: strategy, source_domain, target_domain,
+            n_source, n_target, source_channel_mean, target_channel_mean,
+            mean_shift, metadata.
+    """
     source = ensure_detection_array(source_values)
     target = ensure_detection_array(target_values)
     source_mean = np.mean(source, axis=0)
@@ -628,12 +1235,9 @@ def build_transfer_alignment_report(
         target_domain=target_domain,
         n_source=int(source.shape[0]),
         n_target=int(target.shape[0]),
-        source_channel_mean=tuple(float(value)
-                                  for value in source_mean.tolist()),
-        target_channel_mean=tuple(float(value)
-                                  for value in target_mean.tolist()),
-        mean_shift=tuple(float(value)
-                         for value in (target_mean - source_mean).tolist()),
+        source_channel_mean=tuple(float(value) for value in source_mean.tolist()),
+        target_channel_mean=tuple(float(value) for value in target_mean.tolist()),
+        mean_shift=tuple(float(value) for value in (target_mean - source_mean).tolist()),
         metadata={
             'source_channel_std': [float(value) for value in np.std(source, axis=0).tolist()],
             'target_channel_std': [float(value) for value in np.std(target, axis=0).tolist()],
@@ -649,6 +1253,34 @@ def build_risk_feature_frame(
         node_name: str | None = None,
         domain_name: str | None = None,
 ) -> RiskFeatureFrame:
+    """
+    Формирует таблицу (RiskFeatureFrame) с признаками риска для каждого обнаруженного события.
+
+    Для каждого события извлекаются:
+    - индексы начала, конца, пика,
+    - пиковая и средняя оценки,
+    - длина события,
+    - метка режима, средний уровень и волатильность режима (из regime_segments),
+    - название узла (node_name) и домена (domain_name),
+    - если передан score_series — порог и стратегия калибровки.
+
+    Args:
+        events : Sequence[DetectionEvent]
+            Обнаруженные события.
+        regime_segments : Sequence[RegimeSegment]
+            Сегменты режимов для привязки regime_label и характеристик.
+        score_series : AnomalyScoreSeries или None
+            Серия оценок (для добавления threshold и calibration_strategy).
+        node_name : str или None
+            Имя узла (например, идентификатор оборудования).
+        domain_name : str или None
+            Имя домена.
+
+    Returns:
+        RiskFeatureFrame
+            Объект с полями columns (кортеж названий столбцов),
+            rows (кортеж словарей) и metadata (словарь с n_events и n_regime_segments).
+    """
     rows: list[dict[str, Any]] = []
     regime_lookup = {
         (segment.start_index, segment.end_index): segment

--- a/fedot_ind/core/models/detection/stage_tuning_runtime.py
+++ b/fedot_ind/core/models/detection/stage_tuning_runtime.py
@@ -1,0 +1,530 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from itertools import product
+from typing import Any
+
+import numpy as np
+from fedot.core.operations.operation_parameters import OperationParameters
+
+from fedot_ind.core.models.detection.progress_policy import (
+    DetectionProgressPolicy,
+    resolve_detection_progress_policy,
+)
+from fedot_ind.core.models.detection.runtime import (
+    DetectionSplitKind,
+    DetectionSplitSpec,
+    ensure_detection_array,
+)
+# from fedot_ind.core.metrics._exceptions import MetricValidationError
+# from fedot_ind.core.metrics.metric_library import (
+#     METRIC_REGISTRY,
+#     METRICS_TO_MINIMIZE,
+#     flatten_metric_value,
+#     get_metric,
+# )
+
+from fedot_ind.core.repository.constanst_repository import FEDOT_GET_METRICS
+from fedot_ind.core.metrics.metric_library import METRIC_REGISTRY, METRICS_TO_MINIMIZE
+
+
+from fedot_ind.core.models.detection.stage_tuning import build_detection_stage_tuning_plan
+from fedot_ind.core.operation.interfaces.detection_runtime_strategy import DETECTION_RUNTIME_MODELS
+from fedot_ind.core.repository.detection_registry import canonical_detection_model_name, detection_family_for
+
+try:
+    from tqdm.auto import tqdm
+except Exception:  # pragma: no cover
+    def tqdm(iterable=None, *args, **kwargs):
+        return iterable if iterable is not None else []
+
+
+SUPPORTED_ANOMALY_DETECTION_METRICS = tuple(METRIC_REGISTRY['anomaly_detection'])
+DETECTION_METRICS_TO_MINIMIZE = tuple(set(METRICS_TO_MINIMIZE) & set(SUPPORTED_ANOMALY_DETECTION_METRICS))
+
+
+@dataclass(frozen=True)
+class DetectionSeriesEvaluation:
+    """Single-series evaluation snapshot for one detector parameter set.
+
+    This structure is the atomic unit used in stage-tuning reports:
+    model/params in, metric + labels out.
+    """
+    model_name: str
+    canonical_model_name: str
+    family: str
+    parameters: dict[str, Any]
+    metric_name: str
+    metric_value: float
+    labels: tuple[int, ...]
+    target: tuple[int, ...]
+    split_metadata: dict[str, Any] = field(default_factory=dict)
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            'model_name': self.model_name,
+            'canonical_model_name': self.canonical_model_name,
+            'family': self.family,
+            'parameters': dict(self.parameters),
+            'metric_name': self.metric_name,
+            'metric_value': float(self.metric_value),
+            'labels': list(self.labels),
+            'target': list(self.target),
+            'split_metadata': dict(self.split_metadata),
+            **self.metadata,
+        }
+
+
+@dataclass(frozen=True)
+class DetectionSequentialStageTuningResult:
+    """Sequential tuning trace across stage groups defined in tuning plan."""
+    model_name: str
+    canonical_model_name: str
+    family: str
+    base_parameters: dict[str, Any]
+    best_parameters: dict[str, Any]
+    best_score: float
+    stage_history: tuple[dict[str, Any], ...]
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            'model_name': self.model_name,
+            'canonical_model_name': self.canonical_model_name,
+            'family': self.family,
+            'base_parameters': dict(self.base_parameters),
+            'best_parameters': dict(self.best_parameters),
+            'best_score': float(self.best_score),
+            'stage_history': list(self.stage_history),
+            **self.metadata,
+        }
+
+
+@dataclass(frozen=True)
+class DetectionSeriesStageTuningResult:
+    """Final tuning report containing baseline and best-parameter evaluations."""
+    model_name: str
+    canonical_model_name: str
+    family: str
+    sequential_result: DetectionSequentialStageTuningResult
+    baseline_evaluation: DetectionSeriesEvaluation
+    best_evaluation: DetectionSeriesEvaluation
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            'model_name': self.model_name,
+            'canonical_model_name': self.canonical_model_name,
+            'family': self.family,
+            'sequential_result': self.sequential_result.to_dict(),
+            'baseline_evaluation': self.baseline_evaluation.to_dict(),
+            'best_evaluation': self.best_evaluation.to_dict(),
+            **self.metadata,
+        }
+
+
+def _normalize_base_params(params: dict[str, Any] | None) -> dict[str, Any]:
+    """Drop ``None`` values to avoid overriding detector defaults with nulls."""
+    return {key: value for key, value in dict(params or {}).items() if value is not None}
+
+
+def _split_series(
+        values: np.ndarray,
+        labels: np.ndarray,
+        split_spec: DetectionSplitSpec,
+        *,
+        domain_labels: np.ndarray | None = None,
+) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+    """Build train/calibration split from a labeled time series.
+
+    Returns
+    -------
+    tuple
+        (train_values, train_labels, calibration_values, calibration_labels).
+        If calibration window is empty, it falls back to train slice.
+
+    Для DetectionSplitKind.DOMAIN_HOLDOUT с заданными domain_labels
+    детектор учится на ВСЕХ доменах, кроме plit_spec.target_domain, а
+    оценивается на целевом (невиданном) домене.
+    kind другой или domain_labels=None поведение прежнее
+    """
+    # TODO: на эти изменения необходимо внести тесты
+    # DOMAIN_HOLDOUT: train = исходные домены, calibration = целевой (unseen) домен.
+    if split_spec.kind == DetectionSplitKind.DOMAIN_HOLDOUT and domain_labels is not None:
+        domains = np.asarray(domain_labels, dtype=object).reshape(-1)
+        if domains.shape[0] != values.shape[0]:
+            raise ValueError(
+                f'domain_labels length {domains.shape[0]} must match series length {values.shape[0]}.'
+            )
+        target = split_spec.target_domain
+        if target is None:
+            raise ValueError('DOMAIN_HOLDOUT requires split_spec.target_domain to be set.')
+        holdout_mask = domains == target
+        if not holdout_mask.any():
+            raise ValueError(f'target_domain {target!r} is not present in domain_labels.')
+        if holdout_mask.all():
+            raise ValueError(f'target_domain {target!r} leaves no source domain for training.')
+        train_mask = ~holdout_mask
+        return (
+            values[train_mask], labels[train_mask],
+            values[holdout_mask], labels[holdout_mask],
+        )
+
+    n_samples = int(values.shape[0])
+    train_end = max(1, int(round(n_samples * split_spec.train_fraction)))
+    remaining = max(0, n_samples - train_end)
+    calibration_size = int(round(remaining * split_spec.calibration_fraction))
+    calibration_end = min(n_samples, train_end + calibration_size)
+    train_values = values[:train_end]
+    train_labels = labels[:train_end]
+    calibration_values = values[train_end:calibration_end]
+    calibration_labels = labels[train_end:calibration_end]
+    if calibration_values.size == 0:
+        calibration_values = train_values
+        calibration_labels = train_labels
+    return train_values, train_labels, calibration_values, calibration_labels
+
+
+def iter_domain_holdouts(domain_labels: np.ndarray) -> tuple[str, ...]:
+    """Уникальные домены в порядке появления для leave-one-domain-out цикла.
+
+    Каждый возвращённый домен по очереди становится ``target_domain`` (unseen),
+    остальные идут в train. Падает при < 2 доменах нет.
+    """
+    domains = np.asarray(domain_labels, dtype=object).reshape(-1)
+    unique = tuple(dict.fromkeys(domains.tolist()))
+    if len(unique) < 2:
+        raise ValueError('Leave-one-domain-out requires at least two distinct domains.')
+    return tuple(str(domain) for domain in unique)
+
+
+def _build_detector(model_name: str, params: dict[str, Any]):
+    """Instantiate runtime detector by canonical name from registry map."""
+    canonical_name = canonical_detection_model_name(model_name)
+    if canonical_name not in DETECTION_RUNTIME_MODELS:
+        raise ValueError(f'Unsupported detection model for stage tuning: {model_name}')
+    return DETECTION_RUNTIME_MODELS[canonical_name](OperationParameters(**params))
+
+
+def _evaluate_parameters(
+        model_name: str,
+        *,
+        values: np.ndarray,
+        labels: np.ndarray,
+        parameters: dict[str, Any],
+        metric_name: str,
+        split_spec: DetectionSplitSpec,
+        domain_labels: np.ndarray | None = None,
+) -> DetectionSeriesEvaluation:
+    """Fit/evaluate one detector configuration on one series split."""
+    canonical_name = canonical_detection_model_name(model_name)
+    series = ensure_detection_array(values)
+    target = np.asarray(labels, dtype=int).reshape(-1)
+    train_values, _, calibration_values, calibration_labels = _split_series(
+        series, target, split_spec, domain_labels=domain_labels,
+    )
+    detector = _build_detector(model_name, parameters)
+    detector.fit(train_values)
+    score_series = detector.score_series_on_values(calibration_values)
+    predicted = np.asarray(score_series.labels, dtype=int).reshape(-1)
+
+    metric_values = FEDOT_GET_METRICS['anomaly_detection'](target=calibration_labels,
+                                                           predicted_labels=predicted,
+                                                           metric_names=(metric_name,),
+                                                           return_dataframe=False)
+    metric_value = float(metric_values[metric_name])
+
+    # # Прямой вызов registry (metric_library.METRIC_REGISTRY['anomaly_detection']),
+    # # без обёртки FEDOT_GET_METRICS
+    # if metric_name not in SUPPORTED_ANOMALY_DETECTION_METRICS:
+    #     raise MetricValidationError(
+    #         f'Unsupported anomaly_detection metric for stage tuning: {metric_name!r}. '
+    #         f'Supported: {SUPPORTED_ANOMALY_DETECTION_METRICS}.'
+    #     )
+    # metric_fn = get_metric('anomaly_detection', metric_name)
+    # raw_metric_value = metric_fn(calibration_labels, predicted)
+    # flat = flatten_metric_value(metric_name, raw_metric_value)
+    # if metric_name not in flat:
+    #     raise MetricValidationError(
+    #         f'Metric {metric_name!r} did not produce a scalar value usable for '
+    #         f'stage tuning ranking (raw value: {raw_metric_value!r}). Use a scalar '
+    #         f'variant (e.g. "nab_standard" instead of "nab") in metric_name.'
+    #     )
+    # metric_value = flat[metric_name]
+    return DetectionSeriesEvaluation(
+        model_name=model_name,
+        canonical_model_name=canonical_name,
+        family=detection_family_for(canonical_name),
+        parameters=dict(parameters),
+        metric_name=metric_name,
+        metric_value=float(metric_value),
+        labels=tuple(int(value) for value in predicted.tolist()),
+        target=tuple(int(value) for value in calibration_labels.tolist()),
+        split_metadata={
+            'train_size': int(train_values.shape[0]),
+            'calibration_size': int(calibration_values.shape[0]),
+            'split_kind': split_spec.kind.value,
+        },
+    )
+
+
+_DETECTION_ENUM_CANDIDATES: dict[str, tuple[str, ...]] = {
+    'calibration_strategy': (
+        'mad',
+        'quantile',
+        'regime_conditional',
+        'domain_calibrated',
+    ),
+    'representation_mode': (
+        'statistical',
+        'flatten',
+        'identity',
+    ),
+    'transfer_strategy': (
+        'domain_invariant_scaling',
+        'feature_alignment',  # CORAL
+    ),
+}
+
+
+def _candidate_values(parameter_name: str, current_value: Any, max_values: int) -> tuple[Any, ...]:
+    """Generate compact candidate values around current parameter value."""
+    if parameter_name in _DETECTION_ENUM_CANDIDATES:
+        universe = _DETECTION_ENUM_CANDIDATES[parameter_name]
+        if isinstance(current_value, str) and current_value in universe:
+            ordered = (current_value,) + tuple(v for v in universe if v != current_value)
+        else:
+            ordered = universe
+        return ordered[:max_values]
+
+    if isinstance(current_value, bool):
+        return (current_value,)
+    if isinstance(current_value, int):
+        deltas = (-max(1, current_value // 4), 0, max(1, current_value // 4))
+        candidates = tuple(dict.fromkeys(max(1, current_value + delta) for delta in deltas))[:max_values]
+        return candidates or (current_value,)
+    if isinstance(current_value, float):
+        scale = max(abs(current_value) * 0.25, 1e-3)
+        return tuple(dict.fromkeys((current_value - scale, current_value, current_value + scale)))[:max_values]
+    if isinstance(current_value, str):
+        return (current_value,)
+    return (current_value,)
+
+
+def _stage_candidate_grid(
+        group_parameters: tuple[str, ...],
+        current_parameters: dict[str, Any],
+        *,
+        max_values_per_parameter: int,
+        max_stage_candidates: int,
+) -> tuple[dict[str, Any], ...]:
+    """Construct Cartesian candidate grid for one tuning stage."""
+    parameter_values: list[tuple[str, tuple[Any, ...]]] = []
+    for parameter_name in group_parameters:
+        if parameter_name not in current_parameters:
+            continue
+        values = _candidate_values(
+            parameter_name,
+            current_parameters[parameter_name],
+            max_values_per_parameter,
+        )
+        parameter_values.append((parameter_name, values))
+    if not parameter_values:
+        return ({},)
+    grid: list[dict[str, Any]] = []
+    for combination in product(*(values for _, values in parameter_values)):
+        candidate = {
+            parameter_name: value
+            for (parameter_name, _), value in zip(parameter_values, combination)
+        }
+        grid.append(candidate)
+        if len(grid) >= max_stage_candidates:
+            break
+    return tuple(grid[:max_stage_candidates])
+
+
+def _is_better_detection_score(candidate_score: float, best_score: float, metric_name: str) -> bool:
+    """Сравнение значения метрик учитывая направление,
+    указанное в реестре общих метрик."""
+    if metric_name in DETECTION_METRICS_TO_MINIMIZE:
+        return candidate_score <= best_score
+    return candidate_score >= best_score
+
+
+def run_detection_stage_tuning_on_series(
+        model_name: str,
+        *,
+        values: np.ndarray,
+        labels: np.ndarray,
+        base_params: dict[str, Any] | None = None,
+        stage_updates: dict[str, Any] | None = None,
+        metric_name: str,
+        split_spec: DetectionSplitSpec | None = None,
+        domain_labels: np.ndarray | None = None,
+        max_values_per_parameter: int = 3,
+        max_stage_candidates: int = 16,
+        progress_policy: DetectionProgressPolicy | dict[str, Any] | bool | None = None,
+) -> DetectionSeriesStageTuningResult:
+    """Run sequential stage tuning for one detector on one labeled series.
+
+    Parameters
+    ----------
+    model_name:
+        Adapter/detector name (canonical or alias).
+    values:
+        Input time-series values, univariate or multivariate.
+    labels:
+        Point-wise anomaly labels aligned with ``values``.
+    base_params:
+        Initial detector parameters before stage-wise updates.
+    stage_updates:
+        Reserved for future explicit per-stage updates (currently ignored).
+    metric_name:
+        Metric optimized during tuning (`accuracy`, `balanced_accuracy`, `f1_macro`).
+    split_spec:
+        Optional split configuration; defaults to temporal split.
+    domain_labels:
+        Optional per-sample domain/node labels aligned with ``values``. Used only
+        for ``DetectionSplitKind.DOMAIN_HOLDOUT``: the detector trains on all
+        domains except ``split_spec.target_domain`` and is evaluated on that
+        unseen domain. For leave-one-domain-out, call this once per target domain
+        (see ``iter_domain_holdouts``) and average the metrics on the caller side.
+    max_values_per_parameter:
+        Upper bound on generated candidate values per parameter.
+    max_stage_candidates:
+        Upper bound on evaluated combinations per stage.
+    progress_policy:
+        Optional progress display policy.
+    """
+    del stage_updates
+    resolved_params = _normalize_base_params(base_params)
+    resolved_split = split_spec or DetectionSplitSpec(kind=DetectionSplitKind.TEMPORAL)
+    resolved_progress = resolve_detection_progress_policy(progress_policy)
+    plan = build_detection_stage_tuning_plan(model_name, resolved_params)
+    if not plan.groups:
+        baseline = _evaluate_parameters(
+            model_name,
+            values=values,
+            labels=labels,
+            parameters=resolved_params,
+            metric_name=metric_name,
+            split_spec=resolved_split,
+            domain_labels=domain_labels,
+        )
+        sequential = DetectionSequentialStageTuningResult(
+            model_name=model_name,
+            canonical_model_name=plan.canonical_model_name,
+            family=plan.family,
+            base_parameters=resolved_params,
+            best_parameters=resolved_params,
+            best_score=baseline.metric_value,
+            stage_history=(),
+            metadata={'supports_stage_tuning': False},
+        )
+        return DetectionSeriesStageTuningResult(
+            model_name=model_name,
+            canonical_model_name=plan.canonical_model_name,
+            family=plan.family,
+            sequential_result=sequential,
+            baseline_evaluation=baseline,
+            best_evaluation=baseline,
+            metadata={'improved': False, 'baseline_score': baseline.metric_value, 'best_score': baseline.metric_value},
+        )
+
+    current_parameters = dict(resolved_params)
+    stage_history: list[dict[str, Any]] = []
+    baseline_evaluation = _evaluate_parameters(
+        model_name,
+        values=values,
+        labels=labels,
+        parameters=current_parameters,
+        metric_name=metric_name,
+        split_spec=resolved_split,
+        domain_labels=domain_labels,
+    )
+    best_score = baseline_evaluation.metric_value
+    best_parameters = dict(current_parameters)
+
+    stage_iterator = plan.groups
+    if resolved_progress.is_stage_tuning_enabled():
+        stage_iterator = tqdm(plan.groups, **resolved_progress.tqdm_kwargs(
+            scope='stage_tuning',
+            desc='detection stage tuning',
+            unit='stage',
+        ))
+
+    for group in stage_iterator:
+        evaluations: list[dict[str, Any]] = []
+        stage_best_score = best_score
+        stage_best_parameters = dict(current_parameters)
+        # Stage-local search: vary only parameters assigned to current stage.
+        for candidate in _stage_candidate_grid(
+                group.parameters,
+                current_parameters,
+                max_values_per_parameter=max_values_per_parameter,
+                max_stage_candidates=max_stage_candidates,
+        ):
+            candidate_parameters = {**current_parameters, **candidate}
+            evaluation = _evaluate_parameters(
+                model_name,
+                values=values,
+                labels=labels,
+                parameters=candidate_parameters,
+                metric_name=metric_name,
+                split_spec=resolved_split,
+                domain_labels=domain_labels,
+            )
+            evaluations.append({
+                'parameters': dict(candidate),
+                'score': float(evaluation.metric_value),
+            })
+            # if evaluation.metric_value >= stage_best_score:
+            if _is_better_detection_score(evaluation.metric_value, stage_best_score, metric_name):
+                stage_best_score = evaluation.metric_value
+                stage_best_parameters = dict(candidate_parameters)
+        # Sequential tuning semantics: next stage starts from best params of previous stage.
+        current_parameters = stage_best_parameters
+        # if stage_best_score >= best_score:
+        if _is_better_detection_score(stage_best_score, best_score, metric_name):
+            best_score = stage_best_score
+            best_parameters = dict(current_parameters)
+        stage_history.append({
+            'stage': group.stage,
+            'best_parameters': dict(stage_best_parameters),
+            'best_score': float(stage_best_score),
+            'evaluations': evaluations,
+        })
+
+    best_evaluation = _evaluate_parameters(
+        model_name,
+        values=values,
+        labels=labels,
+        parameters=best_parameters,
+        metric_name=metric_name,
+        split_spec=resolved_split,
+        domain_labels=domain_labels,
+    )
+    sequential_result = DetectionSequentialStageTuningResult(
+        model_name=model_name,
+        canonical_model_name=plan.canonical_model_name,
+        family=plan.family,
+        base_parameters=resolved_params,
+        best_parameters=best_parameters,
+        best_score=float(best_score),
+        stage_history=tuple(stage_history),
+        metadata={'supports_stage_tuning': True, 'progress_policy': resolved_progress.to_dict()},
+    )
+    return DetectionSeriesStageTuningResult(
+        model_name=model_name,
+        canonical_model_name=plan.canonical_model_name,
+        family=plan.family,
+        sequential_result=sequential_result,
+        baseline_evaluation=baseline_evaluation,
+        best_evaluation=best_evaluation,
+        metadata={
+            'improved': bool(_is_better_detection_score(best_score, baseline_evaluation.metric_value, metric_name)),
+            'baseline_score': float(baseline_evaluation.metric_value),
+            'best_score': float(best_score),
+        },
+    )

--- a/fedot_ind/core/operation/interfaces/detection_runtime_strategy.py
+++ b/fedot_ind/core/operation/interfaces/detection_runtime_strategy.py
@@ -6,8 +6,11 @@ from typing import Optional
 from fedot.core.data.data import InputData, OutputData
 from fedot.core.operations.evaluation.evaluation_interfaces import EvaluationStrategy
 from fedot.core.operations.operation_parameters import OperationParameters
+from fedot.core.repository.dataset_types import DataTypesEnum
 from fedot.utilities.random import ImplementationRandomStateHandler
 
+from fedot_ind.core.models.detection.anomaly.algorithms.arima_fault_detector import ARIMAFaultDetector
+from fedot_ind.core.models.detection.anomaly.algorithms.lstm_autoencoder_detector import LSTMAutoEncoderDetector
 from fedot_ind.core.models.detection.modern_detectors import (
     ConvAutoencoderDetector,
     FeatureIsolationForestDetector,
@@ -15,27 +18,20 @@ from fedot_ind.core.models.detection.modern_detectors import (
     TCNAutoencoderDetector,
 )
 from fedot_ind.core.models.detection.runtime import DetectionBoundaryAdapter, ensure_detection_array
-from fedot_ind.core.repository.detection_registry import ensure_canonical_detection_model
+from fedot_ind.core.repository.detection_registry import canonical_detection_model_name
 
 DETECTION_RUNTIME_MODELS = {
     'feature_iforest_detector': FeatureIsolationForestDetector,
     'feature_oneclass_detector': FeatureOneClassDetector,
     'conv_autoencoder_detector': ConvAutoencoderDetector,
     'tcn_autoencoder_detector': TCNAutoencoderDetector,
-    # DETECTION_RUNTIME_MODELS ограничен canonical-only
-    # 'legacy_lstm_autoencoder_detector': LSTMAutoEncoderDetector,
-    # 'legacy_arima_detector': ARIMAFaultDetector,
+    'legacy_lstm_autoencoder_detector': LSTMAutoEncoderDetector,
+    'legacy_arima_detector': ARIMAFaultDetector,
 }
 
 
 def build_detection_boundary_batch(input_data: InputData, params: Optional[OperationParameters] = None):
-    """Build a FEDOT-boundary detection batch using the shared runtime adapter.
-
-    Legacy anomaly pipelines used ``window_length`` as a percentage-like knob,
-    while the new runtime speaks explicitly in ``window_size`` and
-    ``window_size_percent``. This helper keeps that boundary rule in one place
-    for strategies and tests.
-    """
+    """Build a FEDOT-boundary detection batch using the shared runtime adapter."""
     params = params or OperationParameters()
     return DetectionBoundaryAdapter.from_input_data(
         input_data,
@@ -47,36 +43,28 @@ def build_detection_boundary_batch(input_data: InputData, params: Optional[Opera
 
 
 class IndustrialDetectionModelRuntimeStrategy(EvaluationStrategy):
-    """Thin FEDOT evaluation strategy for stage-first anomaly detectors."""
+    """FEDOT evaluation strategy for modern and legacy anomaly detectors."""
 
     _operations_by_types = DETECTION_RUNTIME_MODELS
 
     def __init__(self, operation_type: str, params: Optional[OperationParameters] = None):
-        # self.canonical_operation_type = canonical_detection_model_name(operation_type)
-        # alias типа *_detector продолжают работать, т.к. сначала канонизируются в feature_*
-        self.canonical_operation_type = ensure_canonical_detection_model(operation_type, context='Runtime strategy')
+        self.canonical_operation_type = canonical_detection_model_name(operation_type)
         super().__init__(operation_type, params)
         self.operation_impl = self._convert_to_operation(operation_type)
         self.output_mode = self.params_for_fit.get('output_mode', 'labels')
 
     def _convert_to_operation(self, operation_type: str):
-        # canonical_name = canonical_detection_model_name(operation_type)
-        # if canonical_name in self._operations_by_types:
-        #     return self._operations_by_types[canonical_name]
-        canonical_name = ensure_canonical_detection_model(
-            operation_type,
-            context='Runtime strategy'
-        )
-        return self._operations_by_types[canonical_name]
-        # raise ValueError(f'Impossible to obtain detection runtime strategy for {operation_type}')
+        canonical_name = canonical_detection_model_name(operation_type)
+        if canonical_name in self._operations_by_types:
+            return self._operations_by_types[canonical_name]
+        raise ValueError(f'Impossible to obtain detection runtime strategy for {operation_type}')
 
     def fit(self, train_data: InputData):
         warnings.filterwarnings("ignore", category=RuntimeWarning)
         operation_implementation = self.operation_impl(self.params_for_fit)
         train_data = self._normalize_input_data(train_data)
-        # runtime detectors принимают чистые данные, не InputData
         with ImplementationRandomStateHandler(implementation=operation_implementation):
-            operation_implementation.fit(train_data.features)
+            operation_implementation.fit(train_data)
         return operation_implementation
 
     def predict(self, trained_operation, predict_data: InputData, output_mode: str = 'default') -> OutputData:
@@ -84,26 +72,32 @@ class IndustrialDetectionModelRuntimeStrategy(EvaluationStrategy):
 
     def predict_for_fit(self, trained_operation, predict_data: InputData,
                         output_mode: str = 'default') -> OutputData:
-        # На fit FEDOT merge ждёт табличные признаки (proba), не бинарные labels.
         fit_output_mode = 'probs' if output_mode == 'default' else output_mode
-        # prediction = self._predict_by_mode(trained_operation, predict_data, fit_output_mode)
-        # return self._convert_to_output(prediction, predict_data, output_data_type=DataTypesEnum.table)
         return self._build_output(trained_operation, predict_data, fit_output_mode)
 
     def _build_output(self, trained_operation, predict_data: InputData, output_mode: str) -> OutputData:
-        # boundary живёт в адаптере, детектор отдаёт типизированный AnomalyScoreSeries,
-        # адаптер выводит из него FEDOT predict (labels/scores/probs)
         predict_data = self._normalize_input_data(predict_data)
         resolved_mode = output_mode if output_mode != 'default' else self.output_mode
         if resolved_mode == 'default':
             resolved_mode = 'labels'
-        # единая точка получения скоров/меток/порога от детектора
-        score_series = trained_operation.score_series_on_values(predict_data.features)
+        if not hasattr(trained_operation, 'score_series_on_values'):
+            prediction = self._predict_by_mode(trained_operation, predict_data, resolved_mode)
+            return self._convert_to_output(prediction, predict_data, output_data_type=DataTypesEnum.table)
+
+        score_series = trained_operation.score_series_on_values(predict_data)
         return DetectionBoundaryAdapter.to_output_data(
             predict_data,
             score_series=score_series,
             predict_mode=resolved_mode,
         )
+
+    def _predict_by_mode(self, trained_operation, input_data: InputData, output_mode: str):
+        resolved_mode = self.output_mode if output_mode == 'default' else output_mode
+        if resolved_mode in {'probs', 'probabilities'}:
+            return trained_operation.predict_proba(input_data)
+        if resolved_mode in {'scores', 'score'}:
+            return trained_operation.score_samples(input_data)
+        return trained_operation.predict(input_data)
 
     def _normalize_input_data(self, input_data: InputData) -> InputData:
         features = ensure_detection_array(input_data.features)

--- a/fedot_ind/core/operation/interfaces/detection_runtime_strategy.py
+++ b/fedot_ind/core/operation/interfaces/detection_runtime_strategy.py
@@ -19,14 +19,16 @@ from fedot_ind.core.models.detection.modern_detectors import (
 )
 from fedot_ind.core.models.detection.runtime import DetectionBoundaryAdapter, ensure_detection_array
 from fedot_ind.core.repository.detection_registry import canonical_detection_model_name
+from fedot_ind.core.repository.detection_registry import ensure_canonical_detection_model
 
 DETECTION_RUNTIME_MODELS = {
     'feature_iforest_detector': FeatureIsolationForestDetector,
     'feature_oneclass_detector': FeatureOneClassDetector,
     'conv_autoencoder_detector': ConvAutoencoderDetector,
     'tcn_autoencoder_detector': TCNAutoencoderDetector,
-    'legacy_lstm_autoencoder_detector': LSTMAutoEncoderDetector,
-    'legacy_arima_detector': ARIMAFaultDetector,
+    # DETECTION_RUNTIME_MODELS ограничен canonical-only
+    # 'legacy_lstm_autoencoder_detector': LSTMAutoEncoderDetector,
+    # 'legacy_arima_detector': ARIMAFaultDetector,
 }
 
 
@@ -54,42 +56,58 @@ class IndustrialDetectionModelRuntimeStrategy(EvaluationStrategy):
     _operations_by_types = DETECTION_RUNTIME_MODELS
 
     def __init__(self, operation_type: str, params: Optional[OperationParameters] = None):
-        self.canonical_operation_type = canonical_detection_model_name(operation_type)
+        # self.canonical_operation_type = canonical_detection_model_name(operation_type)
+        # alias типа *_detector продолжают работать, т.к. сначала канонизируются в feature_*
+        self.canonical_operation_type = ensure_canonical_detection_model(operation_type, context='Runtime strategy')
         super().__init__(operation_type, params)
         self.operation_impl = self._convert_to_operation(operation_type)
         self.output_mode = self.params_for_fit.get('output_mode', 'labels')
 
     def _convert_to_operation(self, operation_type: str):
-        canonical_name = canonical_detection_model_name(operation_type)
-        if canonical_name in self._operations_by_types:
-            return self._operations_by_types[canonical_name]
-        raise ValueError(f'Impossible to obtain detection runtime strategy for {operation_type}')
+        # canonical_name = canonical_detection_model_name(operation_type)
+        # if canonical_name in self._operations_by_types:
+        #     return self._operations_by_types[canonical_name]
+        canonical_name = ensure_canonical_detection_model(
+            operation_type,
+            context='Runtime strategy'
+        )
+        return self._operations_by_types[canonical_name]
+        # raise ValueError(f'Impossible to obtain detection runtime strategy for {operation_type}')
 
     def fit(self, train_data: InputData):
         warnings.filterwarnings("ignore", category=RuntimeWarning)
         operation_implementation = self.operation_impl(self.params_for_fit)
         train_data = self._normalize_input_data(train_data)
+        # runtime detectors принимают чистые данные, не InputData
         with ImplementationRandomStateHandler(implementation=operation_implementation):
-            operation_implementation.fit(train_data)
+            operation_implementation.fit(train_data.features)
         return operation_implementation
 
     def predict(self, trained_operation, predict_data: InputData, output_mode: str = 'default') -> OutputData:
-        prediction = self._predict_by_mode(trained_operation, predict_data, output_mode)
-        return self._convert_to_output(prediction, predict_data, output_data_type=DataTypesEnum.table)
+        return self._build_output(trained_operation, predict_data, output_mode)
 
     def predict_for_fit(self, trained_operation, predict_data: InputData,
                         output_mode: str = 'default') -> OutputData:
-        prediction = self._predict_by_mode(trained_operation, predict_data, output_mode)
-        return self._convert_to_output(prediction, predict_data, output_data_type=DataTypesEnum.table)
+        # На fit FEDOT merge ждёт табличные признаки (proba), не бинарные labels.
+        fit_output_mode = 'probs' if output_mode == 'default' else output_mode
+        # prediction = self._predict_by_mode(trained_operation, predict_data, fit_output_mode)
+        # return self._convert_to_output(prediction, predict_data, output_data_type=DataTypesEnum.table)
+        return self._build_output(trained_operation, predict_data, fit_output_mode)
 
-    def _predict_by_mode(self, trained_operation, input_data: InputData, output_mode: str):
-        input_data = self._normalize_input_data(input_data)
-        resolved_mode = self.output_mode if output_mode == 'default' else output_mode
-        if resolved_mode in {'probs', 'probabilities'}:
-            return trained_operation.predict_proba(input_data)
-        if resolved_mode in {'scores', 'score'}:
-            return trained_operation.score_samples(input_data)
-        return trained_operation.predict(input_data)
+    def _build_output(self, trained_operation, predict_data: InputData, output_mode: str) -> OutputData:
+        # boundary живёт в адаптере, детектор отдаёт типизированный AnomalyScoreSeries,
+        # адаптер выводит из него FEDOT predict (labels/scores/probs)
+        predict_data = self._normalize_input_data(predict_data)
+        resolved_mode = output_mode if output_mode != 'default' else self.output_mode
+        if resolved_mode == 'default':
+            resolved_mode = 'labels'
+        # единая точка получения скоров/меток/порога от детектора
+        score_series = trained_operation.score_series_on_values(predict_data.features)
+        return DetectionBoundaryAdapter.to_output_data(
+            predict_data,
+            score_series=score_series,
+            predict_mode=resolved_mode,
+        )
 
     def _normalize_input_data(self, input_data: InputData) -> InputData:
         features = ensure_detection_array(input_data.features)

--- a/fedot_ind/core/operation/interfaces/detection_runtime_strategy.py
+++ b/fedot_ind/core/operation/interfaces/detection_runtime_strategy.py
@@ -6,11 +6,8 @@ from typing import Optional
 from fedot.core.data.data import InputData, OutputData
 from fedot.core.operations.evaluation.evaluation_interfaces import EvaluationStrategy
 from fedot.core.operations.operation_parameters import OperationParameters
-from fedot.core.repository.dataset_types import DataTypesEnum
 from fedot.utilities.random import ImplementationRandomStateHandler
 
-from fedot_ind.core.models.detection.anomaly.algorithms.arima_fault_detector import ARIMAFaultDetector
-from fedot_ind.core.models.detection.anomaly.algorithms.lstm_autoencoder_detector import LSTMAutoEncoderDetector
 from fedot_ind.core.models.detection.modern_detectors import (
     ConvAutoencoderDetector,
     FeatureIsolationForestDetector,
@@ -18,7 +15,6 @@ from fedot_ind.core.models.detection.modern_detectors import (
     TCNAutoencoderDetector,
 )
 from fedot_ind.core.models.detection.runtime import DetectionBoundaryAdapter, ensure_detection_array
-from fedot_ind.core.repository.detection_registry import canonical_detection_model_name
 from fedot_ind.core.repository.detection_registry import ensure_canonical_detection_model
 
 DETECTION_RUNTIME_MODELS = {

--- a/fedot_ind/core/repository/IndustrialOperationParameters.py
+++ b/fedot_ind/core/repository/IndustrialOperationParameters.py
@@ -3,6 +3,7 @@ import os
 
 from fedot.core.operations.operation_parameters import OperationParameters
 
+from fedot_ind.core.repository.detection_registry import canonical_detection_model_name
 from fedot_ind.core.repository.forecasting_registry import canonical_forecasting_model_name
 
 
@@ -51,6 +52,7 @@ class DefaultOperationParamsRepository:
     def get_default_params_for_operation(self, model_name: str) -> dict:
         model_name = model_name.split('/')[0]
         model_name = canonical_forecasting_model_name(model_name)
+        model_name = canonical_detection_model_name(model_name)
         if model_name in self._repo:
             return self._repo[model_name]
         return {}

--- a/fedot_ind/core/repository/data/default_operation_params.json
+++ b/fedot_ind/core/repository/data/default_operation_params.json
@@ -583,6 +583,76 @@
     "ucl_quantile": 0.99,
     "n_steps_share": 0.15
   },
+  "feature_oneclass_detector": {
+    "window_length": 10,
+    "calibration_strategy": "mad",
+    "threshold_quantile": 0.99,
+    "min_event_length": 1,
+    "representation_mode": "statistical",
+    "nu": 0.05,
+    "kernel": "rbf",
+    "gamma": "scale"
+  },
+  "feature_iforest_detector": {
+    "window_length": 10,
+    "calibration_strategy": "mad",
+    "threshold_quantile": 0.99,
+    "min_event_length": 1,
+    "representation_mode": "statistical",
+    "n_jobs": 1,
+    "n_estimators": 200,
+    "contamination": "auto",
+    "random_state": 42
+  },
+  "conv_autoencoder_detector": {
+    "window_length": 10,
+    "calibration_strategy": "mad",
+    "threshold_quantile": 0.99,
+    "min_event_length": 1,
+    "epochs": 10,
+    "batch_size": 16,
+    "learning_rate": 0.001,
+    "latent_dim": 16,
+    "reconstruction_loss": "mse"
+  },
+  "tcn_autoencoder_detector": {
+    "window_length": 10,
+    "calibration_strategy": "mad",
+    "threshold_quantile": 0.99,
+    "min_event_length": 1,
+    "epochs": 10,
+    "batch_size": 16,
+    "learning_rate": 0.001,
+    "latent_dim": 16,
+    "reconstruction_loss": "mse"
+  },
+  "legacy_sst_detector": {
+    "window_length": 10,
+    "threshold_quantile": 0.99
+  },
+  "legacy_kalman_detector": {
+    "n_jobs": 2,
+    "window_size_as_share": 0.33,
+    "max_homology_dimension": 1,
+    "metric": "euclidean"
+  },
+  "legacy_arima_detector": {
+    "window_length": 10,
+    "anomaly_thr": 0.9,
+    "ar_order": 3
+  },
+  "legacy_lstm_autoencoder_detector": {
+    "window_length": 10,
+    "anomaly_thr": 0.9,
+    "ucl_quantile": 0.99,
+    "n_steps_share": 0.15
+  },
+  "legacy_functional_pca_detector": {
+    "n_jobs": 2,
+    "window_size_as_share": 0.33,
+    "max_homology_dimension": 1,
+    "metric": "euclidean"
+  },
   "one_class_svm": {
     "kernel": "rbf",
     "gamma": "auto"

--- a/fedot_ind/core/repository/detection_registry.py
+++ b/fedot_ind/core/repository/detection_registry.py
@@ -37,6 +37,16 @@ def canonical_detection_model_name(name: str | None) -> str:
     return DETECTION_MODEL_ALIASES.get(normalized, normalized)
 
 
+def ensure_canonical_detection_model(name: str | None, *, context: str = 'runtime') -> str:
+    """legacy остается как aliases, не проходит в runtime-first ветку"""
+    canonical = canonical_detection_model_name(name)
+    if canonical not in CANONICAL_STAGE_DETECTION_MODELS:
+        raise ValueError(
+            f'{context} accepts canonical detectors only, got: {name} -> {canonical}'
+        )
+    return canonical
+
+
 def detection_aliases_for(model_name: str) -> tuple[str, ...]:
     canonical = canonical_detection_model_name(model_name)
     aliases = [alias for alias, target in DETECTION_MODEL_ALIASES.items() if target == canonical]

--- a/tests/unit/core/metrics/test_metrics.py
+++ b/tests/unit/core/metrics/test_metrics.py
@@ -1,0 +1,748 @@
+"""Tests for public API for metrics: new (dict) и legacy (DataFrame).
+
+Check, that ``metrics.calculate_*`` and ``metrics_implementation.calculate_*``
+return the same values, and for sklearn-compatible metrics — also reference from sklearn.
+"""
+
+import numpy as np
+import pandas as pd
+import pytest
+from sklearn.metrics import (
+    accuracy_score,
+    balanced_accuracy_score,
+    f1_score as sklearn_f1,
+    precision_score as sklearn_prec,
+    recall_score as sklearn_recall,
+    log_loss as sklearn_log_loss,
+    mean_absolute_error as sklearn_mae,
+    mean_squared_error as sklearn_mse,
+    r2_score as sklearn_r2,
+    roc_auc_score as sklearn_roc_auc,
+    mean_squared_log_error,
+    mean_absolute_percentage_error,
+    median_absolute_error,
+    explained_variance_score,
+    max_error,
+    d2_absolute_error_score,
+)
+
+from fedot_ind.core.metrics._exceptions import MetricNotFoundError, MetricValidationError
+from fedot_ind.core.metrics.metrics import (
+    calculate_classification_metric,
+    calculate_detection_metric,
+    calculate_forecasting_metric,
+    calculate_regression_metric,
+)
+# from fedot_ind.core.metrics.metrics_implementation import (
+#     calculate_classification_metric as legacy_classification,
+#     calculate_detection_metric as legacy_detection,
+#     calculate_forecasting_metric as legacy_forecasting,
+#     calculate_regression_metric as legacy_regression,
+# )
+
+# Same rounding in both APIs to make comparisons easy
+ROUND = 8
+
+# --- Data for classification/detection (binary labels) ---
+Y_TRUE_BIN = np.array([0, 0, 1, 1, 0, 1, 0, 0])
+Y_PRED_BIN = np.array([0, 1, 1, 0, 0, 1, 0, 1])
+
+Y_TRUE_MC = np.array([0, 1, 2, 1, 2, 0, 1, 2])
+Y_PRED_MC = np.array([0, 1, 1, 1, 2, 0, 2, 2])
+
+Y_TRUE_PROB = np.array([0, 1, 0, 1, 0, 1])
+Y_PRED_PROB = np.array([0, 1, 1, 1, 0, 0])
+PROBS_2D = np.array([
+    [0.9, 0.1],
+    [0.2, 0.8],
+    [0.4, 0.6],
+    [0.3, 0.7],
+    [0.85, 0.15],
+    [0.75, 0.25],
+])
+
+# --- Data for regression ---
+_rng = np.random.default_rng(42)
+Y_TRUE_REG = _rng.normal(0, 1, size=24)
+Y_PRED_REG = Y_TRUE_REG + _rng.normal(0, 0.15, size=24)
+
+# --- Data for forecasting ---
+_rng_fc = np.random.default_rng(7)
+TRAIN_SERIES = np.cumsum(_rng_fc.normal(0, 0.3, size=40)) + 10.0
+Y_TRUE_FC = TRAIN_SERIES[-12:] + _rng_fc.normal(0, 0.1, size=12)
+Y_PRED_FC = Y_TRUE_FC + _rng_fc.normal(0, 0.2, size=12)
+SEASONALITY = 4
+
+# --- Data for NAB / average_time ---
+Y_TRUE_ANOM = np.zeros(30, dtype=int)
+Y_TRUE_ANOM[12:15] = 1
+Y_PRED_ANOM = np.zeros(30, dtype=int)
+Y_PRED_ANOM[13] = 1
+
+
+def assert_new_equals_legacy(new_dict: dict, legacy_df: pd.DataFrame, keys: str) -> float:
+    """The new API and legacy API must match in terms of metric key and value."""
+    res = []
+    for key in keys:
+        assert key in new_dict
+        assert key in legacy_df
+        new_val = new_dict[key]
+        leg_val = legacy_df[key].iloc[0]
+        if isinstance(new_val, dict):
+            assert leg_val == new_val
+        elif isinstance(new_val, (list, np.ndarray)):
+            np.testing.assert_allclose(np.asarray(new_val), np.asarray(leg_val), rtol=1e-6)
+        elif isinstance(new_val, (int, float, np.floating)):
+            assert float(new_val) == float(leg_val)
+        else:
+            raise Exception(f'wrong type: new_val - {type(new_val)} ; leg_val - {type(leg_val)}')
+        res.append(float(new_val) if np.isscalar(new_val) or isinstance(new_val, (int, float)) else new_val)
+    return res
+
+
+def run_classification(metric, y_true=Y_TRUE_BIN, y_pred=Y_PRED_BIN, **kwargs):
+    """Calling new and legacy APIs for classification."""
+    spec = metric if isinstance(metric, (list, tuple)) else (metric,)
+    new = calculate_classification_metric(
+        y_true,
+        y_pred,
+        metric_names=spec,
+        rounding_order=ROUND,
+        return_dataframe=False,
+        return_raw_dict=True,
+        **kwargs,
+    )
+    # legacy = legacy_classification(target=y_true, predicted_labels=y_pred, metric_names=spec, rounding_order=ROUND, **kwargs,)
+    legacy = calculate_classification_metric(
+        target=y_true,
+        predicted_labels=y_pred,
+        metric_names=spec,
+        rounding_order=ROUND,
+        **kwargs,
+    )
+    name = []
+    for s in spec:
+        if isinstance(s, str):
+            name.append(s)
+        elif isinstance(s, dict):
+            name.append(s['name'])
+        else:
+            raise Exception(f'wrong spec element type: {type(s)}')
+    return new, legacy, name
+
+
+def run_regression(metric, y_true=Y_TRUE_REG, y_pred=Y_PRED_REG):
+    """Calling new and legacy APIs for regression."""
+    spec = metric if isinstance(metric, (list, tuple)) else (metric,)
+    new = calculate_regression_metric(
+        y_true,
+        y_pred,
+        metric_names=spec,
+        rounding_order=ROUND,
+        return_dataframe=False,
+        return_raw_dict=True,
+    )
+    # legacy = legacy_regression(target=y_true, predicted_labels=y_pred,metric_names=spec, rounding_order=ROUND,)
+    legacy = calculate_regression_metric(target=y_true, predicted_labels=y_pred,
+                                         metric_names=spec, rounding_order=ROUND,)
+    name = []
+    for s in spec:
+        if isinstance(s, str):
+            name.append(s)
+        elif isinstance(s, dict):
+            name.append(s['name'])
+        else:
+            raise Exception(f'wrong spec element type: {type(s)}')
+    return new, legacy, name
+
+
+def run_forecasting(metric, y_true=Y_TRUE_FC, y_pred=Y_PRED_FC):
+    spec = metric if isinstance(metric, (list, tuple)) else (metric,)
+    new = calculate_forecasting_metric(
+        y_true, y_pred, metric_names=spec, rounding_order=ROUND,
+        train_data=TRAIN_SERIES, seasonality=SEASONALITY,
+        return_dataframe=False, return_raw_dict=True,
+    )
+    # legacy = legacy_forecasting(target=y_true, predicted_labels=y_pred, metric_names=spec,rounding_order=ROUND, train_data=TRAIN_SERIES, seasonality=SEASONALITY,)
+    legacy = calculate_forecasting_metric(
+        target=y_true,
+        predicted_labels=y_pred,
+        metric_names=spec,
+        rounding_order=ROUND,
+        train_data=TRAIN_SERIES,
+        seasonality=SEASONALITY,
+    )
+    name = []
+    for s in spec:
+        if isinstance(s, str):
+            name.append(s)
+        elif isinstance(s, dict):
+            name.append(s['name'])
+        else:
+            raise Exception(f'wrong spec element type: {type(s)}')
+    return new, legacy, name
+
+
+def run_detection(metric, y_true=Y_TRUE_ANOM, y_pred=Y_PRED_ANOM):
+    spec = metric if isinstance(metric, (list, tuple)) else (metric,)
+    new = calculate_detection_metric(
+        y_true,
+        y_pred,
+        metric_names=spec,
+        rounding_order=ROUND,
+        return_dataframe=False,
+        return_raw_dict=True,
+    )
+    # legacy = legacy_detection(target=y_true, predicted_labels=y_pred, metric_names=spec, rounding_order=ROUND,)
+    legacy = calculate_detection_metric(target=y_true, predicted_labels=y_pred,
+                                        metric_names=spec, rounding_order=ROUND,)
+    name = []
+    for s in spec:
+        if isinstance(s, str):
+            name.append(s)
+        elif isinstance(s, dict):
+            name.append(s['name'])
+        else:
+            raise Exception(f'wrong spec element type: {type(s)}')
+    return new, legacy, name
+
+# =============================================================================
+# Classification
+# =============================================================================
+
+
+class TestClassificationMetrics:
+    """metrics.calculate_classification_metric vs legacy + sklearn."""
+
+    def test_accuracy(self):
+        new, leg, name = run_classification('accuracy')
+        val = assert_new_equals_legacy(new, leg, name)
+        assert val[0] == pytest.approx(accuracy_score(Y_TRUE_BIN, Y_PRED_BIN), rel=1e-4)
+
+    def test_balanced_accuracy(self):
+        new, leg, name = run_classification('balanced_accuracy')
+        val = assert_new_equals_legacy(new, leg, name)
+        assert val[0] == pytest.approx(balanced_accuracy_score(Y_TRUE_BIN, Y_PRED_BIN), rel=1e-4)
+
+    def test_balanced_accuracy_with_arguments(self):
+        spec = ({'name': 'balanced_accuracy', 'params': {'labels': [0, 1], 'pos_label': 0}})
+        new, leg, name = run_classification(spec)
+        val = assert_new_equals_legacy(new, leg, name)
+        assert val[0] == pytest.approx(balanced_accuracy_score(Y_TRUE_BIN, Y_PRED_BIN), rel=1e-4)
+
+    def test_f1_binary(self):
+        spec = {'name': 'f1', 'params': {'average': 'binary', 'pos_label': 1}}
+        new, leg, name = run_classification(spec)
+        val = assert_new_equals_legacy(new, leg, name)
+        assert val[0] == pytest.approx(
+            sklearn_f1(Y_TRUE_BIN, Y_PRED_BIN, average='binary', pos_label=1), rel=1e-4,
+        )
+
+    def test_f1_bin_with_multiclass(self):
+        spec = {'name': 'f1', 'params': {'average': 'binary', 'pos_label': 1}}
+        with pytest.raises(MetricValidationError, match='binary average для F1 возможна только при 2 классах'):
+            run_classification(spec, y_true=Y_TRUE_MC, y_pred=Y_PRED_MC)
+
+    def test_f1_bin_with_uniform_zeroes(self):
+        spec = {'name': 'f1', 'params': {'average': 'binary', 'pos_label': 1}}
+        new, leg, name = run_classification(spec, y_true=np.ones(10), y_pred=np.ones(10))
+        val = assert_new_equals_legacy(new, leg, name)
+        assert val[0] == pytest.approx(
+            sklearn_f1(np.ones(10), np.ones(10), average='binary', pos_label=1), rel=1e-4,
+        )
+
+    def test_f1_bin_with_uniform_number(self):
+        with pytest.raises(MetricValidationError, match="Please add labels parameter for metric."):
+            spec = {'name': 'f1', 'params': {'average': 'binary', 'pos_label': 1}}
+            a = np.empty(10, dtype=int)
+            a.fill(7)
+            run_classification(spec, y_true=a, y_pred=a)
+
+    def test_f1_bin_with_uniform_number_and_labels_argument(self):
+        spec = {'name': 'f1', 'params': {'average': 'binary', 'pos_label': 7, 'labels': [0, 7]}}
+        a = np.empty(10, dtype=int)
+        a.fill(7)
+        new, leg, name = run_classification(spec, y_true=a, y_pred=a)
+        val = assert_new_equals_legacy(new, leg, name)
+        assert val[0] == pytest.approx(
+            sklearn_f1(a, a, average='binary', pos_label=7), rel=1e-4,
+        )
+
+    def test_f1_with_unknown_average(self):
+        spec = {'name': 'f1', 'params': {'average': 'aaaaa', 'pos_label': 1}}
+        with pytest.raises(MetricValidationError, match='Неизвестный тип усреднения для F1: aaaaa'):
+            run_classification(spec)
+
+    def test_f1_micro(self):
+        spec = {'name': 'f1', 'params': {'average': 'micro'}}
+        new, leg, name = run_classification(spec, y_true=Y_TRUE_MC, y_pred=Y_PRED_MC)
+        val = assert_new_equals_legacy(new, leg, name)
+        assert val[0] == pytest.approx(
+            sklearn_f1(Y_TRUE_MC, Y_PRED_MC, average='micro'), rel=1e-4,
+        )
+
+    def test_f1_macro(self):
+        spec = {'name': 'f1', 'params': {'average': 'macro'}}
+        new, leg, name = run_classification(spec, y_true=Y_TRUE_MC, y_pred=Y_PRED_MC)
+        val = assert_new_equals_legacy(new, leg, name)
+        assert val[0] == pytest.approx(
+            sklearn_f1(Y_TRUE_MC, Y_PRED_MC, average='macro'), rel=1e-4,
+        )
+
+    def test_f1_weighted(self):
+        spec = {'name': 'f1', 'params': {'average': 'weighted'}}
+        new, leg, name = run_classification(spec, y_true=Y_TRUE_MC, y_pred=Y_PRED_MC)
+        val = assert_new_equals_legacy(new, leg, name)
+        assert val[0] == pytest.approx(
+            sklearn_f1(Y_TRUE_MC, Y_PRED_MC, average='weighted'), rel=1e-4,
+        )
+
+    # TODO
+    # def test_f1_auto_auto(self):
+    #     # если всё будет auto (average = default [auto] | pos_label = default [auto])
+    #     pass
+
+    def test_precision_macro_multiclass(self):
+        spec = {'name': 'precision', 'params': {'average': 'macro'}}
+        new, leg, name = run_classification(spec, y_true=Y_TRUE_MC, y_pred=Y_PRED_MC)
+        val = assert_new_equals_legacy(new, leg, name)
+        assert val[0] == pytest.approx(
+            sklearn_prec(Y_TRUE_MC, Y_PRED_MC, average='macro'), rel=1e-4,
+        )
+
+    def test_precision_weighted(self):
+        spec = {'name': 'precision', 'params': {'average': 'weighted'}}
+        new, leg, name = run_classification(spec, y_true=Y_TRUE_MC, y_pred=Y_PRED_MC)
+        val = assert_new_equals_legacy(new, leg, name)
+        assert val[0] == pytest.approx(
+            sklearn_prec(Y_TRUE_MC, Y_PRED_MC, average='weighted'), rel=1e-4,
+        )
+
+    def test_recall_macro_multiclass(self):
+        spec = {'name': 'recall', 'params': {'average': 'macro'}}
+        new, leg, name = run_classification(spec, y_true=Y_TRUE_MC, y_pred=Y_PRED_MC)
+        val = assert_new_equals_legacy(new, leg, name)
+        assert val[0] == pytest.approx(
+            sklearn_recall(Y_TRUE_MC, Y_PRED_MC, average='macro'), rel=1e-4,
+        )
+
+    def test_logloss_with_probs(self):
+        new, leg, name = run_classification(
+            'logloss', y_true=Y_TRUE_PROB, y_pred=Y_PRED_PROB, predicted_probs=PROBS_2D,
+        )
+        val = assert_new_equals_legacy(new, leg, name)
+        assert val[0] == pytest.approx(sklearn_log_loss(Y_TRUE_PROB, PROBS_2D), rel=1e-4)
+
+    # Тут скорее вылетает ошибка, что разные размеры у предиктед_лейблс и таргета.
+    # В целом, это хорошо, но я добавлю проверку на то, если предиктед_лейблс = None. Или не добавлю, хз пока что
+    def test_logloss_without_predicted_and_probs(self):
+        with pytest.raises(MetricValidationError, match='Predicted labels is None.'):
+            run_classification(
+                'logloss', y_true=Y_TRUE_PROB, y_pred=None, predicted_probs=None,
+            )
+
+    # Должно сделать one-hot от predicted и использовать, как probs
+    def test_log_loss_without_probs(self):
+        new, leg, name = run_classification(
+            'logloss', y_true=Y_TRUE_PROB, y_pred=Y_PRED_PROB)
+        val = assert_new_equals_legacy(new, leg, name)
+        assert val[0] == pytest.approx(sklearn_log_loss(Y_TRUE_PROB, np.array(
+            [[1.0, 0.0], [0.0, 1.0], [0.0, 1.0], [0.0, 1.0], [1.0, 0.0], [1.0, 0.0]])), rel=1e-4)
+
+    def test_roc_auc_with_probs_multiclass(self):
+        # Должно пойти по ветке, типа больше, чем 2 класса
+        probs_MC = np.array([np.array([0.8, 0.1, 0.1]),
+                             np.array([0.1, 0.8, 0.1]),
+                             np.array([0.1, 0.8, 0.1]),
+                             np.array([0.1, 0.8, 0.1]),
+                             np.array([0.1, 0.1, 0.8]),
+                             np.array([0.8, 0.1, 0.1]),
+                             np.array([0.1, 0.1, 0.8]),
+                             np.array([0.1, 0.1, 0.8])])
+        new, leg, name = run_classification(
+            'roc_auc',
+            y_true=Y_TRUE_MC,
+            # y_pred=Y_PRED_MC,
+            predicted_probs=probs_MC,
+        )
+        val = assert_new_equals_legacy(new, leg, name)
+        # assert val[0] == pytest.approx(
+        #     sklearn_roc_auc(Y_TRUE_MC, probs_MC), rel=1e-4,
+        # )
+
+    def test_roc_auc_without_probs_multiclass(self):
+        # Должно пойти по ветке, типа больше, чем 2 класса и сделать one-hot из predicted_labels
+        probs_MC_OH = np.array([[1.0, 0.0, 0.0],
+                                [0.0, 1.0, 0.0],
+                                [0.0, 1.0, 0.0],
+                                [0.0, 1.0, 0.0],
+                                [0.0, 0.0, 1.0],
+                                [1.0, 0.0, 0.0],
+                                [0.0, 0.0, 1.0],
+                                [0.0, 0.0, 1.0]])
+        new, leg, name = run_classification(
+            'roc_auc', y_true=Y_TRUE_MC, y_pred=Y_PRED_MC,
+        )
+        val = assert_new_equals_legacy(new, leg, name)
+        assert val[0] == pytest.approx(
+            sklearn_roc_auc(Y_TRUE_MC, probs_MC_OH, multi_class='ovr', average='macro'), rel=1e-4,
+        )
+
+    def test_roc_auc_with_probs_bin(self):
+        new, leg, name = run_classification(
+            'roc_auc', y_true=Y_TRUE_PROB, y_pred=Y_PRED_PROB, predicted_probs=PROBS_2D,
+        )
+        val = assert_new_equals_legacy(new, leg, name)
+        assert val[0] == pytest.approx(
+            sklearn_roc_auc(Y_TRUE_PROB, PROBS_2D[:, 1]), rel=1e-4,
+        )
+
+    # TODO - доработать, чтобы он сравнил поточечно типа
+    def test_per_class_scores(self):
+        new, leg, name = run_classification('per_class_scores', y_true=Y_TRUE_MC, y_pred=Y_PRED_MC)
+        block = new[name[0]]
+        # legacy expands the nested dict into columns per_class_scores_f1, ...
+        assert leg[f'{name[0]}.f1'].iloc[0] == block['f1']
+        assert 'recall' in block and 'precision' in block
+
+    def test_per_class_scores_with_pos_label(self):
+        spec = ({'name': 'per_class_scores', 'params': {'labels': [0, 1, 2]}},)
+        new, leg, name = run_classification(spec, y_true=Y_TRUE_MC, y_pred=Y_PRED_MC)
+        block = new[name[0]]
+        # legacy expands the nested dict into columns per_class_scores_f1, ...
+
+        assert leg[f'{name[0]}.f1'].iloc[0] == block['f1']
+        assert 'recall' in block and 'precision' in block
+
+    def test_binary_metrics(self):
+        new, leg, name = run_detection(
+            'bin_metrics', y_true=Y_TRUE_BIN, y_pred=Y_PRED_BIN,
+        )
+        block = new[name[0]]
+        assert leg[f'{name[0]}.FAR'].iloc[0] == block['FAR']
+        assert leg[f'{name[0]}.MAR'].iloc[0] == block['MAR']
+        assert 'recall' in block and 'precision' in block and 'f1' in block
+
+    def test_binary_conf_matrix_for_multiclass(self):
+        with pytest.raises(MetricValidationError, match='Confusion matrix должна быть 2x2 для бинарного случая'):
+            run_detection(
+                'bin_confusion_matrix', y_true=Y_TRUE_MC, y_pred=Y_PRED_MC,
+            )
+
+# =============================================================================
+# Regression
+# =============================================================================
+
+
+class TestRegressionMetrics:
+    def test_mse(self):
+        new, leg, name = run_regression('mse')
+        val = assert_new_equals_legacy(new, leg, name)
+        assert val[0] == pytest.approx(sklearn_mse(Y_TRUE_REG, Y_PRED_REG), rel=1e-4)
+
+    def test_rmse(self):
+        new, leg, name = run_regression('rmse')
+        val = assert_new_equals_legacy(new, leg, name)
+        assert val[0] == pytest.approx(sklearn_mse(Y_TRUE_REG, Y_PRED_REG, squared=False), rel=1e-4)
+
+    def test_mae(self):
+        new, leg, name = run_regression('mae')
+        val = assert_new_equals_legacy(new, leg, name)
+        assert val[0] == pytest.approx(sklearn_mae(Y_TRUE_REG, Y_PRED_REG), rel=1e-4)
+
+    def test_r2(self):
+        new, leg, name = run_regression('r2')
+        val = assert_new_equals_legacy(new, leg, name)
+        assert val[0] == pytest.approx(sklearn_r2(Y_TRUE_REG, Y_PRED_REG), rel=1e-4)
+
+    def test_multi_metrics(self):
+        new, leg, name = run_regression(('mse', 'mae'))
+        val = assert_new_equals_legacy(new, leg, name)
+        assert val[0] == pytest.approx(sklearn_mse(Y_TRUE_REG, Y_PRED_REG), rel=1e-4)
+        assert val[1] == pytest.approx(sklearn_mae(Y_TRUE_REG, Y_PRED_REG), rel=1e-4)
+
+    def test_msle(self):
+        a = Y_TRUE_REG + 5.
+        b = Y_PRED_REG + 5.
+        new, leg, name = run_regression('msle', y_true=a, y_pred=b)
+        val = assert_new_equals_legacy(new, leg, name)
+        assert val[0] == pytest.approx(mean_squared_log_error(a, b), rel=1e-4)
+
+    def test_msle_neg_values(self):
+        with pytest.raises(MetricValidationError, match="There are negative values in GT or predicted sequence. MSLE does not support negative values"):
+            run_regression('msle')
+
+    def test_mape(self):
+        new, leg, name = run_regression('mape')
+        val = assert_new_equals_legacy(new, leg, name)
+        assert val[0] == pytest.approx(mean_absolute_percentage_error(Y_TRUE_REG, Y_PRED_REG), rel=1e-4)
+
+    def test_median_abs_er(self):
+        new, leg, name = run_regression('median_absolute_error')
+        val = assert_new_equals_legacy(new, leg, name)
+        assert val[0] == pytest.approx(median_absolute_error(Y_TRUE_REG, Y_PRED_REG), rel=1e-4)
+
+    def test_explained_variance_score(self):
+        new, leg, name = run_regression('explained_variance_score')
+        val = assert_new_equals_legacy(new, leg, name)
+        assert val[0] == pytest.approx(explained_variance_score(Y_TRUE_REG, Y_PRED_REG), rel=1e-4)
+
+    def test_max_error(self):
+        new, leg, name = run_regression('max_error')
+        val = assert_new_equals_legacy(new, leg, name)
+        assert val[0] == pytest.approx(max_error(Y_TRUE_REG, Y_PRED_REG), rel=1e-4)
+
+    def test_d2_absolute_error_score(self):
+        new, leg, name = run_regression('d2_absolute_error_score')
+        val = assert_new_equals_legacy(new, leg, name)
+        assert val[0] == pytest.approx(d2_absolute_error_score(Y_TRUE_REG, Y_PRED_REG), rel=1e-4)
+
+    def test_different_length(self):
+        with pytest.raises(MetricValidationError, match='target and predicted must have the same length'):
+            aaa = np.append(Y_PRED_REG, np.array([0.0, 1.0]))
+            run_regression(
+                'mse', y_true=Y_TRUE_REG, y_pred=aaa,)
+
+    def test_different_shape(self):
+        with pytest.raises(MetricValidationError, match='target and predicted must have the same length'):
+            aaa = np.append(Y_PRED_REG, Y_PRED_REG).reshape(2, -1)
+            run_regression(
+                'mse', y_true=Y_TRUE_REG, y_pred=aaa,)
+
+# =============================================================================
+# Forecasting
+# =============================================================================
+
+
+class TestForecastingMetrics:
+    def test_mse(self):
+        new, leg, name = run_forecasting('mse')
+        val = assert_new_equals_legacy(new, leg, name)
+        assert val[0] == pytest.approx(sklearn_mse(Y_TRUE_FC, Y_PRED_FC), rel=1e-4)
+
+    def test_smape(self):
+        spec = ({'name': 'smape', 'params': {'epsilon': 15.0, 'aaa': 5}},
+                'smape')
+        new, leg, name = run_forecasting(spec)
+        assert_new_equals_legacy(new, leg, name)
+        keys = list(new.keys())
+        assert new[keys[0]] != new[keys[1]]
+
+    def test_mase(self):
+        new, leg, name = run_forecasting('mase')
+        assert_new_equals_legacy(new, leg, name)
+
+    def test_owa(self):
+        new, leg, name = run_forecasting('owa')
+        assert_new_equals_legacy(new, leg, name)
+
+    def test_pw_mae_pointwise(self):
+        new, leg, name = run_forecasting('pw_mae')
+        val = assert_new_equals_legacy(new, leg, name)
+        np.testing.assert_allclose(val[0], np.abs(Y_TRUE_FC - Y_PRED_FC), rtol=1e-6)
+
+# =============================================================================
+# Detection
+# =============================================================================
+
+
+class TestDetectionMetrics:
+    def test_accuracy_via_detection_task(self):
+        new, leg, name = run_detection('accuracy', y_true=Y_TRUE_BIN, y_pred=Y_PRED_BIN)
+        assert_new_equals_legacy(new, leg, name)
+
+    def test_bin_f1(self):
+        new, leg, name = run_detection('bin_f1', y_true=Y_TRUE_BIN, y_pred=Y_PRED_BIN)
+        val = assert_new_equals_legacy(new, leg, name)
+        assert val[0] == pytest.approx(
+            sklearn_f1(Y_TRUE_BIN, Y_PRED_BIN, average='binary', pos_label=1), rel=1e-4,
+        )
+
+    def test_bin_confusion_matrix(self):
+        new, leg, name = run_detection('bin_confusion_matrix', y_true=Y_TRUE_BIN, y_pred=Y_PRED_BIN)
+        cm = new[name[0]]
+        assert leg[f'{name[0]}.TP'].iloc[0] == cm['TP']
+        assert set(cm) == {'TP', 'TN', 'FP', 'FN'}
+
+    # ПРОВЕРЯТЬ
+    def test_nab(self):
+        new, leg, name = run_detection('nab')
+        new_data = new[name[0]]
+        # Standard  LowFP  LowFN
+        assert leg[f'{name[0]}.Standard'].iloc[0] == new_data['Standard']
+        assert leg[f'{name[0]}.LowFP'].iloc[0] == new_data['LowFP']
+        assert leg[f'{name[0]}.LowFN'].iloc[0] == new_data['LowFN']
+
+    def test_nab_all(self):
+        spec = (
+            {'name': 'nab', 'params': {
+                'anomaly_window_destination': 'center'
+            }},
+            {'name': 'nab', 'params': {
+                'anomaly_window_destination': 'center',
+                'portion': 0.5
+            }},
+            {'name': 'nab_standard', 'params': {
+                'anomaly_window_destination': 'center'
+            }},
+            {'name': 'nab_low_fp', 'params': {
+                'anomaly_window_destination': 'center'
+            }},
+            {'name': 'nab_low_fn', 'params': {
+                'anomaly_window_destination': 'center'
+            }},
+        )
+        dictt = calculate_detection_metric(
+            Y_TRUE_ANOM,
+            Y_PRED_ANOM,
+            metric_names=spec,
+            rounding_order=ROUND,
+            return_dataframe=False,
+            return_raw_dict=True)
+        assert dictt['nab__1'] != dictt['nab']
+        full = dictt['nab']
+        assert full['Standard'] == dictt['nab_standard']
+        assert full['LowFP'] == dictt['nab_low_fp']
+        assert full['LowFN'] == dictt['nab_low_fn']
+
+    # ПРОВЕРЯТЬ
+    def test_average_time(self):
+        new, leg, name = run_detection('average_time')
+        # assert_new_equals_legacy(new, leg, name)
+        block = new[name[0]]
+        # legacy expands the nested dict into columns per_class_scores_f1, ...
+        assert leg[f'{name[0]}.average_delay'].iloc[0] == block['average_delay']
+        assert 'missing' in block and 'FP' in block and 'total_anomalies' in block
+
+
+# =============================================================================
+# Спецификация метрик: dict и дубликаты имён
+# =============================================================================
+
+class TestMetricSpecifications:
+
+    def test_metric_as_dict_with_params(self):
+        """The metric is specified by a dictionary ``{'name': ..., 'params': ...}``."""
+        spec = {'name': 'f1', 'params': {'average': 'binary', 'pos_label': 1}}
+        # new = calculate_classification_metric(Y_TRUE_BIN, Y_PRED_BIN, metrics=[spec], rounding_order=ROUND)
+        # legacy = legacy_classification(
+        #     target=Y_TRUE_BIN, predicted_labels=Y_PRED_BIN,
+        #     metric_names=[spec], rounding_order=ROUND,
+        # )
+        new, leg, name = run_classification(spec)
+        assert_new_equals_legacy(new, leg, name)
+
+    def test_two_metrics_same_name_different_params(self):
+        """Two ``f1`` with different params → keys ``f1`` and ``f1__1`` (binary case)."""
+        specs = [
+            {'name': 'f1', 'params': {'average': 'binary', 'pos_label': 1}},
+            {'name': 'f1', 'params': {'average': 'weighted'}},
+        ]
+        new = calculate_classification_metric(
+            Y_TRUE_BIN,
+            Y_PRED_BIN,
+            metric_names=specs,
+            rounding_order=ROUND,
+            return_dataframe=False)
+        assert 'f1' in new and 'f1__1' in new
+        assert new['f1'] != new['f1__1']
+
+    def test_duplicate_mse_regression(self):
+        new = calculate_regression_metric(
+            Y_TRUE_REG, Y_PRED_REG,
+            metric_names=[{'name': 'mse'}, {'name': 'mse'}],
+            rounding_order=ROUND, return_dataframe=False,
+        )
+        assert 'mse' in new and 'mse__1' in new
+        assert new['mse'] == new['mse__1']
+
+    def test_duplicate_nab_detection(self):
+        specs = [
+            {'name': 'nab', 'params': {'profile': 'Standard', 'scale_koef': 1.0}},
+            {'name': 'nab', 'params': {'profile': 'Standard', 'scale_koef': 0.5}},
+        ]
+        new = calculate_detection_metric(
+            Y_TRUE_ANOM,
+            Y_PRED_ANOM,
+            metric_names=specs,
+            rounding_order=ROUND,
+            return_dataframe=False,
+            return_raw_dict=True)
+        assert 'nab' in new and 'nab__1' in new
+        # assert new['nab'] != new['nab__1']    # Не работает, потому что тестовая последовательность такая, что там не будет отлиций.
+        # Но если дебажить, то всё прокидывается нормально
+
+    def test_multi_metrics(self):
+        new, leg, name = run_classification(('accuracy',
+                                             {'name': 'f1',
+                                              'params': {
+                                                  'average': 'binary',
+                                                  'pos_label': 1}}))
+        val = assert_new_equals_legacy(new, leg, name)
+        assert val[0] == pytest.approx(accuracy_score(Y_TRUE_BIN, Y_PRED_BIN), rel=1e-4)
+        assert val[1] == pytest.approx(
+            sklearn_f1(Y_TRUE_BIN, Y_PRED_BIN, average='binary', pos_label=1), rel=1e-4,
+        )
+
+# =============================================================================
+# Ошибки и граничные случаи
+# =============================================================================
+
+
+class TestMetricsValidation:
+
+    def test_probs3D(self):
+        with pytest.raises(MetricValidationError, match='predicted_probs must be 1D or 2D'):
+            calculate_classification_metric([1, 2], [1, 2], [[[1.0, 0.0], [0.0, 1.0]]])
+
+    def test_probs_not_same_length(self):
+        with pytest.raises(MetricValidationError, match='predicted_probs must be 1D or 2D'):
+            calculate_classification_metric([1, 2], [1, 2], [[1.0, 0.0], [0.0, 1.0], [0.0, 0.0]])
+
+    # TODO - ещё можно сделать тест на _labels типа, там делается аргмакс (только классификация и аномалии)
+
+    def test_regression_length_mismatch(self):
+        with pytest.raises(MetricValidationError, match='same length'):
+            calculate_regression_metric([1.0, 2.0], [1.0])
+
+    def test_detection_length_mismatch(self):
+        with pytest.raises(MetricValidationError, match='length mismatch'):
+            calculate_detection_metric([0, 1], [0, 1, 0], metric_names=('accuracy',), return_dataframe=False)
+
+    def test_nested_series_not_supported(self):
+        with pytest.raises(MetricValidationError, match='multiple series'):
+            calculate_detection_metric([[0, 1], [1, 0]], [0, 1], metric_names=('accuracy',), return_dataframe=False)
+
+    def test_unknown_metric(self):
+        with pytest.raises(MetricNotFoundError):
+            calculate_regression_metric([1.0], [1.0], metric_names=('no_such_metric',))
+
+    def test_invalid_metric_spec_type(self):
+        with pytest.raises(MetricValidationError, match='Invalid metric spec'):
+            calculate_regression_metric([1.0], [1.0], metric_names=[123])  # type: ignore[list-item]
+
+    # TODO - ещё тогда уж можно проверить _parse_spec(), как ниже, но для другого
+    # raise MetricValidationError('Metric spec "params" must be a mapping.')
+
+    def test_dict_spec_without_name(self):
+        with pytest.raises(MetricValidationError, match='must include "name"'):
+            calculate_regression_metric([1.0], [1.0], metric_names=[{'params': {}}])
+
+
+class TestInputTypes:
+    """Different types of input data (list / numpy)."""
+
+    def test_classification_with_lists(self):
+        y_t = Y_TRUE_BIN.tolist()
+        y_p = Y_PRED_BIN.tolist()
+        new, leg, name = run_classification('accuracy', y_true=y_t, y_pred=y_p)
+        assert_new_equals_legacy(new, leg, name)
+
+    def test_classification_with_numpy(self):
+        new, leg, name = run_classification('accuracy')
+        assert_new_equals_legacy(new, leg, name)
+
+
+# TODO - Надо сделать тест на проверку округления, нормально ли оно работает, а то мало ли забыл где-то округлять, а где-то норм
+# Я это переделал, теперь там вроде бы всё норм в одном месте делается
+# округление после подсчёта каждой метрики в цикле по метрикам

--- a/tests/unit/core/metrics/test_metrics.py
+++ b/tests/unit/core/metrics/test_metrics.py
@@ -365,7 +365,7 @@ class TestClassificationMetrics:
             # y_pred=Y_PRED_MC,
             predicted_probs=probs_MC,
         )
-        val = assert_new_equals_legacy(new, leg, name)
+        assert_new_equals_legacy(new, leg, name)
         # assert val[0] == pytest.approx(
         #     sklearn_roc_auc(Y_TRUE_MC, probs_MC), rel=1e-4,
         # )

--- a/tests/unit/core/metrics/test_metrics.py
+++ b/tests/unit/core/metrics/test_metrics.py
@@ -33,6 +33,13 @@ from fedot_ind.core.metrics.metrics import (
     calculate_forecasting_metric,
     calculate_regression_metric,
 )
+
+try:
+    from sklearn.metrics import root_mean_squared_error as sklearn_rmse
+except ImportError:
+    def sklearn_rmse(y_true, y_pred):
+        return np.sqrt(sklearn_mse(y_true, y_pred))
+
 # from fedot_ind.core.metrics.metrics_implementation import (
 #     calculate_classification_metric as legacy_classification,
 #     calculate_detection_metric as legacy_detection,
@@ -443,7 +450,7 @@ class TestRegressionMetrics:
     def test_rmse(self):
         new, leg, name = run_regression('rmse')
         val = assert_new_equals_legacy(new, leg, name)
-        assert val[0] == pytest.approx(sklearn_mse(Y_TRUE_REG, Y_PRED_REG, squared=False), rel=1e-4)
+        assert val[0] == pytest.approx(sklearn_rmse(Y_TRUE_REG, Y_PRED_REG), rel=1e-4)
 
     def test_mae(self):
         new, leg, name = run_regression('mae')

--- a/tests/unit/core/models/detection/test_detection_alignment.py
+++ b/tests/unit/core/models/detection/test_detection_alignment.py
@@ -1,0 +1,570 @@
+import os
+
+import numpy as np
+import pytest
+
+from fedot_ind.tools.serialisation.path_lib import EXAMPLES_DATA_PATH
+from fedot_ind.core.models.detection.data_quality import (
+    align_timestamps,
+    prepare_detection_series,
+    _timestamps_to_seconds,
+    _resolve_duplicates,
+    _resample_to_grid,
+    _forward_fill,
+    _interpolate_linear,
+)
+
+# Ожидаемые имена фич-колонок valve-файлов (без меток anomaly/changepoint).
+VALVE_FEATURE_COLUMNS = (
+    'Accelerometer1RMS',
+    'Accelerometer2RMS',
+    'Current',
+    'Pressure',
+    'Temperature',
+    'Thermocouple',
+    'Voltage',
+    'Volume Flow RateRMS',
+)
+VALVE_N_FEATURES = len(VALVE_FEATURE_COLUMNS)
+VALVE_SLICE_ROWS = 20
+
+
+def _valve_csv_path(valve: str) -> str:
+    """Абсолютный путь к 0.csv"""
+    return os.path.join(
+        EXAMPLES_DATA_PATH, 'benchmark', 'detection', 'data', valve, '0.csv',
+    )
+
+
+def _load_valve_slice(valve: str, n_rows: int = VALVE_SLICE_ROWS):
+    """Загружает первые ``n_rows`` строк valve как (values, timestamps, columns).
+
+    * values     — np.ndarray формы (n_rows, 8) только по фич-колонкам;
+    * timestamps — список строк datetime (как они придут в align_timestamps);
+    * columns    — кортеж имён фич-колонок.
+
+    Если csv отсутствует (например, данные не выкачаны в окружении) — тест
+    пропускается через pytest.skip, чтобы не падать на CI без данных.
+    """
+    pd = pytest.importorskip('pandas')
+    path = _valve_csv_path(valve)
+    if not os.path.exists(path):
+        pytest.skip(f'valve dataset is not available: {path}')
+    frame = pd.read_csv(path, sep=';', index_col='datetime', nrows=n_rows)
+    feature_columns = [
+        column for column in frame.columns if column not in {'anomaly', 'changepoint'}
+    ]
+    values = frame[feature_columns].to_numpy(dtype=float)
+    timestamps = [str(value) for value in frame.index.astype(str)]
+    return values, timestamps, tuple(feature_columns)
+
+
+# Сортировка по времени
+
+def test_align_sorts_values_by_time_when_order_is_broken():
+    """Нарушенный порядок timestamps должен восстанавливаться стабильной сортировкой.
+
+    Вход: значения [[10],[20],[30]] с метками времени [2.0, 0.0, 1.0].
+    align_timestamps сортирует по возрастанию времени (np.argsort, kind='stable'),
+    поэтому:
+        * aligned_timestamps == [0.0, 1.0, 2.0];
+        * aligned_values     == [[20],[30],[10]] (строки переставлены вслед за временем);
+        * gap_mask           == [False, False, False] (равномерный шаг, без NaN);
+        * report['n_duplicates'] == 0, report['has_timestamps'] is True;
+        * nominal_dt = median положительных разностей == 1.0;
+        * resampling_method == 'none' (target_sample_rate_hz не задан).
+    """
+    values = np.array([[10.0], [20.0], [30.0]])  # TODO: проверить на формат как 2020-03-09 10:14:33
+    timestamps = [2.0, 0.0, 1.0]
+
+    aligned_values, aligned_ts, gap_mask, report = align_timestamps(values, timestamps)
+
+    np.testing.assert_array_equal(aligned_ts, np.array([0.0, 1.0, 2.0]))
+    np.testing.assert_array_equal(aligned_values, np.array([[20.0], [30.0], [10.0]]))
+    np.testing.assert_array_equal(gap_mask, np.array([False, False, False]))
+    assert report['n_duplicates'] == 0
+    assert report['has_timestamps'] is True
+    assert report['nominal_dt_seconds'] == 1.0
+    assert report['resampling_method'] == 'none'
+
+
+# 2. Дедупликация по политикам keep_last / mean / drop
+
+def test_resolve_duplicates_keep_last_keeps_latest_row():
+    """keep_last: для повторяющегося времени остаётся ПОСЛЕДНЕЕ вхождение.
+
+    Вход: seconds=[0,0,1], values=[[1],[2],[3]].
+    Для t=0 встречаются строки [1] и [2]; keep_last берёт последнюю → [2].
+    Ожидается:
+        * series == [[2],[3]];
+        * seconds == [0,1];
+        * n_duplicates == 1 (число удалённых дублей = len - n_unique = 3 - 2).
+    """
+    series = np.array([[1.0], [2.0], [3.0]])
+    seconds = np.array([0.0, 0.0, 1.0])
+
+    out_series, out_seconds, n_duplicates = _resolve_duplicates(series, seconds, 'keep_last')
+
+    np.testing.assert_array_equal(out_series, np.array([[2.0], [3.0]]))
+    np.testing.assert_array_equal(out_seconds, np.array([0.0, 1.0]))
+    assert n_duplicates == 1
+
+
+def test_resolve_duplicates_mean_averages_collisions():
+    """mean: для повторяющегося времени значения усредняются поканально.
+
+    Вход: seconds=[0,0,1], values=[[1],[3],[10]].
+    Для t=0: (1+3)/2 = 2.0; для t=1: 10.0.
+    Ожидается:
+        * series == [[2.0],[10.0]];
+        * seconds == [0,1];
+        * n_duplicates == 1.
+    """
+    series = np.array([[1.0], [3.0], [10.0]])
+    seconds = np.array([0.0, 0.0, 1.0])
+
+    out_series, out_seconds, n_duplicates = _resolve_duplicates(series, seconds, 'mean')
+
+    np.testing.assert_allclose(out_series, np.array([[2.0], [10.0]]))
+    np.testing.assert_array_equal(out_seconds, np.array([0.0, 1.0]))
+    assert n_duplicates == 1
+
+
+def test_resolve_duplicates_drop_removes_all_collided_rows():
+    """drop: ВСЕ строки с конфликтующим временем выбрасываются целиком.
+
+    Вход: seconds=[0,0,1,2], values=[[1],[3],[10],[20]].
+    t=0 встречается дважды → обе строки удаляются; уникальные t=1,2 остаются.
+    Особенность контракта: для 'drop' возвращается число УДАЛЁННЫХ строк
+    (np.count_nonzero(~keep)), т.е. 2, а не len-n_unique.
+    Ожидается:
+        * series == [[10],[20]];
+        * seconds == [1,2];
+        * n_duplicates == 2.
+    """
+    series = np.array([[1.0], [3.0], [10.0], [20.0]])
+    seconds = np.array([0.0, 0.0, 1.0, 2.0])
+
+    out_series, out_seconds, n_duplicates = _resolve_duplicates(series, seconds, 'drop')
+
+    np.testing.assert_array_equal(out_series, np.array([[10.0], [20.0]]))
+    np.testing.assert_array_equal(out_seconds, np.array([1.0, 2.0]))
+    assert n_duplicates == 2
+
+
+def test_align_timestamps_reports_duplicates_for_each_policy():
+    """Сквозная проверка report['n_duplicates'] через align_timestamps по политикам.
+
+    Один и тот же вход (метки [0,0,1], значения [[1],[3],[5]]) даёт:
+        * keep_last → n_duplicates == 1, остаётся [[3],[5]];
+        * mean      → n_duplicates == 1, остаётся [[2],[5]] (среднее (1+3)/2);
+        * drop      → n_duplicates == 1 (удалена 1 конфликтующая строка t=0,
+          но т.к. удаляются обе строки t=0, остаётся только [[5]]).
+    Для drop удаляются ОБЕ строки t=0, поэтому остаётся [[5]] и seconds=[1].
+    """
+    values = np.array([[1.0], [3.0], [5.0]])
+    timestamps = [0.0, 0.0, 1.0]
+
+    keep_vals, _ts, _mask, keep_report = align_timestamps(values, timestamps, duplicate_policy='keep_last')
+    np.testing.assert_array_equal(keep_vals, np.array([[3.0], [5.0]]))
+    assert keep_report['n_duplicates'] == 1
+
+    mean_vals, _ts, _mask, mean_report = align_timestamps(values, timestamps, duplicate_policy='mean')
+    np.testing.assert_allclose(mean_vals, np.array([[2.0], [5.0]]))
+    assert mean_report['n_duplicates'] == 1
+
+    drop_vals, _ts, _mask, drop_report = align_timestamps(values, timestamps, duplicate_policy='drop')
+    np.testing.assert_array_equal(drop_vals, np.array([[5.0]]))
+    assert drop_report['n_duplicates'] == 2
+
+
+# 3. Обнаружение пропусков (n_gaps, gap_total_seconds)
+
+def test_align_detects_time_gaps_without_resampling():
+    """Пропуск фиксируется, когда интервал > 1.5 * nominal_dt (без ресемплинга).
+
+    Вход: seconds=[0,1,2,5], values=[[0],[1],[2],[3]], target_sample_rate_hz не задан.
+    diffs = [1,1,3]; nominal_dt = median положительных diffs = 1.0.
+    gap_factor = diffs/nominal_dt = [1,1,3]; порог 1.5 → разрыв только на 3.0.
+    Ожидается:
+        * report['n_gaps'] == 1;
+        * report['gap_total_seconds'] == 3 - 1 = 2.0 (избыточное время сверх nominal_dt);
+        * resampling_method == 'none' (без target_sample_rate_hz сетка не строится);
+        * aligned_n == original_n == 4 (ряд только отсортирован, точки не добавлялись).
+    """
+    values = np.array([[0.0], [1.0], [2.0], [3.0]])
+    timestamps = [0.0, 1.0, 2.0, 5.0]
+
+    aligned_values, _ts, _mask, report = align_timestamps(values, timestamps)
+
+    assert report['n_gaps'] == 1
+    assert report['gap_total_seconds'] == pytest.approx(2.0)
+    assert report['resampling_method'] == 'none'
+    assert report['original_n'] == 4
+    assert report['aligned_n'] == 4
+    assert aligned_values.shape == (4, 1)
+
+
+# 4. Ресемплинг на регулярную сетку при target_sample_rate_hz
+
+def test_align_resamples_to_regular_grid_mark_only():
+    """target_sample_rate_hz=1 строит сетку 1 Гц; пропущенная точка остаётся NaN.
+
+    Вход: seconds=[0,1,2,4] (нет t=3), values=[[10],[20],[30],[50]],
+    target_sample_rate_hz=1.0, gap_policy='mark_only' (по умолчанию).
+    nominal_dt = 1/1 = 1.0; сетка = arange(0, 4 + 0.5, 1) = [0,1,2,3,4] (5 точек).
+    position наблюдений = [0,1,2,4]; точка t=3 (индекс 3) синтетическая.
+    Ожидается:
+        * aligned_timestamps == [0,1,2,3,4];
+        * aligned_values     == [[10],[20],[30],[nan],[50]] (mark_only НЕ заполняет);
+        * gap_mask           == [F,F,F,T,F] (только синтетическая/NaN-точка недостоверна);
+        * report['aligned_n'] == 5, resampling_method == 'mark_only';
+        * report['n_gaps'] == 1 (считается ПО исходным diffs до сетки:
+          diffs=[1,1,2], gap_factor=[1,1,2] → один разрыв на 2.0);
+        * report['gap_total_seconds'] == 2 - 1 = 1.0.
+    Также важна согласованность длины: len(gap_mask) == len(aligned_values) == 5.
+    """
+    values = np.array([[10.0], [20.0], [30.0], [50.0]])
+    timestamps = [0.0, 1.0, 2.0, 4.0]
+
+    aligned_values, aligned_ts, gap_mask, report = align_timestamps(
+        values, timestamps, target_sample_rate_hz=1.0,
+    )
+
+    np.testing.assert_array_equal(aligned_ts, np.array([0.0, 1.0, 2.0, 3.0, 4.0]))
+    np.testing.assert_array_equal(gap_mask, np.array([False, False, False, True, False]))
+    assert np.isnan(aligned_values[3, 0])
+    np.testing.assert_array_equal(aligned_values[[0, 1, 2, 4], 0], np.array([10.0, 20.0, 30.0, 50.0]))
+    assert report['aligned_n'] == 5
+    assert report['resampling_method'] == 'mark_only'
+    assert report['n_gaps'] == 1
+    assert report['gap_total_seconds'] == pytest.approx(1.0)
+    assert len(gap_mask) == aligned_values.shape[0] == 5
+
+
+def test_resample_to_grid_positions_and_gap_mask_directly():
+    """Прямой тест _resample_to_grid: позиции наблюдений и базовый gap_mask.
+
+    Вход: series=[[1],[2],[3]], seconds=[0,2,4], nominal_dt=2.0, gap_policy='mark_only'.
+    grid = arange(0, 4 + 1.0, 2) = [0,2,4] (3 точки) — здесь сетка совпадает с
+    наблюдениями, синтетических точек нет.
+    Возьмём более показательный случай ниже отдельным под-блоком: seconds=[0,2],
+    nominal_dt=1.0 → grid=[0,1,2], наблюдения в позициях 0 и 2, точка 1 — синтетическая.
+    Ожидается для второго случая:
+        * grid == [0,1,2];
+        * aligned == [[1],[nan],[2]];
+        * gap_mask == [F,T,F];
+        * method == 'mark_only'.
+    """
+    series = np.array([[1.0], [2.0]])
+    seconds = np.array([0.0, 2.0])
+
+    aligned, grid, gap_mask, method = _resample_to_grid(series, seconds, 1.0, 'mark_only')
+
+    np.testing.assert_array_equal(grid, np.array([0.0, 1.0, 2.0]))
+    np.testing.assert_array_equal(gap_mask, np.array([False, True, False]))
+    assert np.isnan(aligned[1, 0])
+    np.testing.assert_array_equal(aligned[[0, 2], 0], np.array([1.0, 2.0]))
+    assert method == 'mark_only'
+
+
+# ---------------------------------------------------------------------------
+# 5. Заполнение пропусков: forward_fill и interpolate_linear
+# ---------------------------------------------------------------------------
+
+def test_forward_fill_locf_and_backfill_leading_nans():
+    """_forward_fill: LOCF (последнее наблюдение вперёд) + backfill ведущих NaN.
+
+    Одноканальный вход [nan, nan, 5, nan, 7, nan]:
+        * LOCF протягивает 5 на индекс 3 и 7 на индекс 5;
+        * ведущие NaN (индексы 0,1) заполняются первым валидным значением 5.
+    Ожидается: [5, 5, 5, 5, 7, 7].
+
+    Многоканальный вход проверяет независимость каналов:
+        канал0 [nan,1,nan,4] → [1,1,1,4] (ведущий NaN backfill=1, LOCF 1→2);
+        канал1 [2,nan,nan,nan] → [2,2,2,2] (LOCF от первого значения 2).
+    Ожидается: [[1,2],[1,2],[1,2],[4,2]].
+    """
+    single = np.array([[np.nan], [np.nan], [5.0], [np.nan], [7.0], [np.nan]])
+    filled_single = _forward_fill(single)
+    np.testing.assert_array_equal(
+        filled_single[:, 0], np.array([5.0, 5.0, 5.0, 5.0, 7.0, 7.0]),
+    )
+
+    multi = np.array([
+        [np.nan, 2.0],
+        [1.0, np.nan],
+        [np.nan, np.nan],
+        [4.0, np.nan],
+    ])
+    filled_multi = _forward_fill(multi)
+    np.testing.assert_array_equal(
+        filled_multi,
+        np.array([[1.0, 2.0], [1.0, 2.0], [1.0, 2.0], [4.0, 2.0]]),
+    )
+
+
+def test_interpolate_linear_exact_values():
+    """_interpolate_linear: линейная интерполяция между валидными точками.
+
+    Вход [nan, nan, 2, nan, 6, nan]; валидные индексы = [2, 4] со значениями [2, 6].
+    np.interp(arange(6), [2,4], [2,6]):
+        * x<2 (индексы 0,1) клиппируется к крайнему значению 2;
+        * x=3 → середина между (2,2) и (4,6) → 4;
+        * x>4 (индекс 5) клиппируется к 6.
+    Ожидается: [2, 2, 2, 4, 6, 6].
+    """
+    column = np.array([[np.nan], [np.nan], [2.0], [np.nan], [6.0], [np.nan]])
+    filled = _interpolate_linear(column)
+    np.testing.assert_array_equal(
+        filled[:, 0], np.array([2.0, 2.0, 2.0, 4.0, 6.0, 6.0]),
+    )
+
+
+def test_align_interpolate_linear_fills_resampled_gap():
+    """Сквозной gap_policy='interpolate_linear' на ресемплированной сетке.
+
+    Вход: seconds=[0,1,3], values=[[0],[10],[30]], target_sample_rate_hz=1.0.
+    nominal_dt=1.0; сетка = arange(0, 3 + 0.5, 1) = [0,1,2,3]; точка t=2 синтетическая.
+    До заполнения колонка = [0,10,nan,30]; интерполяция даёт значение 20 на индексе 2.
+    Ключевая проверка: gap_mask считается ДО заполнения, поэтому индекс 2 остаётся
+    помеченным как недостоверный (True), хотя значение уже заполнено числом 20.
+    Ожидается:
+        * aligned_values == [[0],[10],[20],[30]];
+        * gap_mask == [F,F,T,F];
+        * resampling_method == 'interpolate_linear';
+        * len(gap_mask) == len(aligned_values) == 4.
+    """
+    values = np.array([[0.0], [10.0], [30.0]])
+    timestamps = [0.0, 1.0, 3.0]
+
+    aligned_values, _ts, gap_mask, report = align_timestamps(
+        values, timestamps, target_sample_rate_hz=1.0, gap_policy='interpolate_linear',
+    )
+
+    np.testing.assert_allclose(aligned_values[:, 0], np.array([0.0, 10.0, 20.0, 30.0]))
+    np.testing.assert_array_equal(gap_mask, np.array([False, False, True, False]))
+    assert report['resampling_method'] == 'interpolate_linear'
+    assert len(gap_mask) == aligned_values.shape[0] == 4
+
+
+# 6. Поведение без timestamps (timestamps=None)
+
+def test_align_without_timestamps_uses_integer_index_and_nan_mask():
+    """timestamps=None → регулярный целочисленный индекс, gap_mask только по NaN.
+
+    Вход: values=[[1],[2],[nan],[4]], timestamps=None.
+    Ожидается:
+        * aligned_values возвращается без изменений (включая NaN на индексе 2);
+        * aligned_timestamps == arange(4) == [0,1,2,3] (фиктивная регулярная ось);
+        * gap_mask == [F,F,T,F] (True только там, где NaN хотя бы в одном канале);
+        * report['has_timestamps'] is False;
+        * report['nominal_dt_seconds'] == 0.0, resampling_method == 'none';
+        * report['n_gaps'] == 0, n_duplicates == 0, aligned_n == 4.
+    """
+    values = np.array([[1.0], [2.0], [np.nan], [4.0]])
+
+    aligned_values, aligned_ts, gap_mask, report = align_timestamps(values, None)
+
+    np.testing.assert_array_equal(aligned_ts, np.array([0.0, 1.0, 2.0, 3.0]))
+    np.testing.assert_array_equal(gap_mask, np.array([False, False, True, False]))
+    assert np.isnan(aligned_values[2, 0])
+    assert report['has_timestamps'] is False
+    assert report['nominal_dt_seconds'] == 0.0
+    assert report['resampling_method'] == 'none'
+    assert report['n_gaps'] == 0
+    assert report['n_duplicates'] == 0
+    assert report['aligned_n'] == 4
+
+
+# 7. Согласованность gap_mask (длина и порядок относительно заполнения)
+
+def test_gap_mask_length_matches_series_and_marks_before_fill():
+    """gap_mask всегда длиной с выровненный ряд и помечает синтетику ДО заполнения.
+
+    Сравниваем две политики на одном входе seconds=[0,2], values=[[10],[30]],
+    target_sample_rate_hz=1.0 (синтетическая точка на t=1):
+        * forward_fill: значение индекса 1 = 10 (LOCF), но gap_mask[1] == True;
+        * mark_only:    значение индекса 1 = NaN,        gap_mask[1] == True.
+    В обоих случаях:
+        * len(gap_mask) == aligned_values.shape[0] == 3;
+        * gap_mask == [F,T,F].
+    Это подтверждает: маска отражает достоверность исходного измерения, а не факт
+    наличия числа после заполнения.
+    """
+    values = np.array([[10.0], [30.0]])
+    timestamps = [0.0, 2.0]
+
+    ff_values, _ts, ff_mask, _report = align_timestamps(
+        values, timestamps, target_sample_rate_hz=1.0, gap_policy='forward_fill',
+    )
+    assert len(ff_mask) == ff_values.shape[0] == 3
+    np.testing.assert_array_equal(ff_mask, np.array([False, True, False]))
+    assert ff_values[1, 0] == 10.0  # LOCF заполнил, но точка всё равно помечена
+
+    mo_values, _ts, mo_mask, _report = align_timestamps(
+        values, timestamps, target_sample_rate_hz=1.0, gap_policy='mark_only',
+    )
+    assert len(mo_mask) == mo_values.shape[0] == 3
+    np.testing.assert_array_equal(mo_mask, np.array([False, True, False]))
+    assert np.isnan(mo_values[1, 0])
+
+
+# 8. Сохранение числа каналов (синтетический + valve-срез)
+
+def test_align_preserves_channel_count_synthetic():
+    """Многоканальный вход сохраняет число каналов при сортировке.
+
+    Вход формы (5, 3) с перемешанными timestamps [4,3,2,1,0]; без ресемплинга.
+    Ожидается:
+        * aligned_values.shape == (5, 3) — число каналов не меняется;
+        * строки переставлены в порядке возрастания времени, т.е. реверс входа.
+    """
+    rng = np.random.default_rng(0)
+    values = rng.normal(size=(5, 3))
+    timestamps = [4.0, 3.0, 2.0, 1.0, 0.0]
+
+    aligned_values, aligned_ts, _mask, report = align_timestamps(values, timestamps)
+
+    assert aligned_values.shape == (5, 3)
+    np.testing.assert_array_equal(aligned_ts, np.array([0.0, 1.0, 2.0, 3.0, 4.0]))
+    np.testing.assert_array_equal(aligned_values, values[::-1])
+    assert report['aligned_n'] == 5
+
+
+@pytest.mark.parametrize('valve', ['valve1', 'valve2'])
+def test_valve_slice_shape_is_preserved(valve):
+    """Для среза valve (20 строк, 8 фич) форма выровненного ряда == (20, 8).
+
+    Без target_sample_rate_hz ряд только сортируется/дедуплицируется (дубликатов
+    времени в первых 20 строках нет), поэтому число строк остаётся 20, а число
+    каналов равно числу фич-колонок (8). Это контрактная проверка размерностей
+    на реальных данных без зависимости от конкретных числовых значений.
+    """
+    values, timestamps, columns = _load_valve_slice(valve)
+    assert values.shape == (VALVE_SLICE_ROWS, VALVE_N_FEATURES)
+    assert columns == VALVE_FEATURE_COLUMNS
+
+    aligned_values, _ts, gap_mask, report = align_timestamps(values, timestamps)
+
+    assert aligned_values.shape == (VALVE_SLICE_ROWS, VALVE_N_FEATURES)
+    assert report['original_n'] == VALVE_SLICE_ROWS
+    assert report['aligned_n'] == VALVE_SLICE_ROWS
+    assert len(gap_mask) == VALVE_SLICE_ROWS
+
+
+# 9. Парсинг datetime-строк valve в секунды и nominal_dt
+
+def test_timestamps_to_seconds_parses_iso_datetime_strings():
+    """_timestamps_to_seconds корректно парсит ISO-строки valve в секунды.
+
+    Берём три подряд идущие метки valve-формата с шагом 1 c:
+        '2020-03-09 10:14:33', ':34', ':35'.
+    pd.to_datetime → int64 наносекунды → / 1e9 секунд. Проверяем НЕ абсолютные
+    эпохи (зависят от таймзоны интерпретации), а разности соседних значений:
+        np.diff(seconds) == [1.0, 1.0].
+    """
+    timestamps = ['2020-03-09 10:14:33', '2020-03-09 10:14:34', '2020-03-09 10:14:35']
+    seconds = _timestamps_to_seconds(timestamps)
+    assert seconds.shape == (3,)
+    np.testing.assert_allclose(np.diff(seconds), np.array([1.0, 1.0]))
+
+
+def test_timestamps_to_seconds_handles_numeric_strings():
+    """Числовые строки ('0.0','1.5','3.0') приводятся к float напрямую без datetime.
+
+    Контракт: если массив можно сконвертировать в float, datetime-парсинг не
+    вызывается. Ожидается seconds == [0.0, 1.5, 3.0].
+    """
+    seconds = _timestamps_to_seconds(['0.0', '1.5', '3.0'])
+    np.testing.assert_allclose(seconds, np.array([0.0, 1.5, 3.0]))
+
+
+@pytest.mark.parametrize('valve', ['valve1', 'valve2'])
+def test_valve_slice_nominal_dt_is_one_second(valve):
+    """Срез valve имеет шаг дискретизации 1 c → nominal_dt_seconds == 1.0.
+
+    Без target_sample_rate_hz nominal_dt = median положительных diffs реальных
+    меток времени. Шаг valve — 1 секунда, поэтому медиана == 1.0. Кроме того, в
+    первых 20 строках каждого valve есть ровно один пропущенный секундный отсчёт,
+    поэтому report['n_gaps'] >= 1 (ожидается ровно 1, но используем >= для
+    устойчивости к возможным правкам данных).
+    """
+    values, timestamps, _columns = _load_valve_slice(valve)
+    _aligned, _ts, _mask, report = align_timestamps(values, timestamps)
+
+    assert report['has_timestamps'] is True
+    assert report['nominal_dt_seconds'] == pytest.approx(1.0)
+    assert report['n_gaps'] >= 1
+
+# 10. Сквозной prepare_detection_series на реальном срезе valve
+
+
+@pytest.mark.parametrize('valve', ['valve1', 'valve2'])
+def test_prepare_detection_series_smoke_on_valve_slice(valve):
+    """prepare_detection_series отрабатывает на реальном срезе valve без падений.
+
+    Прогон с дефолтными политиками (duplicate_policy='keep_last',
+    gap_policy='mark_only', без target_sample_rate_hz). Проверяем КОНТРАКТ:
+        * aligned_values формы (20, 8) — каналы сохранены;
+        * gap_mask — bool длины 20;
+        * quality_report.metadata['alignment_report'] присутствует и содержит
+          ожидаемые ключи (n_duplicates, n_gaps, gap_total_seconds,
+          resampling_method, original_n, aligned_n, has_timestamps,
+          nominal_dt_seconds);
+        * alignment_report['has_timestamps'] is True, nominal_dt ≈ 1.0;
+        * quality_report.n_channels == 8, n_samples == 20.
+    Точные числовые значения сигналов НЕ проверяются (нестабильны).
+    """
+    values, timestamps, _columns = _load_valve_slice(valve)
+
+    aligned_values, gap_mask, quality_report = prepare_detection_series(
+        values,
+        timestamps=timestamps,
+        channel_names=VALVE_FEATURE_COLUMNS,
+    )
+
+    assert aligned_values.shape == (VALVE_SLICE_ROWS, VALVE_N_FEATURES)
+    assert gap_mask.dtype == bool
+    assert gap_mask.shape == (VALVE_SLICE_ROWS,)
+    assert quality_report.n_channels == VALVE_N_FEATURES
+    assert quality_report.n_samples == VALVE_SLICE_ROWS
+
+    alignment_report = quality_report.metadata['alignment_report']
+    expected_keys = {
+        'n_duplicates', 'n_gaps', 'gap_total_seconds', 'resampling_method',
+        'original_n', 'aligned_n', 'has_timestamps', 'nominal_dt_seconds',
+    }
+    assert expected_keys.issubset(alignment_report.keys())
+    assert alignment_report['has_timestamps'] is True
+    assert alignment_report['nominal_dt_seconds'] == pytest.approx(1.0)
+
+
+@pytest.mark.parametrize('valve', ['valve1', 'valve2'])
+def test_prepare_detection_series_resample_forward_fill_no_nans(valve):
+    """Ресемплинг valve на 1 Гц с forward_fill не оставляет NaN и сохраняет каналы.
+
+    Прогон с target_sample_rate_hz=1.0 и gap_policy='forward_fill'. Так как в
+    первых 20 строках есть пропуск по времени, сетка длиннее 20, и синтетические
+    точки заполняются LOCF. Проверяем КОНТРАКТ:
+        * число каналов остаётся 8;
+        * после forward_fill в aligned_values нет NaN;
+        * len(gap_mask) == aligned_values.shape[0] (согласованность длины);
+        * gap_mask.sum() >= 1 (есть хотя бы одна синтетическая точка от пропуска);
+        * resampling_method == 'forward_fill'.
+    """
+    values, timestamps, _columns = _load_valve_slice(valve)
+
+    aligned_values, gap_mask, quality_report = prepare_detection_series(
+        values,
+        timestamps=timestamps,
+        target_sample_rate_hz=1.0,
+        gap_policy='forward_fill',
+        channel_names=VALVE_FEATURE_COLUMNS,
+    )
+
+    assert aligned_values.shape[1] == VALVE_N_FEATURES
+    assert not np.isnan(aligned_values).any()
+    assert len(gap_mask) == aligned_values.shape[0]
+    assert gap_mask.sum() >= 1
+    assert quality_report.metadata['alignment_report']['resampling_method'] == 'forward_fill'

--- a/tests/unit/core/models/detection/test_detection_cross_domain_valves.py
+++ b/tests/unit/core/models/detection/test_detection_cross_domain_valves.py
@@ -3,21 +3,14 @@ import os
 import numpy as np
 import pytest
 
-from fedot.core.operations.operation_parameters import OperationParameters
 from fedot_ind.tools.serialisation.path_lib import EXAMPLES_DATA_PATH
 from fedot_ind.core.models.detection.runtime import (
-    DetectionRuntimeResult,
     DetectionSplitKind,
     DetectionSplitSpec,
     build_detection_window_batch,
     build_transfer_alignment_report,
-    coral_feature_align,
 )
 from fedot_ind.core.models.detection.stage_tuning_runtime import _split_series
-from fedot_ind.core.models.detection.modern_detectors import (
-    FeatureIsolationForestDetector,
-    build_detection_input_data,
-)
 
 VALVE_FEATURE_COLUMNS = (
     'Accelerometer1RMS',

--- a/tests/unit/core/models/detection/test_detection_cross_domain_valves.py
+++ b/tests/unit/core/models/detection/test_detection_cross_domain_valves.py
@@ -1,0 +1,207 @@
+import os
+
+import numpy as np
+import pytest
+
+from fedot.core.operations.operation_parameters import OperationParameters
+from fedot_ind.tools.serialisation.path_lib import EXAMPLES_DATA_PATH
+from fedot_ind.core.models.detection.runtime import (
+    DetectionRuntimeResult,
+    DetectionSplitKind,
+    DetectionSplitSpec,
+    build_detection_window_batch,
+    build_transfer_alignment_report,
+    coral_feature_align,
+)
+from fedot_ind.core.models.detection.stage_tuning_runtime import _split_series
+from fedot_ind.core.models.detection.modern_detectors import (
+    FeatureIsolationForestDetector,
+    build_detection_input_data,
+)
+
+VALVE_FEATURE_COLUMNS = (
+    'Accelerometer1RMS',
+    'Accelerometer2RMS',
+    'Current',
+    'Pressure',
+    'Temperature',
+    'Thermocouple',
+    'Voltage',
+    'Volume Flow RateRMS',
+)
+VALVE_N_FEATURES = len(VALVE_FEATURE_COLUMNS)
+TEMPERATURE_CHANNEL_INDEX = VALVE_FEATURE_COLUMNS.index('Temperature')
+
+# (window_size=16, stride=4 → 9 окон на домен).
+VALVE_CROSS_DOMAIN_ROWS = 50
+DETECTION_WINDOW_SIZE = 16
+DETECTION_STRIDE = 4
+# statistical features: mean, std, min, max, slope × 8 каналов
+STAT_FEATURES_PER_WINDOW = 5 * VALVE_N_FEATURES
+EXPECTED_WINDOWS_PER_VALVE_SLICE = (
+    len(range(0, VALVE_CROSS_DOMAIN_ROWS - DETECTION_WINDOW_SIZE + 1, DETECTION_STRIDE))
+)
+
+
+def _valve_csv_path(valve: str) -> str:
+    return os.path.join(
+        EXAMPLES_DATA_PATH, 'benchmark', 'detection', 'data', valve, '0.csv',
+    )
+
+
+def _load_valve_slice(valve: str, n_rows: int = VALVE_CROSS_DOMAIN_ROWS):
+    """Загружает первые ``n_rows`` строк valve как (values, timestamps, columns)."""
+    pd = pytest.importorskip('pandas')
+    path = _valve_csv_path(valve)
+    if not os.path.exists(path):
+        pytest.skip(f'valve dataset is not available: {path}')
+    frame = pd.read_csv(path, sep=';', index_col='datetime', nrows=n_rows)
+    feature_columns = [
+        column for column in frame.columns if column not in {'anomaly', 'changepoint'}
+    ]
+    values = frame[feature_columns].to_numpy(dtype=float)
+    timestamps = [str(value) for value in frame.index.astype(str)]
+    return values, timestamps, tuple(feature_columns)
+
+
+def _load_merged_valve_domains(n_rows: int = VALVE_CROSS_DOMAIN_ROWS):
+    """Склеивает valve1 и valve2 в один ряд с domain_labels."""
+    valve1_values, _ts1, columns = _load_valve_slice('valve1', n_rows)
+    valve2_values, _ts2, _columns2 = _load_valve_slice('valve2', n_rows)
+    assert columns == VALVE_FEATURE_COLUMNS
+
+    values = np.vstack([valve1_values, valve2_values])
+    labels = np.zeros(values.shape[0], dtype=int)
+    domain_labels = np.asarray(
+        ['valve1'] * n_rows + ['valve2'] * n_rows,
+        dtype=object,
+    )
+    return values, labels, domain_labels, valve1_values, valve2_values
+
+
+def _window_statistical_features(values: np.ndarray) -> np.ndarray:
+    batch = build_detection_window_batch(
+        values,
+        window_size=DETECTION_WINDOW_SIZE,
+        stride=DETECTION_STRIDE,
+        channel_names=VALVE_FEATURE_COLUMNS,
+    )
+    return batch.statistical_features
+
+
+def test_split_series_domain_holdout_valve1_train_valve2_unseen():
+    """DOMAIN_HOLDOUT: train только на valve1, calibration — unseen valve2.
+    Контракт ``_split_series`` из ``stage_tuning_runtime`` для
+    ``DetectionSplitKind.DOMAIN_HOLDOUT``: при склеенном ряде
+    valve1 + valve2 и ``target_domain='valve2'`` обучающая выборка
+    должна содержать **только** valve1, а калибровочная — **только** valve2.
+
+    Первые 50 строк ``examples/.../valve1/0.csv`` и ``valve2/0.csv``
+    (8 каналов, шаг ~1 с). Метки аномалий нулевые — здесь важен только
+    split по ``domain_labels``, не качество детекции.
+
+    * ``n_rows=50`` на домен → ``train.shape == (50, 8)``, ``calib.shape == (50, 8)``;
+    * train/calib **байт-в-байт** совпадают с исходными срезами valve1/valve2;
+    * в train нет ни одной строки valve2 (проверка через маску домена и
+      канал Temperature: средний уровень train ≈ valve1, calib ≈ valve2);
+    * размеры ``labels`` совпадают с ``values``.
+    """
+    n_rows = VALVE_CROSS_DOMAIN_ROWS
+    values, labels, domain_labels, valve1_values, valve2_values = _load_merged_valve_domains(
+        n_rows,
+    )
+    split_spec = DetectionSplitSpec(
+        kind=DetectionSplitKind.DOMAIN_HOLDOUT,
+        target_domain='valve2',
+    )
+
+    train_values, train_labels, calib_values, calib_labels = _split_series(
+        values,
+        labels,
+        split_spec,
+        domain_labels=domain_labels,
+    )
+
+    assert train_values.shape == (n_rows, VALVE_N_FEATURES)
+    assert calib_values.shape == (n_rows, VALVE_N_FEATURES)
+    assert train_labels.shape == (n_rows,)
+    assert calib_labels.shape == (n_rows,)
+
+    np.testing.assert_array_equal(train_values, valve1_values)
+    np.testing.assert_array_equal(calib_values, valve2_values)
+
+    holdout_mask = domain_labels == 'valve2'
+    train_mask = ~holdout_mask
+    assert holdout_mask.sum() == n_rows
+    assert train_mask.sum() == n_rows
+    assert not np.any(domain_labels[train_mask] == 'valve2')
+
+    valve1_temp_mean = float(valve1_values[:, TEMPERATURE_CHANNEL_INDEX].mean())
+    valve2_temp_mean = float(valve2_values[:, TEMPERATURE_CHANNEL_INDEX].mean())
+    assert abs(valve1_temp_mean - valve2_temp_mean) > 1.0
+
+    train_temp_mean = float(train_values[:, TEMPERATURE_CHANNEL_INDEX].mean())
+    calib_temp_mean = float(calib_values[:, TEMPERATURE_CHANNEL_INDEX].mean())
+    np.testing.assert_allclose(train_temp_mean, valve1_temp_mean, rtol=0.0, atol=1e-9)
+    np.testing.assert_allclose(calib_temp_mean, valve2_temp_mean, rtol=0.0, atol=1e-9)
+    assert abs(train_temp_mean - calib_temp_mean) > 1.0
+
+
+def test_build_transfer_alignment_report_valve1_to_valve2():
+    """Статистический отчёт сдвига доменов valve1 → valve2 на реальных срезах.
+    ``build_transfer_alignment_report(source, target)`` на point-level
+    значениях двух valve: число наблюдений, 8 каналов в ``mean_shift``,
+    формула ``mean_shift = target_mean - source_mean``.
+
+    Те же 50 строк каждого valve CSV (8 каналов без меток).
+    * ``n_source == n_target == 50``;
+    * длины ``source_channel_mean``, ``target_channel_mean``, ``mean_shift`` == 8;
+    * ``mean_shift`` совпадает с разностью средних по каналам;
+    * сдвиг Temperature заметно ненулевой (разные operating conditions);
+    * в ``metadata`` есть ``source_channel_std`` / ``target_channel_std``.
+    """
+    _values, _labels, _domains, valve1_values, valve2_values = _load_merged_valve_domains()
+
+    report = build_transfer_alignment_report(
+        valve1_values,
+        valve2_values,
+        strategy='coral',
+        source_domain='valve1',
+        target_domain='valve2',
+    )
+
+    assert report.strategy == 'coral'
+    assert report.source_domain == 'valve1'
+    assert report.target_domain == 'valve2'
+    assert report.n_source == VALVE_CROSS_DOMAIN_ROWS
+    assert report.n_target == VALVE_CROSS_DOMAIN_ROWS
+    assert len(report.source_channel_mean) == VALVE_N_FEATURES
+    assert len(report.target_channel_mean) == VALVE_N_FEATURES
+    assert len(report.mean_shift) == VALVE_N_FEATURES
+
+    source_mean = np.mean(valve1_values, axis=0)
+    target_mean = np.mean(valve2_values, axis=0)
+    expected_shift = target_mean - source_mean
+
+    np.testing.assert_allclose(
+        np.array(report.source_channel_mean),
+        source_mean,
+        rtol=0.0,
+        atol=1e-9,
+    )
+    np.testing.assert_allclose(
+        np.array(report.target_channel_mean),
+        target_mean,
+        rtol=0.0,
+        atol=1e-9,
+    )
+    np.testing.assert_allclose(
+        np.array(report.mean_shift),
+        expected_shift,
+        rtol=0.0,
+        atol=1e-9,
+    )
+    assert abs(report.mean_shift[TEMPERATURE_CHANNEL_INDEX]) > 1.0
+    assert 'source_channel_std' in report.metadata
+    assert 'target_channel_std' in report.metadata
+    assert len(report.metadata['source_channel_std']) == VALVE_N_FEATURES

--- a/tests/unit/core/models/test_detection_no_future_leakage.py
+++ b/tests/unit/core/models/test_detection_no_future_leakage.py
@@ -1,0 +1,82 @@
+import numpy as np
+import pytest
+
+from fedot_ind.core.models.detection.runtime import infer_regime_segments
+
+
+def _three_regime_signal(length: int = 1200, seed: int = 0) -> np.ndarray:
+    """Синтетика с тремя регимами: low → high → low с плавными переходами.
+
+    Используется чтобы пороги high/low/transition были осмысленными
+    (не вырожденными в 0). Без шума, чтобы тест был детерминирован.
+    """
+    rng = np.random.default_rng(seed)
+    base = np.zeros(length, dtype=float)
+    base[: length // 3] = 0.0
+    base[length // 3: 2 * length // 3] = 5.0
+    base[2 * length // 3:] = 0.0
+    smoothed = np.convolve(base, np.ones(20) / 20.0, mode='same')
+    return smoothed + 0.01 * rng.standard_normal(length)
+
+
+def _expand_segments_to_labels(segments, length: int) -> np.ndarray:
+    labels = np.full(length, 'unknown', dtype=object)
+    for segment in segments:
+        labels[segment.start_index: segment.end_index + 1] = segment.regime_label
+    return labels
+
+
+@pytest.mark.parametrize('cut', [400, 600, 900])
+def test_causal_mode_labels_stable_under_truncation(cut: int) -> None:
+    """С reference_window полностью внутри [0..cut] метки не меняются."""
+    series = _three_regime_signal(length=1200)
+    reference = (0, 300)
+
+    full_segments = infer_regime_segments(series, reference_window=reference)
+    truncated_segments = infer_regime_segments(series[:cut], reference_window=reference)
+
+    full_labels = _expand_segments_to_labels(full_segments, length=1200)
+    truncated_labels = _expand_segments_to_labels(truncated_segments, length=cut)
+
+    assert reference[1] <= cut, 'предусловие теста: reference_window должен лежать в обрезке'
+    assert np.array_equal(full_labels[:cut], truncated_labels), (
+        f'Causal-режим протёк будущее: метки [0..{cut}) меняются от наличия данных после {cut}'
+    )
+
+
+def test_causal_mode_invariant_holds_for_all_three_labels() -> None:
+    """Контроль: в наборе меток присутствуют high/low/transition.
+
+    Гарантирует, что сам тест не вырождается (например, при ровно нулевых
+    квантилях, когда все точки помечаются 'stable' и инвариант тривиален).
+    """
+    series = _three_regime_signal(length=1200)
+    labels = _expand_segments_to_labels(
+        infer_regime_segments(series, reference_window=(0, 300)),
+        length=1200,
+    )
+    distinct = set(labels.tolist())
+    assert {'low_load', 'high_load'}.issubset(distinct), (
+        f'Сетап теста вырожден — нет high/low меток, есть только {distinct}'
+    )
+
+
+def test_legacy_mode_documented_to_leak_future() -> None:
+    """Legacy режим (reference_window=None) использует глобальные квантили
+    и потому НЕ удовлетворяет инварианту causality. Этот тест защищает от
+    случайного "улучшения" legacy режима без обновления контракта.
+    """
+    series = _three_regime_signal(length=1200)
+    cut = 600
+
+    full_labels = _expand_segments_to_labels(
+        infer_regime_segments(series), length=1200,
+    )
+    truncated_labels = _expand_segments_to_labels(
+        infer_regime_segments(series[:cut]), length=cut,
+    )
+
+    assert not np.array_equal(full_labels[:cut], truncated_labels), (
+        'Legacy режим неожиданно стал causal — это breaking change контракта. '
+        'Если намеренно — обновите docstring и удалите этот тест.'
+    )

--- a/tests/unit/core/models/test_detection_runtime.py
+++ b/tests/unit/core/models/test_detection_runtime.py
@@ -1,16 +1,37 @@
+from dataclasses import replace
+
 import numpy as np
+import pytest
 
 from fedot_ind.core.models.detection.runtime import (
     AnomalyScoreSeries,
     DetectionSplitKind,
     DetectionSplitSpec,
+    DetectionWindowBatch,
+    RegimeSegment,
+    DetectionEvent,
     build_detection_window_batch,
     build_risk_feature_frame,
     detect_events_from_score_series,
     estimate_detection_threshold,
     infer_regime_segments,
     split_detection_batch,
+    ensure_detection_array,
+    resolve_detection_window_size,
+    resolve_detection_stride,
+    _split_temporal_window_ids,
+    build_window_statistical_features,
+    align_window_scores_to_points,
+    estimate_detection_threshold,
+    build_anomaly_score_series,
+    domain_invariant_scale,
+    coral_feature_align,
+    build_transfer_alignment_report,
 )
+
+from fedot_ind.core.models.detection.stage_tuning import (
+    DetectionStageName,
+    build_detection_stage_tuning_plan)
 
 
 def _multichannel_series(length: int = 48) -> np.ndarray:
@@ -38,7 +59,28 @@ def test_build_detection_window_batch_preserves_window_count_and_shape():
     assert batch.statistical_features.shape == (21, 10)
 
 
-def test_split_detection_batch_temporal_prevents_cross_split_window_overlap():
+def test_split_detection_batch_temporal_prevents_future_leakage_between_calib_and_test():
+    """TEMPORAL-разбиение: единственная реальная гарантия отсутствия утечки из будущего —
+    калибровочные окна полностью предшествуют тестовым по ВРЕМЕНИ (calib_end <= test_start).
+        Окна перекрываются, когда stride < window_size (здесь window_size=10, stride=2).
+        TEMPORAL-сплит в split_detection_batch режет ПО ПОРЯДКУ ID окон:
+        train = первые n_train окон (по id), остаток уходит в calib/test.
+        Поэтому train идёт раньше calib по id (и по START), но временной КОНЕЦ
+        последнего train-окна налезает на START первого calib-окна. То есть
+        train_end <= calib_start в общем случае НЕ выполняется — это была неверная
+        предпосылка прежней версии теста. prevent_future_leakage влияет только на
+        границу calib/test (см. _split_temporal_window_ids).
+
+        series_length=64, window_size=10, stride=2
+        -> n_windows = (64-10)//2 + 1 = 28, окно i имеет start=2*i, end=2*i+10.
+        train_fraction=0.5  -> n_train = round(28*0.5) = 14  (id 0..13, start 0..26).
+        remaining = id 14..27 (14 окон).
+        calibration_fraction=0.25 -> n_calib = round(14*0.25/(1-0.5)) = round(7.0) = 7
+                                     (id 14..20, start 28..40), calib_end = end(id=20) = 40+10 = 50.
+        prevent_future_leakage=True -> test = окна со start >= 50: 2*i>=50 => i>=25
+                                       (id 25..27, start 50..54) => 3 окна.
+        Окна id 21..24 (start 42..48 < 50) отбрасываются как пересекающие границу calib.
+    """
     batch = build_detection_window_batch(
         _multichannel_series(64),
         window_size=10,
@@ -56,9 +98,14 @@ def test_split_detection_batch_temporal_prevents_cross_split_window_overlap():
 
     assert train_batch is not None
     assert calibration_batch is not None
-    assert train_batch.window_indices[-1, 1] <= calibration_batch.window_indices[0, 0]
-    if test_batch is not None and len(test_batch.window_indices):
-        assert calibration_batch.window_indices[-1, 1] <= test_batch.window_indices[0, 0]
+    # Размеры сплитов (детерминированы для TEMPORAL).
+    assert train_batch.n_windows == 14
+    assert calibration_batch.n_windows == 7
+    assert test_batch is not None and test_batch.n_windows == 3
+    # train предшествует calib по ПОРЯДКУ START (id-упорядоченность), но НЕ по концу окна.
+    assert train_batch.window_indices[-1, 0] < calibration_batch.window_indices[0, 0]
+    # Главная гарантия prevent_future_leakage: calib целиком раньше test по времени.
+    assert calibration_batch.window_indices[-1, 1] <= test_batch.window_indices[0, 0]
 
 
 def test_split_detection_batch_random_holdout_is_deterministic_for_same_seed():
@@ -149,3 +196,839 @@ def test_detect_events_and_risk_frame_preserve_regime_context():
     frame = risk_frame.to_frame()
     assert {'event_peak_score', 'regime_label', 'node_name', 'domain_name'} <= set(frame.columns)
     assert set(frame['node_name']) == {'mill_1'}
+
+
+class TestEnsureDetectionArray:
+    """Тесты для ensure_detection_array"""
+
+    def test_detection_array_contract_K(self):
+        series = np.arange(100)
+
+        arr = ensure_detection_array(series)
+
+        assert arr.ndim == 2
+        assert arr.shape == (100, 1)
+
+    def test_1d_list_returns_2d_column(self):
+        values = [1, 2, 3]
+        result = ensure_detection_array(values)
+        expected = np.array([[1], [2], [3]], dtype=float)
+        np.testing.assert_array_equal(result, expected)
+
+    def test_1d_numpy_returns_2d_column(self):
+        values = np.array([1, 2, 3])
+        result = ensure_detection_array(values)
+        expected = np.array([[1], [2], [3]], dtype=float)
+        np.testing.assert_array_equal(result, expected)
+
+    def test_2d_array_unchanged(self):
+        values = np.array([[1, 2], [3, 4]])
+        result = ensure_detection_array(values)
+        np.testing.assert_array_equal(result, values)
+
+    def test_3d_array_reshaped_to_2d(self):
+        values = np.random.rand(4, 3, 2)  # shape (4,3,2)
+        result = ensure_detection_array(values)
+        # ожидается (4, 6)
+        assert result.shape == (4, 3 * 2)
+        np.testing.assert_array_equal(result, values.reshape(4, -1))
+
+    def test_empty_array_raises(self):
+        with pytest.raises(ValueError, match='Detection input must be at least one-dimensional.'):
+            ensure_detection_array(np.array(5))  # 0-dim
+
+
+class TestResolveDetectionWindowSize:
+    """Тесты для resolve_detection_window_size"""
+
+    def test_very_short_series(self):
+        assert resolve_detection_window_size(-1) == 1
+        assert resolve_detection_window_size(3) == 3  # <4 -> max(1, series_length)
+        assert resolve_detection_window_size(2) == 2
+        assert resolve_detection_window_size(1) == 1
+
+    def test_window_size_explicit(self):
+        assert resolve_detection_window_size(100, window_size=20) == 20
+        assert resolve_detection_window_size(100, window_size=150) == 100  # capped
+        assert resolve_detection_window_size(100, window_size=1) == 2     # min=2
+
+    def test_window_size_percent(self):
+        assert resolve_detection_window_size(200, window_size_percent=10) == 20
+        assert resolve_detection_window_size(200, window_size_percent=0.5) == 2  # min 2
+        assert resolve_detection_window_size(200, window_size_percent=150) == 200
+        # Вот это место в коде странное, для граничного случая в меньшую сторону округляет (ДОЛЖНО ЛИ ТАК БЫТЬ?)
+        # assert resolve_detection_window_size(5, window_size_percent=50) == 3      # round(2.5)=3, cap=5
+
+    def test_default_behavior(self):
+        # default = max(8, round(series_length*0.1))
+        assert resolve_detection_window_size(100) == max(8, 10) == 10
+        assert resolve_detection_window_size(50) == max(8, 5) == 8
+        assert resolve_detection_window_size(200, minimum_window_size=5) == max(5, 20) == 20
+        assert resolve_detection_window_size(10, minimum_window_size=20) == min(20, 10) == 10
+
+
+class TestResolveDetectionStride:
+    """Тесты для resolve_detection_stride"""
+
+    def test_stride_given(self):
+        assert resolve_detection_stride(100, stride=5) == 5
+        assert resolve_detection_stride(100, stride=0) == 1   # max(1,0)
+
+    def test_default_stride(self):
+        assert resolve_detection_stride(100) == 100 // 4 == 25
+        assert resolve_detection_stride(1) == 1  # max(1,0) = 1
+
+
+class TestBuildDetectionWindowBatch:
+    """Тесты для build_detection_window_batch"""
+
+    def test_detection_window_batch_contract_K(self):
+        series = np.linspace(0.0, 1.0, num=120)
+
+        batch = build_detection_window_batch(
+            series,
+            window_size=20,
+            stride=5
+        )
+
+        start, end = batch.window_indices[0]
+
+        assert batch.windows.ndim == 3  # [N, W, C]
+        assert batch.window_indices.shape[1] == 2
+        assert batch.n_windows > 0
+        assert batch.n_channels == 1
+        assert end - start == batch.window_size
+
+    def test_basic_2d_series(self):
+        values = np.random.rand(50, 3)
+        # values = np.linspace(1.0, 50.0, num=50).reshape(2,25)
+        batch = build_detection_window_batch(values, window_size=10, stride=5)
+        assert batch.windows.shape == (9, 10, 3)   # (50-10)//5 +1 = 9
+        assert batch.window_indices.shape == (9, 2)
+        assert batch.original_length == 50
+        assert batch.window_size == 10
+        assert batch.stride == 5
+        assert len(batch.channel_names) == 3
+        assert batch.channel_names == tuple(f'channel_{i}' for i in range(3))
+
+    def test_1d_series(self):
+        values = list(range(20))
+        batch = build_detection_window_batch(values, window_size=5, stride=2)
+        assert batch.windows.shape == (8, 5, 1)   # (20-5)//2+1=8
+        row = np.arange(5.0)
+        offsets = np.arange(0.0, 15.0, 2.0).reshape(-1, 1)
+        result = row + offsets
+        np.testing.assert_array_equal(batch.windows[:, :, 0], result)
+
+    def test_custom_channel_names(self):
+        values = np.random.rand(30, 2)
+        names = ['A', 'B']
+        batch = build_detection_window_batch(values, window_size=6, channel_names=names)
+        assert batch.channel_names == ('A', 'B')
+
+    def test_metadata(self):
+        values = np.random.rand(30, 2)
+        meta = {'source': 'test'}
+        batch = build_detection_window_batch(values, window_size=6, metadata=meta)
+        assert batch.metadata == meta
+
+    def test_series_shorter_than_window(self):
+        values = np.random.rand(5, 2)
+        with pytest.raises(ValueError, match="shorter than the requested detection window"):
+            build_detection_window_batch(values, window_size=10)
+
+
+class TestSplitDetectionBatch:
+
+    def test_split_detection_batch_contract_invariants_K(self):
+        """Контрактные инварианты TEMPORAL-сплита: дизъюнктность множеств окон,
+        id-упорядоченность train -> calib -> test и сохранность общего объёма.
+
+        Сценарий: series_length=120, window_size=10, stride=1 (окна сильно перекрываются),
+        train_fraction=0.6, calibration_fraction=0.2, prevent_future_leakage=True.
+            n_windows = (120-10)//1 + 1 = 111, окно i: start=i, end=i+10.
+            n_train = round(111*0.6) = round(66.6) = 67  -> id 0..66.
+            remaining = id 67..110 (44 окна).
+            n_calib = round(44*0.2/(1-0.6)) = round(22.0) = 22 -> id 67..88,
+                      calib_end = end(id=88) = 88+10 = 98.
+            test = окна со start >= 98: id 98..110 -> 13 окон.
+            id 89..97 (start 89..97 < 98) отбрасываются границей утечки.
+            Итого train=67, calib=22, test=13, total = 102 <= 111.
+        сравниваем НАБОРЫ id окон (а не пары (start,end)),
+        потому что перекрывающиеся окна — это разные окна с разными id, и именно
+        непересечение id-множеств train/calib/test и есть смысл контракта.
+        Прежнее утверждение ``max(train_end) <= min(calib_start)`` убрано как НЕВЕРНОЕ:
+        при stride=1 < window_size конец train-окна (76) больше начала calib-окна (67).
+        Корректный временной порядок гарантируется только между calib и test.
+        """
+        series = np.linspace(0, 1, 120)
+
+        batch = build_detection_window_batch(
+            series,
+            window_size=10,
+            stride=1
+        )
+
+        split_spec = DetectionSplitSpec(
+            kind=DetectionSplitKind.TEMPORAL,
+            train_fraction=0.6,
+            calibration_fraction=0.2,
+            prevent_future_leakage=True,
+        )
+
+        train, calib, test = split_detection_batch(batch, split_spec)
+
+        # Точные размеры сплитов, выведенные из реализации.
+        assert train.n_windows == 67
+        assert calib.n_windows == 22
+        assert test is not None and test.n_windows == 13
+
+        # Дизъюнктность множеств id окон train/calib/test.
+        train_ids = set(train.metadata['selected_window_ids'])
+        calib_ids = set(calib.metadata['selected_window_ids'])
+        test_ids = set(test.metadata['selected_window_ids'])
+
+        assert train_ids.isdisjoint(calib_ids)
+        assert train_ids.isdisjoint(test_ids)
+        assert calib_ids.isdisjoint(test_ids)
+
+        # id-упорядоченность: train целиком раньше calib, calib целиком раньше test.
+        assert max(train_ids) < min(calib_ids)
+        assert max(calib_ids) < min(test_ids)
+
+        # Реальная гарантия отсутствия утечки: calib раньше test по ВРЕМЕНИ.
+        assert calib.window_indices[-1, 1] <= test.window_indices[0, 0]
+
+        # Сохранность объёма: ни одно окно не задвоено, часть могла быть отброшена.
+        total = len(train_ids | calib_ids | test_ids)
+        assert total == train.n_windows + calib.n_windows + test.n_windows
+        assert total <= batch.n_windows
+
+    def test_domain_holdout_split_contract_K(self):
+        """DOMAIN_HOLDOUT: train = исходный домен ('A'), holdout (calib+test) = целевой ('B'),
+        внутри целевого домена calib предшествует test по времени.
+            series_length=200, window_size=10, stride=2
+            -> n_windows = (200-10)//2 + 1 = 96, окно i: start=2*i, end=2*i+10.
+            domains: id 0..39 = 'A' (40 окон), id 40..95 = 'B' (56 окон).
+            train = окна с доменом != 'B' = id 0..39  -> 40 окон.
+            holdout = окна с доменом == 'B' = id 40..95 -> 56 окон.
+            n_calib = round(56 * 0.3) = round(16.8) = 17 -> id 40..56,
+                      calib_end = end(id=56) = 56*2+10 = 122.
+            prevent_future_leakage=True -> test = окна holdout со start >= 122:
+                      2*i>=122 => i>=61 => id 61..95 -> 35 окон.
+            id 57..60 (start 114..120 < 122) отбрасываются границей утечки.
+            ain=40, calib=17, test=35.
+        """
+        series = np.linspace(0, 1, 200)
+
+        batch = build_detection_window_batch(
+            series,
+            window_size=10,
+            stride=2
+        )
+
+        n_windows = batch.n_windows
+        assert n_windows == 96
+        split_point = 40
+        domains = np.array(["A"] * split_point + ["B"] * (n_windows - split_point))
+
+        batch = replace(batch, metadata={"window_domains": domains})
+
+        split_spec = DetectionSplitSpec(
+            kind=DetectionSplitKind.DOMAIN_HOLDOUT,
+            target_domain="B",
+            calibration_fraction=0.3,
+            prevent_future_leakage=True,
+        )
+
+        train, calib, test = split_detection_batch(batch, split_spec)
+
+        # Домены сплитов: train = только 'A', calib/test = только 'B'.
+        assert all(d == "A" for d in train.metadata["window_domains"])
+        assert all(d == "B" for d in calib.metadata["window_domains"])
+
+        # Точные размеры, выведенные из реализации.
+        assert train.n_windows == 40
+        assert calib.n_windows == 17
+
+        if test is not None:
+            assert all(d == "B" for d in test.metadata["window_domains"])
+            assert test.n_windows == 35
+
+        if test is not None and test.n_windows > 0:
+            calib_end = calib.window_indices[-1][1]
+            test_start = test.window_indices[0][0]
+            assert calib_end <= test_start
+
+    @pytest.fixture
+    def sample_batch(self):
+        # создаём простой batch: 10 окон, индексы [0,5), [5,10), ...
+        n_windows = 10
+        window_size = 5
+        stride = 5
+        original_length = n_windows * stride + window_size - stride  # 5*10+5-5=50
+        windows = np.random.rand(n_windows, window_size, 2)
+        indices = np.array([[i * stride, i * stride + window_size] for i in range(n_windows)])
+        return DetectionWindowBatch(
+            windows=windows,
+            window_indices=indices,
+            original_length=original_length,
+            window_size=window_size,
+            stride=stride,
+            channel_names=('ch0', 'ch1'),
+            metadata={}
+        )
+
+    def test_domain_holdout_split(self, sample_batch):
+        # добавляем домены в metadata
+        domains = ['A'] * 3 + ['B'] * 7   # 3 домена A, 7 B
+        sample_batch.metadata['window_domains'] = domains
+        split_spec = DetectionSplitSpec(
+            kind=DetectionSplitKind.DOMAIN_HOLDOUT,
+            target_domain='B',
+            calibration_fraction=0.3   # 30% от holdout -> около 2 окон
+        )
+        train, calib, test = split_detection_batch(sample_batch, split_spec)
+        # train: только домен A (3 окна)
+        assert train.n_windows == 3
+        # test: домен B без калибровочных
+        assert test.n_windows == 7 - 2 == 5  # 7 окон B, 2 на калибровку
+        assert calib.n_windows == 2
+        # проверка, что калибровка и тест не пересекаются
+        calib_indices = set(calib.window_indices[:, 0])
+        test_indices = set(test.window_indices[:, 0])
+        assert calib_indices.isdisjoint(test_indices)
+        # проверка метаданных
+        assert train.metadata['split_name'] == 'train'
+        assert calib.metadata['split_name'] == 'calibration'
+        assert test.metadata['split_name'] == 'test'
+
+    def test_domain_holdout_missing_domains(self, sample_batch):
+        split_spec = DetectionSplitSpec(kind=DetectionSplitKind.DOMAIN_HOLDOUT)
+        with pytest.raises(ValueError, match="requires batch.metadata"):
+            split_detection_batch(sample_batch, split_spec)
+
+    def test_holdout_random_split(self, sample_batch):
+        """Случайный HOLDOUT (prevent_future_leakage=False): проверяем ИНВАРИАНТЫ, а не
+        конкретные индексы.
+        Размеры выведены из реализации (sample_batch: n_windows=10, start окна i = 5*i):
+            n_train = max(1, round(10*0.5)) = 5.
+            remaining = 10 - 5 = 5.
+            n_calib = round(remaining * calib_fraction / (1 - train_fraction))
+                    = round(5 * 0.3 / 0.5) = round(3.0) = 3.
+            test = остаток = 5 - 3 = 2.
+        """
+        split_spec = DetectionSplitSpec(
+            kind=DetectionSplitKind.HOLDOUT,
+            train_fraction=0.5,
+            calibration_fraction=0.3,
+            random_seed=42,
+            prevent_future_leakage=False
+        )
+        train, calib, test = split_detection_batch(sample_batch, split_spec)
+
+        # Детерминированные размеры сплитов.
+        assert train.n_windows == 5
+        assert calib.n_windows == 3
+        assert test.n_windows == 2
+
+        # Разбиен перестановка всех 10 окон: дизъюнктность + полное покрытие.
+        train_ids = set(train.metadata['selected_window_ids'])
+        calib_ids = set(calib.metadata['selected_window_ids'])
+        test_ids = set(test.metadata['selected_window_ids'])
+        assert train_ids.isdisjoint(calib_ids)
+        assert train_ids.isdisjoint(test_ids)
+        assert calib_ids.isdisjoint(test_ids)
+        assert train_ids | calib_ids | test_ids == set(range(sample_batch.n_windows))
+
+        # Окна действительно перемешаны, а не взяты подряд (start окна i = 5*i).
+        train_starts = train.window_indices[:, 0]
+        assert not np.array_equal(train_starts, np.arange(0, 5 * 5, 5))
+
+        # Детерминизм при одном и том же random_seed: повторный вызов даёт те же id.
+        train2, calib2, test2 = split_detection_batch(sample_batch, split_spec)
+        assert train2.metadata['selected_window_ids'] == train.metadata['selected_window_ids']
+        assert calib2.metadata['selected_window_ids'] == calib.metadata['selected_window_ids']
+        assert test2.metadata['selected_window_ids'] == test.metadata['selected_window_ids']
+
+    def test_temporal_split_prevent_future_leakage(self, sample_batch):
+        """Проверяем, что при prevent_future_leakage=True калибровка и тест разделены по времени."""
+        split_spec = DetectionSplitSpec(
+            kind=DetectionSplitKind.HOLDOUT,
+            train_fraction=0.5,
+            calibration_fraction=0.3,
+            prevent_future_leakage=True
+        )
+        train, calib, test = split_detection_batch(sample_batch, split_spec)
+        # train - первые 5 окон (индексы 0..4)
+        # калибровка - следующие 3 окна (индексы 5,6,7) - но они могут быть скорректированы
+        # тест - окна после последнего калибровочного по времени
+        # убедимся, что ни одно тестовое окно не начинается раньше конца последнего калибровочного
+        if calib.n_windows > 0 and test.n_windows > 0:
+            calib_end = np.max(calib.window_indices[:, 1])
+            test_starts = test.window_indices[:, 0]
+            assert np.all(test_starts >= calib_end)
+
+    def test_empty_batch(self):
+        empty_batch = DetectionWindowBatch(
+            windows=np.empty((0, 5, 2)), window_indices=np.empty((0, 2), dtype=int),
+            original_length=10, window_size=5, stride=5, channel_names=()
+        )
+        split_spec = DetectionSplitSpec(kind=DetectionSplitKind.HOLDOUT)
+        with pytest.raises(ValueError, match="at least one window"):
+            split_detection_batch(empty_batch, split_spec)
+
+
+class TestSplitTemporalWindowIds:
+    """Тесты для _split_temporal_window_ids"""
+
+    def test_basic_split(self):
+        indices = np.array([[0, 10], [10, 20], [20, 30], [30, 40], [40, 50]])
+        candidate_ids = np.array([0, 1, 2, 3, 4])
+        cal, test = _split_temporal_window_ids(
+            indices, candidate_ids, calibration_size=3,
+            prevent_future_leakage=False, minimum_start=None
+        )
+        np.testing.assert_array_equal(cal, [0, 1, 2])
+        np.testing.assert_array_equal(test, [3, 4])
+
+    def test_future_leakage_prevention(self):
+        indices = np.array([[0, 10], [10, 20], [20, 30], [35, 45], [45, 55]])  # разрыв
+        candidate_ids = np.array([0, 1, 2, 3, 4])
+        cal, test = _split_temporal_window_ids(
+            indices, candidate_ids, calibration_size=2,
+            prevent_future_leakage=True, minimum_start=None
+        )
+        # калибровка: первые 2 окна -> [0,1]
+        # конец калибровки: indices[1,1]=20
+        # тест: все окна, начинающиеся >=20: окна 2 (начало 20), 3 (35), 4 (45)
+        np.testing.assert_array_equal(cal, [0, 1])
+        np.testing.assert_array_equal(test, [2, 3, 4])
+
+    def test_minimum_start_filter(self):
+        indices = np.array([[0, 10], [10, 20], [20, 30], [30, 40]])
+        candidate_ids = np.array([0, 1, 2, 3])
+        cal, test = _split_temporal_window_ids(
+            indices, candidate_ids, calibration_size=2,
+            prevent_future_leakage=False, minimum_start=5
+        )
+        # отфильтровываем окна с start <5 -> оставляем [1,2,3]
+        # затем первые calibration_size = 2 из оставшихся -> [1,2]
+        np.testing.assert_array_equal(cal, [1, 2])
+        np.testing.assert_array_equal(test, [3])
+
+
+class TestBuildWindowStatisticalFeatures:
+    """Тесты для build_window_statistical_features"""
+
+    def test_statistical_features_shape_K(self):
+        series = np.linspace(0, 1, 100)
+
+        batch = build_detection_window_batch(
+            series,
+            window_size=10)
+
+        features = build_window_statistical_features(batch.windows)
+
+        assert features.shape[0] == batch.n_windows
+        assert features.shape[1] == 5 * batch.n_channels
+
+    def test_correct_shape(self):
+        windows = np.random.rand(10, 20, 3)  # 10 окон, 20 временных шагов, 3 канала
+        features = build_window_statistical_features(windows)
+        # каждый из 5 признаков: mean, std, min, max, slope -> 5*3 = 15
+        assert features.shape == (10, 15)
+
+    def test_feature_values(self):
+        # простой случай: одно окно, 2 шага, 1 канал
+        windows = np.array([[[1], [3]]])  # shape (1,2,1)
+        features = build_window_statistical_features(windows)
+        # mean = 2, std = 1, min = 1, max = 3, slope = 3-1=2
+        expected = np.array([[2, 1, 1, 3, 2]])
+        np.testing.assert_allclose(features, expected)
+
+    def test_invalid_ndim(self):
+        with pytest.raises(ValueError, match="shape \\[n_windows, window_size, n_channels\\]"):
+            build_window_statistical_features(np.random.rand(10, 5))
+
+
+class TestInferRegimeSegments:
+    """Тесты для infer_regime_segments"""
+
+    def test_regime_segmentation_covers_series_K(self):
+        series = np.linspace(0, 10, 120)
+
+        segments = infer_regime_segments(series)
+        covered = []
+        for seg in segments:
+            covered.extend(range(seg.start_index, seg.end_index + 1))
+
+        covered_sorted = sorted(covered)
+        assert covered_sorted == list(range(len(series)))
+
+    def test_basic_regime_detection(self):
+        # создаём ряд с явными режимами
+        t = np.arange(100)
+        signal = np.zeros(100)
+        signal[:30] = 10   # высокий уровень
+        signal[30:60] = 0   # стабильный низкий
+        signal[60:80] = np.linspace(0, 10, 20)  # переход
+        signal[80:] = 10
+        values = signal.reshape(-1, 1)
+        segments = infer_regime_segments(values, volatility_window=10, transition_quantile=0.8)
+        # проверим, что получили разумное количество сегментов
+        assert len(segments) >= 3
+        # метки должны быть 'high_load', 'low_load', 'transition'
+        labels = [s.regime_label for s in segments]
+        assert 'high_load' in labels
+        assert 'low_load' in labels or 'stable' in labels
+        # проверка, что сегменты покрывают весь ряд без пропусков
+        assert segments[0].start_index == 0
+        assert segments[-1].end_index == 99
+        for i in range(len(segments) - 1):
+            assert segments[i].end_index + 1 == segments[i + 1].start_index
+
+    def test_single_channel_input(self):
+        values = np.random.rand(50)
+        segments = infer_regime_segments(values)
+        assert isinstance(segments, tuple)
+        assert all(isinstance(s, RegimeSegment) for s in segments)
+
+    def test_multichannel(self):
+        values = np.random.rand(50, 3)
+        segments = infer_regime_segments(values)
+        assert len(segments) > 0
+
+
+class TestAlignWindowScoresToPoints:
+    """Тесты для align_window_scores_to_points"""
+
+    def test_window_to_point_aggregation_contract_K(self):
+        series = np.linspace(0, 1, 50)
+
+        batch = build_detection_window_batch(
+            series,
+            window_size=5,
+            stride=1
+        )
+
+        window_scores = np.arange(batch.n_windows)
+
+        point_scores = align_window_scores_to_points(window_scores, batch)
+        assert len(point_scores) == batch.original_length
+        assert np.isfinite(point_scores).all()
+        assert np.std(point_scores) > 0
+
+    def test_basic_alignment(self):
+        # batch с 3 окнами: [0,2), [2,4), [4,6) (перекрытия нет)
+        indices = np.array([[0, 2], [2, 4], [4, 6]])
+        batch = DetectionWindowBatch(
+            windows=np.empty((3, 2, 1)), window_indices=indices,
+            original_length=6, window_size=2, stride=2,
+            channel_names=('ch',)
+        )
+        scores = np.array([1.0, 2.0, 3.0])
+        point_scores = align_window_scores_to_points(scores, batch)
+        expected = np.array([1.0, 1.0, 2.0, 2.0, 3.0, 3.0])
+        np.testing.assert_array_equal(point_scores, expected)
+
+    def test_overlapping_windows(self):
+        # окна с шагом 1: [0,3), [1,4), [2,5)
+        indices = np.array([[0, 3], [1, 4], [2, 5]])
+        batch = DetectionWindowBatch(
+            windows=np.empty((3, 3, 1)), window_indices=indices,
+            original_length=5, window_size=3, stride=1,
+            channel_names=('ch',)
+        )
+        scores = np.array([1, 10, 100])
+        point_scores = align_window_scores_to_points(scores, batch)
+        # точка0: только окно0 -> 1
+        # точка1: окно0+окно1 -> (1+10)/2=5.5
+        # точка2: окно0+окно1+окно2 -> (1+10+100)/3=37
+        # точка3: окно1+окно2 -> (10+100)/2=55
+        # точка4: окно2 -> 100
+        expected = np.array([1, 5.5, 37, 55, 100])
+        np.testing.assert_allclose(point_scores, expected)
+
+    def test_mismatched_length(self):
+        batch = DetectionWindowBatch(
+            windows=np.empty((5, 2, 1)), window_indices=np.empty((5, 2)),
+            original_length=10, window_size=2, stride=2, channel_names=('ch',)
+        )
+        with pytest.raises(ValueError, match="number of window scores must match"):
+            align_window_scores_to_points([1, 2, 3], batch)
+
+
+class TestEstimateDetectionThreshold:
+    """Тесты для estimate_detection_threshold"""
+
+    def test_mad_strategy(self):
+        scores = np.array([1, 1, 1, 1, 100])
+        thresh = estimate_detection_threshold(scores, strategy='mad')
+        # медиана=1, MAD=0, std=~39.6 -> 1+3*39.6 ~ 119.8
+        # так как MAD=0, берется std
+        assert thresh > 100   # порог должен быть выше выброса
+        # более стабильный тест
+        scores2 = np.array([0, 0, 0, 0, 10])
+        thresh2 = estimate_detection_threshold(scores2, strategy='mad')
+        assert thresh2 > 10
+        # ДОБАВИТЬ ЕЩЕ ТЕСТ НА ТО, ЧТОБЫ НОМАЛЬНЫЙ ВЫВОД БЫЛ
+
+    def test_quantile_strategy(self):
+        scores = np.arange(1, 101)
+        thresh = estimate_detection_threshold(scores, strategy='quantile', quantile=0.95)
+        # ТУТ ЭТО ИЗ-ЗА ТОГО, ЧТО ПОЛУЧАЕТСЯ 95.05 ИЗ-ЗА ЛИНЕЙНОЙ ИНТЕРПОЛЯЦИИ,
+        # КАЖЕТСЯ. ХОТЯ У НАС ДИСКРЕТНОЫЕ ЗНАЧЕНИЯ ЖЕ
+        assert np.round(thresh) == 95.0
+
+    def test_regime_conditional(self):
+        scores = np.array([1, 2, 100, 200, 3, 4])
+        regimes = ['stable', 'stable', 'transition', 'transition', 'stable', 'stable']
+        thresh = estimate_detection_threshold(scores, strategy='regime_conditional', regime_labels=regimes)
+        # стабильные = [1,2,3,4] -> порог MAD = 4?  медиана 2.5, MAD=1.5, порог=2.5+3*1.5=7
+        thresh2 = estimate_detection_threshold([1, 2, 3, 4], strategy='mad')
+        assert thresh == thresh2
+
+    def test_domain_calibrated(self):
+        scores = np.array([10, 12, 11, 13, 100])
+        thresh = estimate_detection_threshold(scores, strategy='domain_calibrated')
+        # mean = 29.2, std ≈ 35.4, mean+2.5std ≈ 29.2+88.5 = 117.7
+        # Проверяем, что порог примерно в той области
+        assert 110 < thresh < 120
+
+    def test_invalid_strategy(self):
+        with pytest.raises(ValueError, match="Unsupported detection calibration"):
+            estimate_detection_threshold([1, 2, 3], strategy='unknown')
+
+
+class TestBuildAnomalyScoreSeries:
+    """Тесты для build_anomaly_score_series"""
+
+    def test_basic(self):
+        scores = [0.1, 0.5, 0.9, 0.2]
+        series = build_anomaly_score_series(scores, threshold=0.5, calibration_strategy='mad')
+        assert series.scores == (0.1, 0.5, 0.9, 0.2)
+        assert series.labels == (0, 1, 1, 0)   # порог >=0.5
+        assert series.threshold == 0.5
+        assert series.calibration_strategy == 'mad'
+
+    def test_metadata(self):
+        scores = [1, 2, 3]
+        series = build_anomaly_score_series(scores, threshold=2, calibration_strategy='q', metadata={'key': 'val'})
+        assert series.metadata == {'key': 'val'}
+
+
+class TestDetectEventsFromScoreSeries:
+    """Тесты для detect_events_from_score_series"""
+
+    def test_event_detection_contract_minimal_K(self):
+        scores = np.array([0.0, 0.6, 0.9, 0.0])
+        series = build_anomaly_score_series(
+            scores,
+            threshold=0.5,
+            calibration_strategy='fixed',
+        )
+
+        events = detect_events_from_score_series(series, min_event_length=2)
+        event = events[0]
+
+        assert len(events) == 1
+        assert event.start_index == 1
+        assert event.end_index == 2
+        assert event.peak_index == 2
+        assert np.isclose(event.peak_score, max(scores[1:3]))
+
+    @pytest.fixture
+    def score_series(self):
+        return AnomalyScoreSeries(
+            scores=(0, 1, 1, 1, 0, 0, 1, 1, 0, 1),
+            labels=(0, 1, 1, 1, 0, 0, 1, 1, 0, 1),
+            threshold=0.5,
+            calibration_strategy='test',
+            metadata={}
+        )
+
+    def test_basic_event_detection(self, score_series):
+        events = detect_events_from_score_series(score_series, min_event_length=2)
+        # ожидаем события: индексы 1-3 (длина 3) и 6-7 (длина 2), одиночный на индексе 9 игнорируется
+        assert len(events) == 2
+        assert events[0].start_index == 1
+        assert events[0].end_index == 3
+        assert events[1].start_index == 6
+        assert events[1].end_index == 7
+
+    def test_min_event_length(self, score_series):
+        events = detect_events_from_score_series(score_series, min_event_length=3)
+        assert len(events) == 1
+        assert events[0].start_index == 1
+        assert events[0].end_index == 3
+
+    def test_with_regime_segments(self, score_series):
+        regimes = [
+            RegimeSegment(0, 4, 'high', 10, 1, 0),
+            RegimeSegment(5, 9, 'low', 2, 0.5, 0)
+        ]
+        events = detect_events_from_score_series(score_series, regime_segments=regimes)
+        event = events[0]  # первое событие 1-3
+        assert event.regime_label == 'high'
+        event2 = events[1]  # 6-7
+        assert event2.regime_label == 'low'
+
+
+class TestDomainInvariantScale:
+    """Тесты для domain_invariant_scale"""
+
+    def test_scaling_1d(self):
+        values = np.array([1, 2, 3, 100]).reshape(-1, 1)
+        scaled = domain_invariant_scale(values)
+        # медиана = 2.5, MAD = 1 (abs diff: 1.5,0.5,0.5,97.5 -> медиана 1)
+        # scaled = (values - 2.5) / 1
+        expected = np.array([-1.5, -0.5, 0.5, 97.5]).reshape(-1, 1)
+        np.testing.assert_allclose(scaled, expected, rtol=1e-4)
+
+    def test_with_reference(self):
+        values = np.array([10, 20, 30]).reshape(-1, 1)
+        ref = np.array([0, 10, 20]).reshape(-1, 1)
+        scaled = domain_invariant_scale(values, reference_values=ref)
+        # ref: медиана=10, MAD=10 -> (values-10)/10 = [0,1,2]
+        np.testing.assert_array_equal(scaled, [[0], [1], [2]])
+
+    def test_multichannel(self):
+        values = np.array([[1, 100], [2, 200], [3, 300]])
+        scaled = domain_invariant_scale(values)
+        # медиана по каждому каналу: [2,200]; MAD: [1,100]; результат [[-1,-1],[0,0],[1,1]]
+        expected = np.array([[-1, -1], [0, 0], [1, 1]])
+        np.testing.assert_allclose(scaled, expected)
+
+
+class TestCoralFeatureAlign:
+    """Тесты для coral_feature_align"""
+
+    def test_alignment(self):
+        source = np.array([[1, 2], [3, 4], [5, 6]])   # 3 samples, 2 features
+        target = np.array([[10, 20], [30, 40]])     # 2 samples
+        aligned = coral_feature_align(source, target, epsilon=1e-6)
+        # Проверяем, что среднее и ковариация aligned совпадают с target
+        assert aligned.shape == (3, 2)
+        np.testing.assert_allclose(np.mean(aligned, axis=0), np.mean(target, axis=0), atol=1e-6)
+        cov_aligned = np.cov(aligned, rowvar=False)
+        cov_target = np.cov(target, rowvar=False)
+        # ТУТ Я ПОНИЗИЛ ДО -4, ПОТОМУ ЧТО В ПЕРВОЙ МАТРИЦЕ ПОЛУЧЕТСЯ 199.9999755, А НЕ 200. НО, ПО СУТИ, БЛИЗКО
+        np.testing.assert_allclose(cov_aligned, cov_target, atol=1e-4)
+
+    def test_invalid_dimensions(self):
+        with pytest.raises(ValueError, match="expects 2D feature matrices"):
+            coral_feature_align(np.random.rand(10), np.random.rand(10, 2))
+
+
+class TestBuildTransferAlignmentReport:
+    """Тесты для build_transfer_alignment_report"""
+
+    def test_transfer_alignment_report_contract_K(self):
+        source = np.random.rand(100, 3)
+        target = np.random.rand(100, 3)
+
+        report = build_transfer_alignment_report(source, target)
+
+        assert report.n_source == 100
+        assert report.n_target == 100
+        assert len(report.source_channel_mean) == 3
+        assert len(report.target_channel_mean) == 3
+        assert len(report.mean_shift) == 3
+        assert np.allclose(
+            np.array(report.mean_shift),
+            np.array(report.target_channel_mean) - np.array(report.source_channel_mean)
+        )
+
+    def test_report_creation(self):
+        source = np.array([[1, 2], [3, 4], [5, 6]])
+        target = np.array([[10, 20], [30, 40]])
+        report = build_transfer_alignment_report(source, target, strategy='my_method')
+        assert report.strategy == 'my_method'
+        assert report.n_source == 3
+        assert report.n_target == 2
+        assert len(report.source_channel_mean) == 2
+        np.testing.assert_allclose(report.source_channel_mean, (3, 4))
+        np.testing.assert_allclose(report.target_channel_mean, (20, 30))
+        np.testing.assert_allclose(report.mean_shift, (17, 26))
+        assert 'source_channel_std' in report.metadata
+
+
+class TestBuildRiskFeatureFrame:
+    """Тесты для build_risk_feature_frame"""
+
+    def test_risk_feature_frame_contract_K(self):
+        scores = np.zeros(100)
+        scores[40:50] = 2.0
+
+        series = build_anomaly_score_series(
+            scores,
+            threshold=1.0,
+            calibration_strategy='fixed',
+        )
+
+        events = detect_events_from_score_series(series)
+        regimes = infer_regime_segments(scores)
+
+        frame = build_risk_feature_frame(
+            events=events,
+            regime_segments=regimes,
+            score_series=series,
+            node_name='node_1',
+            domain_name='test_domain',
+        )
+
+        df = frame.to_frame()
+
+        assert len(df) == len(events)
+        assert 'event_start_index' in df.columns
+        assert 'regime_label' in df.columns
+
+    def test_basic_frame(self):
+        events = [
+            DetectionEvent(0, 5, 2, 10, 8, 'high'),
+            DetectionEvent(10, 12, 11, 5, 4, 'low')
+        ]
+        regimes = [
+            RegimeSegment(0, 7, 'high', 9, 1, 0),
+            RegimeSegment(8, 15, 'low', 3, 0.5, 0)
+        ]
+        score_series = AnomalyScoreSeries((), (), threshold=5, calibration_strategy='mad', metadata={})
+        frame = build_risk_feature_frame(
+            events=events,
+            regime_segments=regimes,
+            score_series=score_series,
+            node_name='nodeA',
+            domain_name='domainX'
+        )
+        assert len(frame.rows) == 2
+        assert frame.columns == (
+            'event_start_index', 'event_end_index', 'event_peak_index', 'event_peak_score',
+            'event_mean_score', 'event_length', 'regime_label', 'regime_mean_level',
+            'regime_volatility', 'node_name', 'domain_name', 'event_threshold', 'calibration_strategy'
+        )
+        row0 = frame.rows[0]
+        assert row0['event_start_index'] == 0
+        assert row0['regime_label'] == 'high'
+        assert row0['regime_mean_level'] == 9
+        assert row0['node_name'] == 'nodeA'
+        assert row0['event_threshold'] == 5
+
+    def test_no_score_series(self):
+        events = [DetectionEvent(0, 2, 1, 5, 3, 'reg')]
+        regimes = [RegimeSegment(0, 5, 'reg', 10, 2, 0)]
+        frame = build_risk_feature_frame(events=events, regime_segments=regimes)
+        assert 'event_threshold' not in frame.columns
+        assert len(frame.rows) == 1
+        assert frame.rows[0]['regime_label'] == 'reg'
+
+
+def test_event_detection_deterministic_K():
+    scores = np.array([0, 1, 1, 0, 1, 1, 0])
+
+    series = build_anomaly_score_series(scores, threshold=0.5, calibration_strategy='fixed')
+
+    e1 = detect_events_from_score_series(series)
+    e2 = detect_events_from_score_series(series)
+
+    assert e1 == e2

--- a/tests/unit/core/models/test_detection_runtime.py
+++ b/tests/unit/core/models/test_detection_runtime.py
@@ -29,10 +29,6 @@ from fedot_ind.core.models.detection.runtime import (
     build_transfer_alignment_report,
 )
 
-from fedot_ind.core.models.detection.stage_tuning import (
-    DetectionStageName,
-    build_detection_stage_tuning_plan)
-
 
 def _multichannel_series(length: int = 48) -> np.ndarray:
     time = np.arange(length, dtype=float)
@@ -668,7 +664,7 @@ class TestInferRegimeSegments:
 
     def test_basic_regime_detection(self):
         # создаём ряд с явными режимами
-        t = np.arange(100)
+        np.arange(100)
         signal = np.zeros(100)
         signal[:30] = 10   # высокий уровень
         signal[30:60] = 0   # стабильный низкий

--- a/tests/unit/core/models/test_detection_stage_tuning.py
+++ b/tests/unit/core/models/test_detection_stage_tuning.py
@@ -40,3 +40,32 @@ def test_build_detection_stage_tuning_plan_marks_legacy_models_as_non_stage_nati
     assert plan.family == 'legacy_detection'
     assert plan.groups == ()
     assert plan.metadata['supports_stage_tuning'] is False
+
+
+def test_stage_tuning_plan_structure_K():
+    model_name = 'conv_autoencoder_detector'
+    plan = build_detection_stage_tuning_plan(model_name)
+    stages_in_plan = {group.stage for group in plan.groups}
+    scoring_group = next(g for g in plan.groups if g.stage == DetectionStageName.ANOMALY_SCORING.value)
+
+    assert plan.model_name == model_name
+    assert plan.metadata['supports_stage_tuning'] is True
+    assert DetectionStageName.REPRESENTATION.value in stages_in_plan
+    assert DetectionStageName.REPRESENTATION.value in scoring_group.depends_on
+
+
+def test_stage_vocabulary_is_complete_K():
+    expected_stages = {
+        'data_quality',
+        'regime_segmentation',
+        'representation',
+        'anomaly_scoring',
+        'calibration',
+        'event_aggregation',
+        'transfer_alignment',
+        'interpretation'
+    }
+
+    actual_stages = {stage.value for stage in DetectionStageName}
+
+    assert actual_stages == expected_stages

--- a/tests/unit/core/models/test_detection_transfer_holdout.py
+++ b/tests/unit/core/models/test_detection_transfer_holdout.py
@@ -1,0 +1,139 @@
+import numpy as np
+import pytest
+
+from fedot_ind.core.models.detection.runtime import (
+    DetectionSplitKind,
+    DetectionSplitSpec,
+)
+from fedot_ind.core.models.detection.stage_tuning_runtime import (
+    _split_series,
+    iter_domain_holdouts,
+    run_detection_stage_tuning_on_series,
+)
+
+
+def _three_domain_series(per_domain: int = 4):
+    """Синтетика из 3 доменов (A, B, C) с разными средними уровнями."""
+    means = {'A': 0.0, 'B': 10.0, 'C': 20.0}
+    values_parts = []
+    domain_parts = []
+    for name, mean in means.items():
+        values_parts.append(np.full(per_domain, mean, dtype=float))
+        domain_parts.extend([name] * per_domain)
+    values = np.concatenate(values_parts).reshape(-1, 1)
+    labels = np.zeros(values.shape[0], dtype=int)
+    domain_labels = np.asarray(domain_parts, dtype=object)
+    return values, labels, domain_labels
+
+
+def test_split_series_domain_holdout_excludes_target_domain():
+    values, labels, domain_labels = _three_domain_series(per_domain=4)
+    split_spec = DetectionSplitSpec(
+        kind=DetectionSplitKind.DOMAIN_HOLDOUT,
+        target_domain='B',
+    )
+
+    train_values, train_labels, calib_values, calib_labels = _split_series(
+        values, labels, split_spec, domain_labels=domain_labels,
+    )
+
+    # Домен B полностью уходит в калибровку (unseen), train — это A и C.
+    assert train_values.shape[0] == 8
+    assert calib_values.shape[0] == 4
+    assert np.all(calib_values == 10.0)          # только домен B
+    assert not np.any(train_values == 10.0)      # B отсутствует в train
+    assert train_labels.shape[0] == train_values.shape[0]
+    assert calib_labels.shape[0] == calib_values.shape[0]
+
+
+def test_split_series_domain_holdout_requires_target_domain():
+    values, labels, domain_labels = _three_domain_series()
+    split_spec = DetectionSplitSpec(kind=DetectionSplitKind.DOMAIN_HOLDOUT)
+
+    with pytest.raises(ValueError):
+        _split_series(values, labels, split_spec, domain_labels=domain_labels)
+
+
+def test_split_series_domain_holdout_rejects_unknown_target():
+    values, labels, domain_labels = _three_domain_series()
+    split_spec = DetectionSplitSpec(
+        kind=DetectionSplitKind.DOMAIN_HOLDOUT,
+        target_domain='Z',
+    )
+
+    with pytest.raises(ValueError):
+        _split_series(values, labels, split_spec, domain_labels=domain_labels)
+
+
+def test_split_series_temporal_branch_unaffected_by_domain_labels():
+    values, labels, domain_labels = _three_domain_series(per_domain=10)
+    split_spec = DetectionSplitSpec(kind=DetectionSplitKind.TEMPORAL)
+
+    train_values, _, calib_values, _ = _split_series(
+        values, labels, split_spec, domain_labels=domain_labels,
+    )
+
+    # Temporal-ветка игнорирует domain_labels: train идёт раньше calibration.
+    assert train_values.shape[0] > 0
+    assert calib_values.shape[0] > 0
+    assert train_values.shape[0] + calib_values.shape[0] <= values.shape[0]
+
+
+def test_iter_domain_holdouts_returns_unique_in_order():
+    domain_labels = np.asarray(
+        ['A', 'A', 'C', 'C', 'B', 'B', 'A'], dtype=object,
+    )
+
+    assert iter_domain_holdouts(domain_labels) == ('A', 'C', 'B')
+
+
+def test_iter_domain_holdouts_raises_with_single_domain():
+    domain_labels = np.asarray(['A', 'A', 'A'], dtype=object)
+
+    with pytest.raises(ValueError):
+        iter_domain_holdouts(domain_labels)
+
+
+def test_lodo_loop_runs_on_each_unseen_domain():
+    """Тонкая LODO-обёртка поверх run_detection_stage_tuning_on_series.
+
+    По одному прогону на каждый target-домен; метрику усредняем снаружи.
+    """
+    rng = np.random.default_rng(0)
+    per_domain = 120
+    means = {'A': 0.0, 'B': 5.0, 'C': 10.0}
+    values_parts, domain_parts, label_parts = [], [], []
+    for name, mean in means.items():
+        block = rng.normal(loc=mean, scale=0.5, size=per_domain)
+        block[-5:] += 8.0  # несколько аномалий в хвосте каждого домена
+        block_labels = np.zeros(per_domain, dtype=int)
+        block_labels[-5:] = 1
+        values_parts.append(block)
+        domain_parts.extend([name] * per_domain)
+        label_parts.append(block_labels)
+    values = np.concatenate(values_parts).reshape(-1, 1)
+    labels = np.concatenate(label_parts)
+    domain_labels = np.asarray(domain_parts, dtype=object)
+
+    per_domain_scores = []
+    for target in iter_domain_holdouts(domain_labels):
+        result = run_detection_stage_tuning_on_series(
+            'feature_iforest_detector',
+            values=values,
+            labels=labels,
+            base_params={'window_size': 16, 'stride': 4},
+            metric_name='bin_f1',
+            split_spec=DetectionSplitSpec(
+                kind=DetectionSplitKind.DOMAIN_HOLDOUT,
+                target_domain=target,
+            ),
+            domain_labels=domain_labels,
+            max_values_per_parameter=1,
+            max_stage_candidates=1,
+            progress_policy=False,
+        )
+        per_domain_scores.append(result.best_evaluation.metric_value)
+
+    # Прогон отработал на каждом из трёх unseen-доменов и вернул конечные метрики.
+    assert len(per_domain_scores) == 3
+    assert all(np.isfinite(score) for score in per_domain_scores)

--- a/tests/unit/core/operation/interfaces/test_detection_runtime_strategy.py
+++ b/tests/unit/core/operation/interfaces/test_detection_runtime_strategy.py
@@ -61,3 +61,12 @@ def test_build_detection_boundary_batch_respects_window_length_parameter():
 
 def test_legacy_detection_strategy_is_now_a_runtime_wrapper():
     assert issubclass(IndustrialAnomalyDetectionStrategy, IndustrialDetectionModelRuntimeStrategy)
+
+
+def test_build_detection_boundary_batch_logic():
+    input_data = _build_detection_input(length=100)
+    params = OperationParameters(window_size=20, stride=5)
+    batch = build_detection_boundary_batch(input_data, params)
+
+    assert batch.window_size == 20
+    assert batch.stride == 5

--- a/tests/unit/core/repository/test_detection_registry.py
+++ b/tests/unit/core/repository/test_detection_registry.py
@@ -5,6 +5,10 @@ from fedot_ind.core.repository.detection_registry import (
     detection_aliases_for,
     detection_family_for,
 )
+from fedot_ind.core.repository.IndustrialOperationParameters import get_default_params
+import pytest
+
+pytest.importorskip('fedot.core.operations.operation_parameters')
 
 
 def test_canonical_detection_model_name_normalizes_aliases_and_whitespace():
@@ -31,3 +35,64 @@ def test_detection_registry_partitions_first_class_and_legacy_sets():
     assert set(CANONICAL_STAGE_DETECTION_MODELS).isdisjoint(set(LEGACY_DETECTION_MODELS))
     assert 'feature_iforest_detector' in CANONICAL_STAGE_DETECTION_MODELS
     assert 'legacy_lstm_autoencoder_detector' in LEGACY_DETECTION_MODELS
+
+
+def test_canonical_anomaly_detection_model_name_normalizes_short_aliases():
+    assert canonical_detection_model_name('iforest_detector') == 'feature_iforest_detector'
+    assert canonical_detection_model_name('feature_iforest') == 'feature_iforest_detector'
+    assert canonical_detection_model_name('stat_detector') == 'feature_oneclass_detector'
+    assert canonical_detection_model_name('feature_oneclass') == 'feature_oneclass_detector'
+    assert canonical_detection_model_name('conv_ae_detector') == 'conv_autoencoder_detector'
+    assert canonical_detection_model_name('conv_autoencoder') == 'conv_autoencoder_detector'
+    assert canonical_detection_model_name('tcn_ae_detector') == 'tcn_autoencoder_detector'
+    assert canonical_detection_model_name('tcn_autoencoder') == 'tcn_autoencoder_detector'
+    assert canonical_detection_model_name('lstm_ae_detector') == 'legacy_lstm_autoencoder_detector'
+    assert canonical_detection_model_name('arima_detector') == 'legacy_arima_detector'
+    assert canonical_detection_model_name('sst') == 'legacy_sst_detector'
+    assert canonical_detection_model_name('unscented_kalman_filter') == 'legacy_kalman_detector'
+    assert canonical_detection_model_name('functional_pca') == 'legacy_functional_pca_detector'
+    assert canonical_detection_model_name('feature_iforest_detector') == 'feature_iforest_detector'
+
+
+# def test_search_space_contains_alias_entries_for_short_anomaly_detection_names():
+#     assert industrial_search_space['iforest_detector'] == industrial_search_space['feature_iforest_detector']
+#     assert industrial_search_space['feature_iforest'] == industrial_search_space['feature_iforest_detector']
+#     assert industrial_search_space['stat_detector'] == industrial_search_space['feature_oneclass_detector']
+#     assert industrial_search_space['feature_oneclass'] == industrial_search_space['feature_oneclass_detector']
+#     assert industrial_search_space['conv_ae_detector'] == industrial_search_space['conv_autoencoder_detector']
+#     assert industrial_search_space['conv_autoencoder'] == industrial_search_space['conv_autoencoder_detector']
+#     assert industrial_search_space['tcn_ae_detector'] == industrial_search_space['tcn_autoencoder_detector']
+#     assert industrial_search_space['tcn_autoencoder'] == industrial_search_space['tcn_autoencoder_detector']
+#     assert industrial_search_space['lstm_ae_detector'] == industrial_search_space['legacy_lstm_autoencoder_detector']
+#     assert industrial_search_space['arima_detector'] == industrial_search_space['legacy_arima_detector']
+#     assert industrial_search_space['sst'] == industrial_search_space['legacy_sst_detector']
+#     assert industrial_search_space['unscented_kalman_filter'] == industrial_search_space['legacy_kalman_detector']
+#     assert industrial_search_space['functional_pca'] == industrial_search_space['legacy_functional_pca_detector']
+
+
+def test_default_params_lookup_uses_canonical_anomaly_detection_names():
+
+    alias_params = get_default_params('iforest_detector')
+    canonical_params = get_default_params('feature_iforest_detector')
+
+    assert alias_params is not None
+    assert alias_params == canonical_params
+    assert get_default_params('iforest_detector') == get_default_params('feature_iforest_detector')
+    assert get_default_params('feature_iforest') == get_default_params('feature_iforest_detector')
+    assert get_default_params('stat_detector') == get_default_params('feature_oneclass_detector')
+    assert get_default_params('feature_oneclass') == get_default_params('feature_oneclass_detector')
+    assert get_default_params('conv_ae_detector') == get_default_params('conv_autoencoder_detector')
+    assert get_default_params('conv_autoencoder') == get_default_params('conv_autoencoder_detector')
+    assert get_default_params('tcn_ae_detector') == get_default_params('tcn_autoencoder_detector')
+    assert get_default_params('tcn_autoencoder') == get_default_params('tcn_autoencoder_detector')
+    assert get_default_params('lstm_ae_detector') == get_default_params('legacy_lstm_autoencoder_detector')
+    assert get_default_params('arima_detector') == get_default_params('legacy_arima_detector')
+    assert get_default_params('sst') == get_default_params('legacy_sst_detector')
+    assert get_default_params('unscented_kalman_filter') == get_default_params('legacy_kalman_detector')
+    assert get_default_params('functional_pca') == get_default_params('legacy_functional_pca_detector')
+
+
+def test_stage_anomaly_detection_models_publish_alias_sets():
+    assert 'feature_iforest_detector' in CANONICAL_STAGE_DETECTION_MODELS
+    assert detection_aliases_for('feature_iforest_detector') == (
+        'feature_iforest', 'feature_iforest_detector', 'iforest_detector')


### PR DESCRIPTION
## Summary
- Clean-ported anomaly detection refactoring onto the current `main` without bringing stale docs/examples/benchmark.v2 changes from the old branch.
- Added runtime-first anomaly detectors, detection data-quality helpers, stage tuning runtime, canonical detection registry/defaults, and FEDOT `InputData` integration.
- Added unified metrics compatibility needed by detection while preserving legacy `FedotIndustrial.get_metrics()` wrappers.

## Verification
- `python -m pytest tests/unit/core/metrics/test_metrics.py ...` targeted detection/metrics set: 181 passed, 10 skipped.
- `python -m pytest tests/unit/api/main/test_api_main.py::test_fit_predict_fedot_industrial`: 4 passed.
- `autopep8 --exit-code --diff` on touched files: passed.
- `git diff --check`: passed.
- Full local `tests/unit -q --maxfail=1` reached 334 passed / 10 skipped, then stopped on unrelated local CUDA/CPU DeepAR mismatch in `tests/unit/core/models/model_impl/test_deepar.py::test_get_initial_state[LSTM]`.